### PR TITLE
fix(ci): break the cache-eviction / cold-build loop keeping main's product gate red (#747)

### DIFF
--- a/.github/scripts/audit-cache-budget.mjs
+++ b/.github/scripts/audit-cache-budget.mjs
@@ -35,6 +35,19 @@ export const CACHE_LIMIT_BYTES = 10 * GIB;
 // observed failure had usage at 9.96 GiB, i.e. 99.6%.
 export const BUDGET_WARN_FRACTION = 0.85;
 
+// A single entry above this size is a standing risk to the whole budget
+// regardless of the total, so it gets its own control rather than waiting for
+// `BUDGET_WARN_FRACTION` to trip. Calibrated between the `semantic-mutation`
+// key's designed floor (~2.2 GiB, predicted: two build trees --
+// `rust/target/debug`'s deps and `rust/target/fault-operators/target`'s deps,
+// both from `~/.cargo` -- structurally larger than any single-tree shared key
+// such as `rust-workspace` at 1.495 GiB) and the defect value this key was
+// actually observed holding, 2.719 GiB, once dead weight from a scratch build
+// tree and stale evidence directories accumulated inside the cached path
+// (fixed elsewhere in this branch). This is an added control, not a
+// replacement for `BUDGET_WARN_FRACTION`, and does not change that threshold.
+export const SINGLE_ENTRY_WARN_BYTES = 2.5 * GIB;
+
 // The shared keys `ci.yml` declares. A `refs/pull/*` entry for any of these
 // means the `save-if` guard regressed -- this is the calibrated rejecting
 // signal for the fix itself, not merely a hygiene check.
@@ -61,14 +74,22 @@ export const REQUIRED_MAIN_ENTRIES = [
 ];
 
 function entryIdentity(key) {
-  // Swatinem/rust-cache composes `v0-rust-<shared-key>-<platform>-<hashes>`.
-  // `platform` is `os.type()`'s actual output, which is `Linux`, `Darwin`, or
-  // `Windows_NT` -- never the GitHub Actions `runner.os` spellings `Linux`,
-  // `macOS`, `Windows`. `Windows_NT` must be tried before the bare `Windows`
-  // alternative below: `Windows_NT` contains `Windows` as a prefix, so
-  // matching `Windows` first would capture it and strand `_NT` on the
-  // shared-key group instead of the platform group.
-  const match = /^v\d+-rust-(.+?)-(Linux|Darwin|Windows_NT|macOS|Windows)-/.exec(key ?? "");
+  // Swatinem/rust-cache composes `v0-rust-<shared-key>-<platform>-<arch>-<hash>-<hash>`.
+  // Parsed from the tail, not the head: a lazy `(.+?)` stops at the *first*
+  // platform-like substring it finds, so a shared key that happens to contain
+  // one -- e.g. a hypothetical `foo-Linux-bar` -- would misparse as shared key
+  // `foo`, and a reviewer reproduced this causing a real, present main-branch
+  // entry to be reported `main-cache-absent` even though its cache existed in
+  // the same listing. A greedy `(.+)` anchored at `$` instead finds the *last*
+  // occurrence of the real trailing structure, which is the one
+  // `Swatinem/rust-cache` actually appends. `platform` is `os.type()`'s actual
+  // output, `Linux`/`Darwin`/`Windows_NT` -- never the GitHub Actions
+  // `runner.os` spellings `Linux`/`macOS`/`Windows`. `Windows_NT` is tried
+  // before the bare `Windows` it is a superset of, though the trailing anchor
+  // below no longer strictly depends on that ordering to be correct.
+  const match = /^v\d+-rust-(.+)-(Linux|Darwin|Windows_NT|macOS|Windows)-[^-]+-[0-9a-f]+-[0-9a-f]+$/.exec(
+    key ?? "",
+  );
   return match ? { sharedKey: match[1], platform: match[2] } : { sharedKey: null, platform: null };
 }
 
@@ -83,7 +104,8 @@ function formatGiB(bytes) {
  *          warnFraction?: number,
  *          requiredMainEntries?: {key: string, platform: string}[],
  *          ciSharedKeys?: string[],
- *          defaultBranchRef?: string}} input
+ *          defaultBranchRef?: string,
+ *          singleEntryWarnBytes?: number}} input
  * @returns {{findings: Array<{code: string, message: string}>, ok: boolean}}
  */
 export function auditCacheBudget({
@@ -94,6 +116,7 @@ export function auditCacheBudget({
   requiredMainEntries = REQUIRED_MAIN_ENTRIES,
   ciSharedKeys = CI_SHARED_KEYS,
   defaultBranchRef = "refs/heads/main",
+  singleEntryWarnBytes = SINGLE_ENTRY_WARN_BYTES,
 }) {
   const findings = [];
 
@@ -180,6 +203,23 @@ export function auditCacheBudget({
       message: `\`${entry.ref}\` holds a rust cache \`${entry.key}\` (${formatGiB(
         entry.size_in_bytes ?? 0,
       )}). No workflow may save a rust cache on a pull-request event; see docs/DESIGN-ci.md, "Actions cache budget".`,
+    });
+  }
+
+  // 5. No single entry should approach the whole repository's budget by
+  //    itself. This is independent of rules 1-4: a key can be entirely
+  //    legitimate (declared, present only where expected, never on a
+  //    pull-request ref) and still be silently regrowing into the same
+  //    accumulation failure `semantic-mutation` had, before `budget-exhausted`
+  //    would ever trip.
+  for (const entry of caches) {
+    const size = entry.size_in_bytes ?? 0;
+    if (size < singleEntryWarnBytes) continue;
+    findings.push({
+      code: "entry-oversized",
+      message: `\`${entry.key}\` on \`${entry.ref}\` is ${formatGiB(size)}, at or above the ${formatGiB(
+        singleEntryWarnBytes,
+      )} single-entry warning threshold. A key this size is a standing risk to the shared budget on its own, independent of the total.`,
     });
   }
 

--- a/.github/scripts/audit-cache-budget.mjs
+++ b/.github/scripts/audit-cache-budget.mjs
@@ -48,15 +48,19 @@ export const BUDGET_WARN_FRACTION = 0.85;
 // mechanism -- the three do not share a common origin (how each key is
 // declared, whether it is "shared" in the same technical sense, or any other
 // generation rule); it is simply the enumerated set rule 3 checks. Do not
-// infer a rule for membership from the list's current contents. Everything
-// else -- `rust-native-z3`, and formerly `fsl-logic` -- is deliberately
-// handled elsewhere instead of being added here: `rust-native-z3` by
-// `REQUIRED_MAIN_ENTRIES`'s per-`{key, platform}` presence check and rule 4's
-// generic `refs/pull/*` detection below; `fsl-logic`, since it went
-// restore-only, by neither (see docs/DESIGN-ci.md, "Actions cache budget").
-// A `refs/pull/*` entry for one of these three means the `save-if` guard
+// infer a rule for membership from the list's current contents. A
+// `refs/pull/*` entry for one of these three means the `save-if` guard
 // regressed -- this is the calibrated rejecting signal for the fix itself,
 // not merely a hygiene check.
+//
+// Every other `v0-rust-*` key, including `rust-native-z3` and `fsl-logic`, is
+// still covered against appearing on a `refs/pull/*` ref -- by rule 4 below,
+// which matches on the raw key prefix and does not consult this list at all.
+// What is *not* covered for a key outside this list is rule 2's default-branch
+// presence requirement, which checks only the `{key, platform}` pairs in
+// `REQUIRED_MAIN_ENTRIES`: `rust-native-z3` is in that list (so its absence
+// from `main` is still caught); `fsl-logic` is not (it went restore-only and
+// never saves a `main` copy of its own to require).
 export const CI_SHARED_KEYS = [
   "rust-workspace",
   "wasm",

--- a/.github/scripts/audit-cache-budget.mjs
+++ b/.github/scripts/audit-cache-budget.mjs
@@ -6,7 +6,8 @@
 // the default branch's, so a pull request's cache is worthless to a sibling
 // pull request while still counting against the shared limit.
 //
-// `ci.yml`'s four shared keys store about 6.9 GiB per ref, so two concurrent
+// `ci.yml`'s shared keys (originally four; `fsl-logic` was later folded into
+// `rust-workspace`, see below) stored about 6.9 GiB per ref, so two concurrent
 // pull requests exceeded the limit and evicted `main`'s caches. Every run then
 // built cold -- measured +8 to +16 min per shard -- and each cold run saved a
 // fresh ref-scoped copy, evicting more. `ci.yml` now restricts saving to
@@ -17,12 +18,13 @@
 // rejecting fixtures in audit-cache-budget.test.mjs possible, and it is the
 // same shape as audit-ruleset-drift.mjs.
 //
-// `merge-readiness.yml` is restore-only against `ci.yml`'s own `rust-workspace`
-// key (`save-if: false`) and therefore owns no shared key of its own to add
-// here. As of that fix, no workflow in this repository ever saves a rust
+// `merge-readiness.yml` and `ci.yml`'s own `fsl-logic` job are both
+// restore-only against `ci.yml`'s `rust-workspace` key (`save-if: false`) and
+// therefore own no shared key of their own to add here. As of the
+// `merge-readiness.yml` fix, no workflow in this repository ever saves a rust
 // cache on a pull-request event -- rule 4 below is the general form of that
 // invariant, covering any future workflow's rust-cache step as well as the
-// four keys `ci.yml` declares.
+// keys `CI_SHARED_KEYS` declares.
 
 export const GIB = 1024 ** 3;
 
@@ -35,26 +37,15 @@ export const CACHE_LIMIT_BYTES = 10 * GIB;
 // observed failure had usage at 9.96 GiB, i.e. 99.6%.
 export const BUDGET_WARN_FRACTION = 0.85;
 
-// A single entry above this size is a standing risk to the whole budget
-// regardless of the total, so it gets its own control rather than waiting for
-// `BUDGET_WARN_FRACTION` to trip. Calibrated between the `semantic-mutation`
-// key's designed floor (~2.2 GiB, predicted: two build trees --
-// `rust/target/debug`'s deps and `rust/target/fault-operators/target`'s deps,
-// both from `~/.cargo` -- structurally larger than any single-tree shared key
-// such as `rust-workspace` at 1.495 GiB) and the defect value this key was
-// actually observed holding, 2.719 GiB, once dead weight from a scratch build
-// tree and stale evidence directories accumulated inside the cached path
-// (fixed elsewhere in this branch). This is an added control, not a
-// replacement for `BUDGET_WARN_FRACTION`, and does not change that threshold.
-export const SINGLE_ENTRY_WARN_BYTES = 2.5 * GIB;
-
 // The shared keys `ci.yml` declares. A `refs/pull/*` entry for any of these
 // means the `save-if` guard regressed -- this is the calibrated rejecting
-// signal for the fix itself, not merely a hygiene check.
+// signal for the fix itself, not merely a hygiene check. `fsl-logic` is not
+// one of these: that job went restore-only against `rust-workspace` (see
+// docs/DESIGN-ci.md, "Actions cache budget") and no longer saves a key of its
+// own, the same way `merge-readiness.yml`'s jobs do not appear here either.
 export const CI_SHARED_KEYS = [
   "rust-workspace",
   "wasm",
-  "fsl-logic",
   "semantic-mutation",
 ];
 
@@ -63,12 +54,13 @@ export const CI_SHARED_KEYS = [
 // key across a `[macos-15, windows-latest]` matrix (`ci.yml`), so a key-only
 // set would let the Darwin entry's presence hide a missing Windows_NT one --
 // exactly the failure this audit never reported when the Windows cache was
-// evicted to zero (issue #747). `rust-workspace`/`wasm`/`fsl-logic` only ever
-// run on `ubuntu-latest`, hence `Linux` for all three.
+// evicted to zero (issue #747). `rust-workspace`/`wasm` only ever run on
+// `ubuntu-latest`, hence `Linux` for both. `fsl-logic` is deliberately absent:
+// it is restore-only against `rust-workspace` and never saves its own key, so
+// requiring one here would always fail.
 export const REQUIRED_MAIN_ENTRIES = [
   { key: "rust-workspace", platform: "Linux" },
   { key: "wasm", platform: "Linux" },
-  { key: "fsl-logic", platform: "Linux" },
   { key: "rust-native-z3", platform: "Windows_NT" },
   { key: "rust-native-z3", platform: "Darwin" },
 ];
@@ -104,8 +96,7 @@ function formatGiB(bytes) {
  *          warnFraction?: number,
  *          requiredMainEntries?: {key: string, platform: string}[],
  *          ciSharedKeys?: string[],
- *          defaultBranchRef?: string,
- *          singleEntryWarnBytes?: number}} input
+ *          defaultBranchRef?: string}} input
  * @returns {{findings: Array<{code: string, message: string}>, ok: boolean}}
  */
 export function auditCacheBudget({
@@ -116,7 +107,6 @@ export function auditCacheBudget({
   requiredMainEntries = REQUIRED_MAIN_ENTRIES,
   ciSharedKeys = CI_SHARED_KEYS,
   defaultBranchRef = "refs/heads/main",
-  singleEntryWarnBytes = SINGLE_ENTRY_WARN_BYTES,
 }) {
   const findings = [];
 
@@ -203,23 +193,6 @@ export function auditCacheBudget({
       message: `\`${entry.ref}\` holds a rust cache \`${entry.key}\` (${formatGiB(
         entry.size_in_bytes ?? 0,
       )}). No workflow may save a rust cache on a pull-request event; see docs/DESIGN-ci.md, "Actions cache budget".`,
-    });
-  }
-
-  // 5. No single entry should approach the whole repository's budget by
-  //    itself. This is independent of rules 1-4: a key can be entirely
-  //    legitimate (declared, present only where expected, never on a
-  //    pull-request ref) and still be silently regrowing into the same
-  //    accumulation failure `semantic-mutation` had, before `budget-exhausted`
-  //    would ever trip.
-  for (const entry of caches) {
-    const size = entry.size_in_bytes ?? 0;
-    if (size < singleEntryWarnBytes) continue;
-    findings.push({
-      code: "entry-oversized",
-      message: `\`${entry.key}\` on \`${entry.ref}\` is ${formatGiB(size)}, at or above the ${formatGiB(
-        singleEntryWarnBytes,
-      )} single-entry warning threshold. A key this size is a standing risk to the shared budget on its own, independent of the total.`,
     });
   }
 

--- a/.github/scripts/audit-cache-budget.mjs
+++ b/.github/scripts/audit-cache-budget.mjs
@@ -16,6 +16,13 @@
 // findings. The workflow does the fetching. That split is what makes the
 // rejecting fixtures in audit-cache-budget.test.mjs possible, and it is the
 // same shape as audit-ruleset-drift.mjs.
+//
+// `merge-readiness.yml` is restore-only against `ci.yml`'s own `rust-workspace`
+// key (`save-if: false`) and therefore owns no shared key of its own to add
+// here. As of that fix, no workflow in this repository ever saves a rust
+// cache on a pull-request event -- rule 4 below is the general form of that
+// invariant, covering any future workflow's rust-cache step as well as the
+// four keys `ci.yml` declares.
 
 export const GIB = 1024 ** 3;
 
@@ -38,14 +45,31 @@ export const CI_SHARED_KEYS = [
   "semantic-mutation",
 ];
 
-// Keys whose absence on the default branch makes every pull request build cold.
-// A subset of CI_SHARED_KEYS: these are the ones on the pre-merge critical path.
-export const REQUIRED_MAIN_KEYS = ["rust-workspace", "wasm", "fsl-logic"];
+// Entries whose absence on the default branch makes every pull request build
+// cold. Per-platform, not just per-key: `rust-native-z3` is a single shared
+// key across a `[macos-15, windows-latest]` matrix (`ci.yml`), so a key-only
+// set would let the Darwin entry's presence hide a missing Windows_NT one --
+// exactly the failure this audit never reported when the Windows cache was
+// evicted to zero (issue #747). `rust-workspace`/`wasm`/`fsl-logic` only ever
+// run on `ubuntu-latest`, hence `Linux` for all three.
+export const REQUIRED_MAIN_ENTRIES = [
+  { key: "rust-workspace", platform: "Linux" },
+  { key: "wasm", platform: "Linux" },
+  { key: "fsl-logic", platform: "Linux" },
+  { key: "rust-native-z3", platform: "Windows_NT" },
+  { key: "rust-native-z3", platform: "Darwin" },
+];
 
-function sharedKeyOf(key) {
+function entryIdentity(key) {
   // Swatinem/rust-cache composes `v0-rust-<shared-key>-<platform>-<hashes>`.
-  const match = /^v\d+-rust-(.+?)-(?:Linux|macOS|Windows)-/.exec(key ?? "");
-  return match ? match[1] : null;
+  // `platform` is `os.type()`'s actual output, which is `Linux`, `Darwin`, or
+  // `Windows_NT` -- never the GitHub Actions `runner.os` spellings `Linux`,
+  // `macOS`, `Windows`. `Windows_NT` must be tried before the bare `Windows`
+  // alternative below: `Windows_NT` contains `Windows` as a prefix, so
+  // matching `Windows` first would capture it and strand `_NT` on the
+  // shared-key group instead of the platform group.
+  const match = /^v\d+-rust-(.+?)-(Linux|Darwin|Windows_NT|macOS|Windows)-/.exec(key ?? "");
+  return match ? { sharedKey: match[1], platform: match[2] } : { sharedKey: null, platform: null };
 }
 
 function formatGiB(bytes) {
@@ -57,7 +81,7 @@ function formatGiB(bytes) {
  *          usageBytes: number|null,
  *          limitBytes?: number,
  *          warnFraction?: number,
- *          requiredMainKeys?: string[],
+ *          requiredMainEntries?: {key: string, platform: string}[],
  *          ciSharedKeys?: string[],
  *          defaultBranchRef?: string}} input
  * @returns {{findings: Array<{code: string, message: string}>, ok: boolean}}
@@ -67,7 +91,7 @@ export function auditCacheBudget({
   usageBytes,
   limitBytes = CACHE_LIMIT_BYTES,
   warnFraction = BUDGET_WARN_FRACTION,
-  requiredMainKeys = REQUIRED_MAIN_KEYS,
+  requiredMainEntries = REQUIRED_MAIN_ENTRIES,
   ciSharedKeys = CI_SHARED_KEYS,
   defaultBranchRef = "refs/heads/main",
 }) {
@@ -102,18 +126,23 @@ export function auditCacheBudget({
     });
   }
 
-  // 2. The default branch must hold every key on the pre-merge critical path.
-  const mainKeys = new Set(
+  // 2. The default branch must hold every {key, platform} pair on the
+  //    pre-merge critical path. Per-platform, not per-key: a shared key backed
+  //    by a matrix job (`rust-native-z3`) can have one platform's entry
+  //    present and another's absent, and a key-only set would let the former
+  //    hide the latter.
+  const mainEntries = new Set(
     caches
       .filter((entry) => entry.ref === defaultBranchRef)
-      .map((entry) => sharedKeyOf(entry.key))
-      .filter(Boolean),
+      .map((entry) => entryIdentity(entry.key))
+      .filter(({ sharedKey, platform }) => sharedKey && platform)
+      .map(({ sharedKey, platform }) => `${sharedKey}::${platform}`),
   );
-  for (const key of requiredMainKeys) {
-    if (!mainKeys.has(key)) {
+  for (const { key, platform } of requiredMainEntries) {
+    if (!mainEntries.has(`${key}::${platform}`)) {
       findings.push({
         code: "main-cache-absent",
-        message: `no \`${defaultBranchRef}\` cache for shared key \`${key}\`. Actions caches are ref-scoped, so the default branch is the only cache every pull request can read; without it each pull request builds cold.`,
+        message: `no \`${defaultBranchRef}\` cache for shared key \`${key}\` on platform \`${platform}\`. Actions caches are ref-scoped, so the default branch is the only cache every pull request can read; without it each pull request (or, for a matrix job, that platform's shard) builds cold.`,
       });
     }
   }
@@ -121,17 +150,37 @@ export function auditCacheBudget({
   // 3. No pull-request-scoped cache for a `ci.yml` shared key. This is the
   //    rejecting control for `save-if`: if the guard is removed, these reappear.
   const ciKeys = new Set(ciSharedKeys);
+  const attributedPullRequestEntries = new Set();
   for (const entry of caches) {
     if (!/^refs\/pull\//.test(entry.ref ?? "")) continue;
-    const key = sharedKeyOf(entry.key);
-    if (key && ciKeys.has(key)) {
+    const { sharedKey } = entryIdentity(entry.key);
+    if (sharedKey && ciKeys.has(sharedKey)) {
+      attributedPullRequestEntries.add(entry);
       findings.push({
         code: "pull-request-cache-present",
-        message: `\`${entry.ref}\` holds a cache for \`ci.yml\`'s shared key \`${key}\` (${formatGiB(
+        message: `\`${entry.ref}\` holds a cache for \`ci.yml\`'s shared key \`${sharedKey}\` (${formatGiB(
           entry.size_in_bytes ?? 0,
         )}). \`ci.yml\` restricts saving to non-pull-request events precisely so this cannot happen; its presence means that guard regressed.`,
       });
     }
+  }
+
+  // 4. Repository invariant since #752 and the `merge-readiness.yml`
+  //    restore-only fix: no workflow saves a rust cache on a pull-request
+  //    event, full stop -- not just the four keys `ci.yml` declares. Any
+  //    `v0-rust-*` key on a `refs/pull/*` ref means that invariant broke
+  //    somewhere, whether in a known shared key (already reported by rule 3
+  //    above, and skipped here to avoid a duplicate finding) or a new one.
+  for (const entry of caches) {
+    if (attributedPullRequestEntries.has(entry)) continue;
+    if (!/^refs\/pull\//.test(entry.ref ?? "")) continue;
+    if (!/^v\d+-rust-/.test(entry.key ?? "")) continue;
+    findings.push({
+      code: "pull-request-rust-cache-present",
+      message: `\`${entry.ref}\` holds a rust cache \`${entry.key}\` (${formatGiB(
+        entry.size_in_bytes ?? 0,
+      )}). No workflow may save a rust cache on a pull-request event; see docs/DESIGN-ci.md, "Actions cache budget".`,
+    });
   }
 
   return { findings, ok: findings.length === 0 };

--- a/.github/scripts/audit-cache-budget.mjs
+++ b/.github/scripts/audit-cache-budget.mjs
@@ -10,8 +10,10 @@
 // `rust-workspace`, see below) stored about 6.9 GiB per ref, so two concurrent
 // pull requests exceeded the limit and evicted `main`'s caches. Every run then
 // built cold -- measured +8 to +16 min per shard -- and each cold run saved a
-// fresh ref-scoped copy, evicting more. `ci.yml` now restricts saving to
-// non-pull-request events, which is what this audit protects.
+// fresh ref-scoped copy, evicting more. Every step that still saves its own
+// key now restricts that save to non-pull-request events; a step that never
+// saves at all is restore-only (`save-if: false`) instead (see below). Rules 3
+// and 4 below are what this audit uses to protect both shapes.
 //
 // This module is pure: it takes an already-fetched cache listing and returns
 // findings. The workflow does the fetching. That split is what makes the
@@ -180,7 +182,7 @@ export function auditCacheBudget({
 
   // 4. Repository invariant since #752 and the `merge-readiness.yml`
   //    restore-only fix: no workflow saves a rust cache on a pull-request
-  //    event, full stop -- not just the four keys `ci.yml` declares. Any
+  //    event, full stop -- not just `CI_SHARED_KEYS`' three declared keys. Any
   //    `v0-rust-*` key on a `refs/pull/*` ref means that invariant broke
   //    somewhere, whether in a known shared key (already reported by rule 3
   //    above, and skipped here to avoid a duplicate finding) or a new one.

--- a/.github/scripts/audit-cache-budget.mjs
+++ b/.github/scripts/audit-cache-budget.mjs
@@ -43,12 +43,18 @@ export const CACHE_LIMIT_BYTES = 10 * GIB;
 // observed failure had usage at 9.96 GiB, i.e. 99.6%.
 export const BUDGET_WARN_FRACTION = 0.85;
 
-// The shared keys `ci.yml` declares. A `refs/pull/*` entry for any of these
-// means the `save-if` guard regressed -- this is the calibrated rejecting
-// signal for the fix itself, not merely a hygiene check. `fsl-logic` is not
-// one of these: that job went restore-only against `rust-workspace` (see
-// docs/DESIGN-ci.md, "Actions cache budget") and no longer saves a key of its
-// own, the same way `merge-readiness.yml`'s jobs do not appear here either.
+// The identities rule 3 below attributes by name: the keys `ci.yml` declares
+// through the `shared-key:` input specifically. A `refs/pull/*` entry for any
+// of these means the `save-if` guard regressed -- this is the calibrated
+// rejecting signal for the fix itself, not merely a hygiene check. This is
+// not every key any workflow actually saves: `ci.yml`'s `rust-native-z3` job
+// saves through `Swatinem/rust-cache`'s default per-job naming (no
+// `shared-key:` input) and is covered separately, by `REQUIRED_MAIN_ENTRIES`
+// below and by rule 4's generic detection, not by name here. `fsl-logic` is
+// not one of these either: that job went restore-only against
+// `rust-workspace` (see docs/DESIGN-ci.md, "Actions cache budget") and no
+// longer saves a key of its own, the same way `merge-readiness.yml`'s jobs do
+// not appear here.
 export const CI_SHARED_KEYS = [
   "rust-workspace",
   "wasm",

--- a/.github/scripts/audit-cache-budget.mjs
+++ b/.github/scripts/audit-cache-budget.mjs
@@ -20,13 +20,17 @@
 // rejecting fixtures in audit-cache-budget.test.mjs possible, and it is the
 // same shape as audit-ruleset-drift.mjs.
 //
-// `merge-readiness.yml` and `ci.yml`'s own `fsl-logic` job are both
+// `merge-readiness.yml`'s `rust-compile` job, `merge-readiness.yml`'s
+// `core-contracts` job, and `ci.yml`'s own `fsl-logic` job are each
 // restore-only against `ci.yml`'s `rust-workspace` key (`save-if: false`) and
-// therefore own no shared key of their own to add here. As of the
-// `merge-readiness.yml` fix, no workflow in this repository ever saves a rust
-// cache on a pull-request event -- rule 4 below is the general form of that
-// invariant, covering any future workflow's rust-cache step as well as the
-// keys `CI_SHARED_KEYS` declares.
+// therefore own no shared key of their own to add here. `ci.yml`'s
+// `semantic-mutation-mutants` job is also restore-only (`save-if: false`),
+// but reads `semantic-mutation` instead -- the key `semantic-mutation-operators`
+// owns and saves, not `rust-workspace`. As of the `merge-readiness.yml` fix,
+// no workflow in this repository ever saves a rust cache on a pull-request
+// event -- rule 4 below is the general form of that invariant, covering any
+// future workflow's rust-cache step as well as the keys `CI_SHARED_KEYS`
+// declares.
 
 export const GIB = 1024 ** 3;
 

--- a/.github/scripts/audit-cache-budget.mjs
+++ b/.github/scripts/audit-cache-budget.mjs
@@ -43,18 +43,20 @@ export const CACHE_LIMIT_BYTES = 10 * GIB;
 // observed failure had usage at 9.96 GiB, i.e. 99.6%.
 export const BUDGET_WARN_FRACTION = 0.85;
 
-// The identities rule 3 below attributes by name: the keys `ci.yml` declares
-// through the `shared-key:` input specifically. A `refs/pull/*` entry for any
-// of these means the `save-if` guard regressed -- this is the calibrated
-// rejecting signal for the fix itself, not merely a hygiene check. This is
-// not every key any workflow actually saves: `ci.yml`'s `rust-native-z3` job
-// saves through `Swatinem/rust-cache`'s default per-job naming (no
-// `shared-key:` input) and is covered separately, by `REQUIRED_MAIN_ENTRIES`
-// below and by rule 4's generic detection, not by name here. `fsl-logic` is
-// not one of these either: that job went restore-only against
-// `rust-workspace` (see docs/DESIGN-ci.md, "Actions cache budget") and no
-// longer saves a key of its own, the same way `merge-readiness.yml`'s jobs do
-// not appear here.
+// The three identities rule 3 below diagnoses by name: `rust-workspace`,
+// `wasm`, `semantic-mutation`. This list is not derived from any single
+// mechanism -- the three do not share a common origin (how each key is
+// declared, whether it is "shared" in the same technical sense, or any other
+// generation rule); it is simply the enumerated set rule 3 checks. Do not
+// infer a rule for membership from the list's current contents. Everything
+// else -- `rust-native-z3`, and formerly `fsl-logic` -- is deliberately
+// handled elsewhere instead of being added here: `rust-native-z3` by
+// `REQUIRED_MAIN_ENTRIES`'s per-`{key, platform}` presence check and rule 4's
+// generic `refs/pull/*` detection below; `fsl-logic`, since it went
+// restore-only, by neither (see docs/DESIGN-ci.md, "Actions cache budget").
+// A `refs/pull/*` entry for one of these three means the `save-if` guard
+// regressed -- this is the calibrated rejecting signal for the fix itself,
+// not merely a hygiene check.
 export const CI_SHARED_KEYS = [
   "rust-workspace",
   "wasm",

--- a/.github/scripts/audit-cache-budget.test.mjs
+++ b/.github/scripts/audit-cache-budget.test.mjs
@@ -32,8 +32,10 @@ function healthyListing() {
     cache("v0-rust-wasm-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.352),
     cache("v0-rust-fsl-logic-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.369),
     cache("v0-rust-semantic-mutation-Linux-x64-e8b3ee54-09fbaf53", MAIN, 2.721),
-    cache("v0-rust-rust-compile-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/900/merge", 0.081),
-    cache("v0-rust-core-contracts-Linux-x64-e8b3ee54-09fbaf53", "refs/pull/900/merge", 0.05),
+    // `rust-native-z3` is one shared key across a `[macos-15, windows-latest]`
+    // matrix (`ci.yml`), so it needs one entry per platform to be healthy.
+    cache("v0-rust-rust-native-z3-Darwin-arm64-e8b3ee54-09fbaf53", MAIN, 0.6),
+    cache("v0-rust-rust-native-z3-Windows_NT-x64-e8b3ee54-09fbaf53", MAIN, 0.577),
   ];
 }
 
@@ -46,18 +48,6 @@ test("accepting: default-branch caches present, budget below threshold, no pull-
   const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
   assert.equal(result.ok, true, formatReport(result));
   assert.deepEqual(result.findings, []);
-});
-
-test("accepting: merge-readiness's own small keys may live on a pull-request ref", () => {
-  // `merge-readiness.yml` deliberately keeps saving from pull requests: its two
-  // keys total ~131 MiB and its lanes are the sub-minute fast path. Only
-  // `ci.yml`'s four shared keys are guarded, so these must not be flagged.
-  const caches = healthyListing();
-  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
-  assert.equal(
-    result.findings.some((finding) => finding.code === "pull-request-cache-present"),
-    false,
-  );
 });
 
 test("rejecting: a pull-request-scoped ci.yml cache means the save-if guard regressed", () => {
@@ -94,10 +84,59 @@ test("rejecting: the 2026-08-06 listing that caused the outage", () => {
   assert.equal(result.ok, false);
   const codes = result.findings.map((finding) => finding.code);
   assert.ok(codes.includes("budget-exhausted"), formatReport(result));
-  // All three critical-path keys are missing from the default branch.
-  assert.equal(codes.filter((code) => code === "main-cache-absent").length, 3);
+  // Every required {key, platform} pair is missing from the default branch:
+  // the three Linux critical-path keys (this listing predates rust-native-z3
+  // joining REQUIRED_MAIN_ENTRIES) plus both native-z3 platforms, absent here
+  // entirely rather than merely missing from `main`.
+  assert.equal(codes.filter((code) => code === "main-cache-absent").length, 5);
   // Every ci.yml key on a pull-request ref is flagged: 3 + 4 across two refs.
   assert.equal(codes.filter((code) => code === "pull-request-cache-present").length, 7);
+  // `core-contracts` and `rust-compile` are not `ci.yml` shared keys, so rule
+  // 3 above does not see them -- this is exactly the gap the generic
+  // pull-request-rust-cache rule (rule 4) closes.
+  assert.equal(codes.filter((code) => code === "pull-request-rust-cache-present").length, 2);
+});
+
+test("rejecting: a non-ci.yml rust cache on a pull-request ref still fires the generic rule", () => {
+  // `rust-compile` is not one of `CI_SHARED_KEYS`, so rule 3 alone would miss
+  // it -- this is the exact shape `merge-readiness.yml` used to produce
+  // before it went restore-only, and the shape any future workflow's
+  // unguarded `Swatinem/rust-cache` step would produce again.
+  const caches = [
+    ...healthyListing(),
+    cache("v0-rust-rust-compile-Linux-x64-aaaaaaaa-bbbbbbbb", "refs/pull/9/merge", 0.08),
+  ];
+  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
+  assert.equal(result.ok, false);
+  const finding = result.findings.find((f) => f.code === "pull-request-rust-cache-present");
+  assert.ok(finding, formatReport(result));
+  assert.match(finding.message, /refs\/pull\/9\/merge/);
+  assert.match(finding.message, /rust-compile/);
+  // Rule 3 must not also fire for the same entry -- one finding, not two.
+  assert.equal(
+    result.findings.filter((f) => f.code === "pull-request-cache-present").length,
+    0,
+  );
+});
+
+test("rejecting: main missing the Windows_NT half of rust-native-z3 is not hidden by Darwin's presence", () => {
+  const caches = healthyListing().filter((entry) => !entry.key.includes("-Windows_NT-"));
+  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
+  assert.equal(result.ok, false);
+  const missing = result.findings.filter((finding) => finding.code === "main-cache-absent");
+  assert.equal(missing.length, 1, formatReport(result));
+  assert.match(missing[0].message, /`rust-native-z3`/);
+  assert.match(missing[0].message, /`Windows_NT`/);
+});
+
+test("rejecting: main missing the Darwin half of rust-native-z3 is not hidden by Windows_NT's presence", () => {
+  const caches = healthyListing().filter((entry) => !entry.key.includes("-Darwin-"));
+  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
+  assert.equal(result.ok, false);
+  const missing = result.findings.filter((finding) => finding.code === "main-cache-absent");
+  assert.equal(missing.length, 1, formatReport(result));
+  assert.match(missing[0].message, /`rust-native-z3`/);
+  assert.match(missing[0].message, /`Darwin`/);
 });
 
 test("rejecting: budget at or above the threshold, even with a healthy ref layout", () => {

--- a/.github/scripts/audit-cache-budget.test.mjs
+++ b/.github/scripts/audit-cache-budget.test.mjs
@@ -32,16 +32,17 @@ function cacheBytes(key, ref, bytes) {
 }
 
 function healthyListing() {
-  // Exact bytes from `gh api actions/caches` (2026-08-12; see
-  // analyst-report-07-cache-budget-redesign.md), not predicted or rounded
-  // values -- `semantic-mutation`'s clean floor in particular was previously
-  // miscalibrated from an unverified prediction (2.2 GiB) that a reviewer's
-  // real-world measurement (run 31210570118 / job 92972117510: a cold
-  // `mutation operators` run that never touched the mutants lane's
-  // scratch/evidence paths still created this exact entry) showed was wrong.
-  // No `fsl-logic` entry: that job is restore-only against `rust-workspace`
-  // (see docs/DESIGN-ci.md, "Actions cache budget") and a healthy state after
-  // that change has no dedicated `fsl-logic` key at all.
+  // Exact bytes from `gh api actions/caches` (2026-08-12), not predicted or
+  // rounded values -- `semantic-mutation`'s observed clean size in particular
+  // was previously miscalibrated from an unverified prediction (2.2 GiB).
+  // Product-gate run 31210570118, job 92972117510 (`mutation operators`)
+  // restored `No cache found.` (a fully cold start, so it never touched the
+  // mutants lane's scratch/evidence paths at all) and still saved this exact
+  // 2,919,716,751-byte entry, showing that prediction was wrong; see
+  // docs/DESIGN-ci.md, "Actions cache budget", for the full account. No
+  // `fsl-logic` entry: that job is restore-only against `rust-workspace`
+  // (same section) and a healthy state after that change has no dedicated
+  // `fsl-logic` key at all.
   return [
     cacheBytes("v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1_605_761_517),
     cacheBytes("v0-rust-wasm-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1_452_450_563),

--- a/.github/scripts/audit-cache-budget.test.mjs
+++ b/.github/scripts/audit-cache-budget.test.mjs
@@ -18,6 +18,8 @@ import {
   formatReport,
   CACHE_LIMIT_BYTES,
   GIB,
+  REQUIRED_MAIN_ENTRIES,
+  SINGLE_ENTRY_WARN_BYTES,
 } from "./audit-cache-budget.mjs";
 
 const MAIN = "refs/heads/main";
@@ -31,7 +33,13 @@ function healthyListing() {
     cache("v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.495),
     cache("v0-rust-wasm-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.352),
     cache("v0-rust-fsl-logic-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.369),
-    cache("v0-rust-semantic-mutation-Linux-x64-e8b3ee54-09fbaf53", MAIN, 2.721),
+    // The designed floor for this key is ~2.2 GiB (two build trees --
+    // `rust/target/debug` and `rust/target/fault-operators/target` -- plus
+    // `~/.cargo`), not the 2.719 GiB it was observed holding once a scratch
+    // build tree and stale evidence directories accumulated inside the cached
+    // path (fixed elsewhere in this branch). This value represents the
+    // corrected healthy state, below `SINGLE_ENTRY_WARN_BYTES`.
+    cache("v0-rust-semantic-mutation-Linux-x64-e8b3ee54-09fbaf53", MAIN, 2.2),
     // `rust-native-z3` is one shared key across a `[macos-15, windows-latest]`
     // matrix (`ci.yml`), so it needs one entry per platform to be healthy.
     cache("v0-rust-rust-native-z3-Darwin-arm64-e8b3ee54-09fbaf53", MAIN, 0.6),
@@ -95,6 +103,9 @@ test("rejecting: the 2026-08-06 listing that caused the outage", () => {
   // 3 above does not see them -- this is exactly the gap the generic
   // pull-request-rust-cache rule (rule 4) closes.
   assert.equal(codes.filter((code) => code === "pull-request-rust-cache-present").length, 2);
+  // The 2.721 GiB `semantic-mutation` entry also trips the single-entry
+  // control independently of everything else wrong with this listing.
+  assert.ok(codes.includes("entry-oversized"), formatReport(result));
 });
 
 test("rejecting: a non-ci.yml rust cache on a pull-request ref still fires the generic rule", () => {
@@ -137,6 +148,61 @@ test("rejecting: main missing the Darwin half of rust-native-z3 is not hidden by
   assert.equal(missing.length, 1, formatReport(result));
   assert.match(missing[0].message, /`rust-native-z3`/);
   assert.match(missing[0].message, /`Darwin`/);
+});
+
+test("accepting: no healthy entry approaches the single-entry warning threshold", () => {
+  const caches = healthyListing();
+  for (const entry of caches) {
+    assert.ok(
+      entry.size_in_bytes < SINGLE_ENTRY_WARN_BYTES,
+      `${entry.key} is ${entry.size_in_bytes} bytes, at or above SINGLE_ENTRY_WARN_BYTES`,
+    );
+  }
+  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
+  assert.equal(
+    result.findings.some((finding) => finding.code === "entry-oversized"),
+    false,
+    formatReport(result),
+  );
+});
+
+test("rejecting: a single oversized entry fires independently of the total budget", () => {
+  // 2.72 GiB reproduces the observed defect value for `semantic-mutation`
+  // before the scratch-build-tree fix elsewhere in this branch.
+  const caches = [
+    cache("v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.495),
+    cache("v0-rust-semantic-mutation-Linux-x64-e8b3ee54-09fbaf53", MAIN, 2.72),
+  ];
+  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
+  assert.equal(result.ok, false);
+  const finding = result.findings.find((f) => f.code === "entry-oversized");
+  assert.ok(finding, formatReport(result));
+  assert.match(finding.message, /semantic-mutation/);
+  // Total usage here is well under the 85% budget threshold -- this control
+  // must not depend on `budget-exhausted` also having fired.
+  assert.equal(
+    result.findings.some((f) => f.code === "budget-exhausted"),
+    false,
+    formatReport(result),
+  );
+});
+
+test("accepting: a shared key containing an earlier platform-like substring is parsed from the tail, not misattributed", () => {
+  // A lazy `(.+?)` stops at the *first* platform-like substring, so a shared
+  // key such as `foo-Linux-bar` (hypothetical, but the bug class is real) would
+  // misparse as shared key `foo` -- a reviewer reproduced this causing a real,
+  // present main-branch entry to be reported `main-cache-absent`. Parsing
+  // greedily from the tail (anchored at `$`) fixes it.
+  const caches = [
+    ...healthyListing(),
+    cache("v0-rust-foo-Linux-bar-Linux-x64-aaaaaaaa-bbbbbbbb", MAIN, 0.01),
+  ];
+  const result = auditCacheBudget({
+    caches,
+    usageBytes: usageOf(caches),
+    requiredMainEntries: [...REQUIRED_MAIN_ENTRIES, { key: "foo-Linux-bar", platform: "Linux" }],
+  });
+  assert.equal(result.ok, true, formatReport(result));
 });
 
 test("rejecting: budget at or above the threshold, even with a healthy ref layout", () => {

--- a/.github/scripts/audit-cache-budget.test.mjs
+++ b/.github/scripts/audit-cache-budget.test.mjs
@@ -19,7 +19,6 @@ import {
   CACHE_LIMIT_BYTES,
   GIB,
   REQUIRED_MAIN_ENTRIES,
-  SINGLE_ENTRY_WARN_BYTES,
 } from "./audit-cache-budget.mjs";
 
 const MAIN = "refs/heads/main";
@@ -28,22 +27,29 @@ function cache(key, ref, gib) {
   return { key, ref, size_in_bytes: Math.round(gib * GIB) };
 }
 
+function cacheBytes(key, ref, bytes) {
+  return { key, ref, size_in_bytes: bytes };
+}
+
 function healthyListing() {
+  // Exact bytes from `gh api actions/caches` (2026-08-12; see
+  // analyst-report-07-cache-budget-redesign.md), not predicted or rounded
+  // values -- `semantic-mutation`'s clean floor in particular was previously
+  // miscalibrated from an unverified prediction (2.2 GiB) that a reviewer's
+  // real-world measurement (run 31210570118 / job 92972117510: a cold
+  // `mutation operators` run that never touched the mutants lane's
+  // scratch/evidence paths still created this exact entry) showed was wrong.
+  // No `fsl-logic` entry: that job is restore-only against `rust-workspace`
+  // (see docs/DESIGN-ci.md, "Actions cache budget") and a healthy state after
+  // that change has no dedicated `fsl-logic` key at all.
   return [
-    cache("v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.495),
-    cache("v0-rust-wasm-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.352),
-    cache("v0-rust-fsl-logic-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.369),
-    // The designed floor for this key is ~2.2 GiB (two build trees --
-    // `rust/target/debug` and `rust/target/fault-operators/target` -- plus
-    // `~/.cargo`), not the 2.719 GiB it was observed holding once a scratch
-    // build tree and stale evidence directories accumulated inside the cached
-    // path (fixed elsewhere in this branch). This value represents the
-    // corrected healthy state, below `SINGLE_ENTRY_WARN_BYTES`.
-    cache("v0-rust-semantic-mutation-Linux-x64-e8b3ee54-09fbaf53", MAIN, 2.2),
+    cacheBytes("v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1_605_761_517),
+    cacheBytes("v0-rust-wasm-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1_452_450_563),
+    cacheBytes("v0-rust-semantic-mutation-Linux-x64-e8b3ee54-09fbaf53", MAIN, 2_919_716_751),
     // `rust-native-z3` is one shared key across a `[macos-15, windows-latest]`
     // matrix (`ci.yml`), so it needs one entry per platform to be healthy.
-    cache("v0-rust-rust-native-z3-Darwin-arm64-e8b3ee54-09fbaf53", MAIN, 0.6),
-    cache("v0-rust-rust-native-z3-Windows_NT-x64-e8b3ee54-09fbaf53", MAIN, 0.577),
+    cacheBytes("v0-rust-rust-native-z3-Darwin-arm64-f9b08cb2-09fbaf53", MAIN, 1_239_235_056),
+    cacheBytes("v0-rust-rust-native-z3-Windows_NT-x64-e8b3ee54-09fbaf53", MAIN, 619_501_189),
   ];
 }
 
@@ -93,19 +99,19 @@ test("rejecting: the 2026-08-06 listing that caused the outage", () => {
   const codes = result.findings.map((finding) => finding.code);
   assert.ok(codes.includes("budget-exhausted"), formatReport(result));
   // Every required {key, platform} pair is missing from the default branch:
-  // the three Linux critical-path keys (this listing predates rust-native-z3
-  // joining REQUIRED_MAIN_ENTRIES) plus both native-z3 platforms, absent here
+  // the two Linux critical-path keys (`rust-workspace`, `wasm`; this listing
+  // predates rust-native-z3 joining REQUIRED_MAIN_ENTRIES and `fsl-logic` is
+  // not a required key at all) plus both native-z3 platforms, absent here
   // entirely rather than merely missing from `main`.
-  assert.equal(codes.filter((code) => code === "main-cache-absent").length, 5);
-  // Every ci.yml key on a pull-request ref is flagged: 3 + 4 across two refs.
-  assert.equal(codes.filter((code) => code === "pull-request-cache-present").length, 7);
-  // `core-contracts` and `rust-compile` are not `ci.yml` shared keys, so rule
-  // 3 above does not see them -- this is exactly the gap the generic
-  // pull-request-rust-cache rule (rule 4) closes.
-  assert.equal(codes.filter((code) => code === "pull-request-rust-cache-present").length, 2);
-  // The 2.721 GiB `semantic-mutation` entry also trips the single-entry
-  // control independently of everything else wrong with this listing.
-  assert.ok(codes.includes("entry-oversized"), formatReport(result));
+  assert.equal(codes.filter((code) => code === "main-cache-absent").length, 4);
+  // `ci.yml` shared keys (`wasm`, `rust-workspace`, `semantic-mutation`) on a
+  // pull-request ref are flagged by rule 3: 2 + 3 across the two refs.
+  assert.equal(codes.filter((code) => code === "pull-request-cache-present").length, 5);
+  // `core-contracts`, `rust-compile`, and `fsl-logic` (not a `ci.yml` shared
+  // key) are not covered by rule 3 -- this is exactly the gap the generic
+  // pull-request-rust-cache rule (rule 4) closes: 2 `fsl-logic` + 1
+  // `core-contracts` + 1 `rust-compile`.
+  assert.equal(codes.filter((code) => code === "pull-request-rust-cache-present").length, 4);
 });
 
 test("rejecting: a non-ci.yml rust cache on a pull-request ref still fires the generic rule", () => {
@@ -148,43 +154,6 @@ test("rejecting: main missing the Darwin half of rust-native-z3 is not hidden by
   assert.equal(missing.length, 1, formatReport(result));
   assert.match(missing[0].message, /`rust-native-z3`/);
   assert.match(missing[0].message, /`Darwin`/);
-});
-
-test("accepting: no healthy entry approaches the single-entry warning threshold", () => {
-  const caches = healthyListing();
-  for (const entry of caches) {
-    assert.ok(
-      entry.size_in_bytes < SINGLE_ENTRY_WARN_BYTES,
-      `${entry.key} is ${entry.size_in_bytes} bytes, at or above SINGLE_ENTRY_WARN_BYTES`,
-    );
-  }
-  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
-  assert.equal(
-    result.findings.some((finding) => finding.code === "entry-oversized"),
-    false,
-    formatReport(result),
-  );
-});
-
-test("rejecting: a single oversized entry fires independently of the total budget", () => {
-  // 2.72 GiB reproduces the observed defect value for `semantic-mutation`
-  // before the scratch-build-tree fix elsewhere in this branch.
-  const caches = [
-    cache("v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53", MAIN, 1.495),
-    cache("v0-rust-semantic-mutation-Linux-x64-e8b3ee54-09fbaf53", MAIN, 2.72),
-  ];
-  const result = auditCacheBudget({ caches, usageBytes: usageOf(caches) });
-  assert.equal(result.ok, false);
-  const finding = result.findings.find((f) => f.code === "entry-oversized");
-  assert.ok(finding, formatReport(result));
-  assert.match(finding.message, /semantic-mutation/);
-  // Total usage here is well under the 85% budget threshold -- this control
-  // must not depend on `budget-exhausted` also having fired.
-  assert.equal(
-    result.findings.some((f) => f.code === "budget-exhausted"),
-    false,
-    formatReport(result),
-  );
 });
 
 test("accepting: a shared key containing an earlier platform-like substring is parsed from the tail, not misattributed", () => {

--- a/.github/workflows/cache-budget-audit.yml
+++ b/.github/workflows/cache-budget-audit.yml
@@ -33,6 +33,7 @@ on:
       - .github/scripts/run-cache-budget-audit.mjs
       - .github/workflows/cache-budget-audit.yml
       - .github/workflows/ci.yml
+      - .github/workflows/merge-readiness.yml
 
 permissions:
   actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,24 +514,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.scope.outputs.run == 'true'
         with:
-          # Saving is restricted to non-pull-request events. A pull request's cache is
-          # readable only by that same pull request -- Actions caches are ref-scoped, so
-          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
-          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
-          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
-          # which every run built cold: measured +8 to +16 min per shard. Only `main`
-          # saves now, and every pull request can read `main` because it is the default
-          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
-          save-if: ${{ github.event_name != 'pull_request' }}
+          # Restore-only: this job never saves the `semantic-mutation` key.
+          # `Swatinem/rust-cache` saves a key once, and whichever job reaches its
+          # post step first wins -- for this key that is always one of the
+          # `semantic-mutation-operators` shards below, which run in parallel and
+          # finish in single-digit minutes against this job's own tens of
+          # minutes, so this job has never actually won that race and its
+          # `cache-on-failure: true` was accordingly dead configuration. This
+          # job's only rust/target-scoped output is its evidence directory
+          # (`rust/target/semantic-mutation.*`, kept under `rust/target` solely
+          # because the artifact-upload glob below requires it), which must not
+          # enter the cache at all. The one thing this job could gain from its
+          # own save -- a warm `~/.cargo/bin/cargo-mutants` -- it already does not
+          # have today, since the operators shards' save always wins first; going
+          # restore-only changes nothing about that and removes the possibility
+          # of this job's evidence directory leaking into a future save. See
+          # docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: false
           workspaces: rust -> target
           shared-key: semantic-mutation
-          # Save even when the job fails. Without this the lane cannot recover from a
-          # cold start: a cold scratch build exceeds the job budget, the job is
-          # cancelled, `rust-cache` skips saving, and the next run is cold again. The
-          # cache can then only be created by a run that succeeds, and a run can only
-          # succeed once the cache exists. Measured on `main` and on three pull
-          # requests; see docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
-          cache-on-failure: true
 
       - name: Install pinned semantic mutation runner
         if: steps.scope.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,15 +669,22 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.scope.outputs.run == 'true'
         with:
-          # Saving is restricted to non-pull-request events. A pull request's cache is
-          # readable only by that same pull request -- Actions caches are ref-scoped, so
-          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
-          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
-          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
-          # which every run built cold: measured +8 to +16 min per shard. Only `main`
-          # saves now, and every pull request can read `main` because it is the default
-          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
-          save-if: ${{ github.event_name != 'pull_request' }}
+          # Restore-only against `rust workspace`'s own `rust-workspace` key, not a
+          # dedicated `fsl-logic` key. This job's entire build is
+          # `cargo test -p fslc-rust --test typed_agreement --locked`
+          # (`tools/run-fsl-logic-test.sh:19-22`), one test target that is a strict
+          # subset of what the `rust workspace` shards already build -- `Swatinem/rust-cache`
+          # prunes workspace-member build artifacts at save time and keeps only external
+          # dependency output (upstream `src/cleanup.ts`), so every lane's cache is
+          # substantively "the same lockfile's external deps" regardless of which job
+          # saved it; restoring `rust-workspace` here loses nothing this job needed a
+          # dedicated key for. This removes the dedicated `fsl-logic` key from the shared
+          # budget -- measured at 1,470,489,603 B (1.369 GiB) before this change -- once a
+          # human deletes the now-orphaned entry. Baseline warm duration: 2m48s-2m53s
+          # (scheduled runs 2026-08-09/10/11); TODO: record this job's first post-change
+          # run duration here once observed.
+          shared-key: rust-workspace
+          save-if: false
           workspaces: rust -> target
 
       - name: Run bounded pull-request generation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,13 @@ jobs:
         with:
           # Saving is restricted to non-pull-request events. A pull request's cache is
           # readable only by that same pull request -- Actions caches are ref-scoped, so
-          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
-          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
-          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
-          # which every run built cold: measured +8 to +16 min per shard. Only `main`
-          # saves now, and every pull request can read `main` because it is the default
-          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          # sibling pull requests cannot use each other's -- while, at the time of the
+          # 2026-08-06 incident, `ci.yml`'s four shared keys together stored about
+          # 6.9 GiB per pull request against a 10 GiB repository limit. Two concurrent
+          # pull requests therefore evicted `main`'s caches, after which every run built
+          # cold: measured +8 to +16 min per shard. Only `main` saves now, and every pull
+          # request can read `main` because it is the default branch. See
+          # docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
           shared-key: rust-workspace
@@ -147,12 +148,13 @@ jobs:
         with:
           # Saving is restricted to non-pull-request events. A pull request's cache is
           # readable only by that same pull request -- Actions caches are ref-scoped, so
-          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
-          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
-          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
-          # which every run built cold: measured +8 to +16 min per shard. Only `main`
-          # saves now, and every pull request can read `main` because it is the default
-          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          # sibling pull requests cannot use each other's -- while, at the time of the
+          # 2026-08-06 incident, `ci.yml`'s four shared keys together stored about
+          # 6.9 GiB per pull request against a 10 GiB repository limit. Two concurrent
+          # pull requests therefore evicted `main`'s caches, after which every run built
+          # cold: measured +8 to +16 min per shard. Only `main` saves now, and every pull
+          # request can read `main` because it is the default branch. See
+          # docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
           shared-key: rust-workspace
@@ -278,12 +280,13 @@ jobs:
         with:
           # Saving is restricted to non-pull-request events. A pull request's cache is
           # readable only by that same pull request -- Actions caches are ref-scoped, so
-          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
-          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
-          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
-          # which every run built cold: measured +8 to +16 min per shard. Only `main`
-          # saves now, and every pull request can read `main` because it is the default
-          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          # sibling pull requests cannot use each other's -- while, at the time of the
+          # 2026-08-06 incident, `ci.yml`'s four shared keys together stored about
+          # 6.9 GiB per pull request against a 10 GiB repository limit. Two concurrent
+          # pull requests therefore evicted `main`'s caches, after which every run built
+          # cold: measured +8 to +16 min per shard. Only `main` saves now, and every pull
+          # request can read `main` because it is the default branch. See
+          # docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
 
@@ -351,12 +354,13 @@ jobs:
         with:
           # Saving is restricted to non-pull-request events. A pull request's cache is
           # readable only by that same pull request -- Actions caches are ref-scoped, so
-          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
-          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
-          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
-          # which every run built cold: measured +8 to +16 min per shard. Only `main`
-          # saves now, and every pull request can read `main` because it is the default
-          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          # sibling pull requests cannot use each other's -- while, at the time of the
+          # 2026-08-06 incident, `ci.yml`'s four shared keys together stored about
+          # 6.9 GiB per pull request against a 10 GiB repository limit. Two concurrent
+          # pull requests therefore evicted `main`'s caches, after which every run built
+          # cold: measured +8 to +16 min per shard. Only `main` saves now, and every pull
+          # request can read `main` because it is the default branch. See
+          # docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
           # Save even when the job fails or is cancelled by the timeout above. Without
@@ -407,12 +411,13 @@ jobs:
         with:
           # Saving is restricted to non-pull-request events. A pull request's cache is
           # readable only by that same pull request -- Actions caches are ref-scoped, so
-          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
-          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
-          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
-          # which every run built cold: measured +8 to +16 min per shard. Only `main`
-          # saves now, and every pull request can read `main` because it is the default
-          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          # sibling pull requests cannot use each other's -- while, at the time of the
+          # 2026-08-06 incident, `ci.yml`'s four shared keys together stored about
+          # 6.9 GiB per pull request against a 10 GiB repository limit. Two concurrent
+          # pull requests therefore evicted `main`'s caches, after which every run built
+          # cold: measured +8 to +16 min per shard. Only `main` saves now, and every pull
+          # request can read `main` because it is the default branch. See
+          # docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
 
@@ -461,12 +466,13 @@ jobs:
         with:
           # Saving is restricted to non-pull-request events. A pull request's cache is
           # readable only by that same pull request -- Actions caches are ref-scoped, so
-          # sibling pull requests cannot use each other's -- while `ci.yml`'s four shared
-          # keys together store about 6.9 GiB per pull request against a 10 GiB repository
-          # limit. Two concurrent pull requests therefore evicted `main`'s caches, after
-          # which every run built cold: measured +8 to +16 min per shard. Only `main`
-          # saves now, and every pull request can read `main` because it is the default
-          # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          # sibling pull requests cannot use each other's -- while, at the time of the
+          # 2026-08-06 incident, `ci.yml`'s four shared keys together stored about
+          # 6.9 GiB per pull request against a 10 GiB repository limit. Two concurrent
+          # pull requests therefore evicted `main`'s caches, after which every run built
+          # cold: measured +8 to +16 min per shard. Only `main` saves now, and every pull
+          # request can read `main` because it is the default branch. See
+          # docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
           shared-key: semantic-mutation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,21 @@ jobs:
       github.base_ref == 'production' ||
       vars.FSL_OPTIMISTIC_CI != 'enabled'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    # Raised rather than narrowed, for the same reason `production-native-z3-linux`
+    # below gives: a gate that runs out of wall clock reports a failure it did not
+    # observe. Warm measured: 32m56s / 32m45s (2026-08-04), 31m49s / 29m44s / 26m56s
+    # (2026-08-05) -- comfortably inside the old 40-minute budget. The scheduled
+    # `windows-latest` run then hit exactly 40m0x and was cancelled on every one of
+    # six consecutive occasions from 2026-08-07 00:23 through 2026-08-11: a step
+    # change, not gradual drift, and neither a regression nor added test volume. The
+    # decisive contrast is the `Swatinem/rust-cache` restore step itself: the last
+    # success (2026-08-05) reported `Cache hit for: v0-rust-rust-native-z3-Windows_NT-x64-...`
+    # and restored 591 MiB; the 2026-08-11 cancellation reported `No cache found.`
+    # instead. The cache had been evicted by pull-request-scoped caches this same
+    # commit's other changes close off (see the `Swatinem/rust-cache` step below and
+    # `merge-readiness.yml`); 60 minutes covers a genuine cold vendored-Z3 build on
+    # this matrix, matching the headroom already given to the Linux promotion lane.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -345,6 +359,21 @@ jobs:
           # branch. See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
+          # Save even when the job fails or is cancelled by the timeout above. Without
+          # this the lane cannot recover from a cold start: a cold scratch build exceeds
+          # the job budget, the job is cancelled, `rust-cache`'s post step is skipped
+          # (`9 skipped Post Run Swatinem/rust-cache@v2`, observed on run 31527197290),
+          # and the next run is cold again -- the cache can then only be created by a
+          # run that succeeds, and a run can only succeed once the cache exists. This is
+          # the same fix already applied to the `semantic-mutation` lanes below for an
+          # identical deadlock; confirmed here from the action's own `post-if:
+          # success() || env.CACHE_ON_FAILURE == 'true'` (does not distinguish a
+          # cancelled conclusion from a failed one) and from this repository's own
+          # history: issues #721 and #678 both recurred with `Conclusion: cancelled`
+          # repeatedly before commit 877fe8c (#752) added this flag to those lanes, and
+          # neither showed `cancelled` again afterward -- only an unrelated `failure`
+          # that was fixed separately. See docs/DESIGN-ci.md, "Actions cache budget".
+          cache-on-failure: true
 
       - name: Test pinned native solver and BMC crates
         working-directory: rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,13 +366,18 @@ jobs:
           # and the next run is cold again -- the cache can then only be created by a
           # run that succeeds, and a run can only succeed once the cache exists. This is
           # the same fix already applied to the `semantic-mutation` lanes below for an
-          # identical deadlock; confirmed here from the action's own `post-if:
-          # success() || env.CACHE_ON_FAILURE == 'true'` (does not distinguish a
-          # cancelled conclusion from a failed one) and from this repository's own
-          # history: issues #721 and #678 both recurred with `Conclusion: cancelled`
-          # repeatedly before commit 877fe8c (#752) added this flag to those lanes, and
-          # neither showed `cancelled` again afterward -- only an unrelated `failure`
-          # that was fixed separately. See docs/DESIGN-ci.md, "Actions cache budget".
+          # identical deadlock. The action's own `post-if: success() ||
+          # env.CACHE_ON_FAILURE == 'true'` does not distinguish a cancelled conclusion
+          # from a failed one, which reads as support for this saving through a timeout
+          # cancellation and not only an ordinary step failure -- but that reading is
+          # inference from the condition text, not a direct observation: commit 877fe8c
+          # (#752), which added this same flag to the semantic-mutation lanes, also
+          # raised those lanes' timeouts in the same commit, so the `cancelled`
+          # conclusions on issues #721/#678 stopping afterward is confounded with more
+          # budget, not isolated evidence for `cache-on-failure` alone. No run in this
+          # repository's history has been observed saving specifically after a
+          # timeout-triggered cancellation; see docs/DESIGN-ci.md, "Actions cache
+          # budget", for what is and is not established here.
           cache-on-failure: true
 
       - name: Test pinned native solver and BMC crates

--- a/.github/workflows/merge-readiness.yml
+++ b/.github/workflows/merge-readiness.yml
@@ -27,6 +27,17 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          # Saving is restricted to non-pull-request events, matching every
+          # `Swatinem/rust-cache` step in `ci.yml`. This workflow runs on every pull
+          # request, so before this guard existed it saved a fresh ref-scoped cache on
+          # every one of them -- measured at 15 open pull requests holding 29 entries /
+          # about 1.90 GiB (roughly 134 MiB per pull request across this job and
+          # `core-contracts` below) against the repository's shared 10 GiB budget. PR
+          # #752 closed this same eviction path in `ci.yml` but left this workflow open,
+          # so its accumulation kept crowding out `main`'s caches -- including the
+          # `native Z3 4.16 (windows-latest)` cache, observed evicted to zero entries.
+          # See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
 
       - name: Check the native-Z3-free Rust surface
@@ -45,6 +56,17 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          # Saving is restricted to non-pull-request events, matching every
+          # `Swatinem/rust-cache` step in `ci.yml`. This workflow runs on every pull
+          # request, so before this guard existed it saved a fresh ref-scoped cache on
+          # every one of them -- measured at 15 open pull requests holding 29 entries /
+          # about 1.90 GiB (roughly 134 MiB per pull request across this job and
+          # `rust-compile` above) against the repository's shared 10 GiB budget. PR
+          # #752 closed this same eviction path in `ci.yml` but left this workflow open,
+          # so its accumulation kept crowding out `main`'s caches -- including the
+          # `native Z3 4.16 (windows-latest)` cache, observed evicted to zero entries.
+          # See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
+          save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
 
       - name: Check solver-independent contracts

--- a/.github/workflows/merge-readiness.yml
+++ b/.github/workflows/merge-readiness.yml
@@ -27,19 +27,39 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Saving is restricted to non-pull-request events, matching every
-          # `Swatinem/rust-cache` step in `ci.yml`. This workflow runs on every pull
-          # request, so before this guard existed it saved a fresh ref-scoped cache on
-          # every one of them -- measured at 15 pull-request refs (#743-#792, all closed
-          # or merged by measurement time, still resident within GitHub's 7-day
-          # no-access retention window) holding 29 entries / about 1.90 GiB (roughly
-          # 134 MiB per ref across this job and `core-contracts` below) against the
-          # repository's shared 10 GiB budget. PR #752 closed this same eviction path in
-          # `ci.yml` but left this workflow open, so its accumulation kept crowding out
-          # `main`'s caches -- including the `native Z3 4.16 (windows-latest)` cache,
-          # observed evicted to zero entries.
+          # Restore-only against `ci.yml`'s `rust-workspace` key, not a `save-if` guard.
+          # (a) This workflow has no `push` trigger (see `on:` above) and never gains one
+          # from `pull_request`/`merge_group` alone, so it has no path of its own to ever
+          # save a main-branch copy. Guarding this step's own key with
+          # `save-if: ${{ github.event_name != 'pull_request' }}`, as `ci.yml` does, would
+          # leave every pull request permanently cold instead: the earlier fix in this
+          # branch made that mistake (see git history) before independent review caught
+          # it. This job never saves at all and instead reads `ci.yml`'s `rust-workspace`
+          # entry, which the `push: branches: [main]` trigger there keeps warm.
+          # (b) Key derivation: `Swatinem/rust-cache` (`src/config.ts`) ignores `key` and
+          # `GITHUB_JOB` once `shared-key` is set, and otherwise hashes the rustc version
+          # plus `CARGO|CC|CFLAGS|CXX|CMAKE|RUST`-prefixed env vars and the workspace
+          # lockfiles. This job and `ci.yml`'s `rust workspace` job both run
+          # `dtolnay/rust-toolchain@stable` on `ubuntu-latest` against the same checkout,
+          # so an exact key match is expected -- not asserted as observed here, because
+          # the pull-request-scoped cache entries that could have confirmed a full-key
+          # match were deleted 2026-08-12 during unrelated cache cleanup and cannot be
+          # re-measured retroactively. Confirm from the first post-merge run's own log:
+          # `Restored from cache key "v0-rust-rust-workspace-Linux-x64-..." full match:
+          # true.` Even on a lockfile-hash mismatch, `src/restore.ts` falls back to the
+          # shared `restoreKey` prefix, so this degrades to a partial restore rather than
+          # a cold build.
+          # (c) This job's `cargo check --workspace --no-default-features` differs in
+          # feature resolution from `rust workspace`'s default-feature build
+          # (`tools/check-merge-readiness.sh:15-22`), so even a full key match leaves some
+          # dependency crates rebuilding -- a partial warm, not a guaranteed full one. The
+          # floor is still strictly better than history: `main` has never held a cache
+          # under this workflow's own former key (no `push` trigger ever existed for it),
+          # so every pull request's first run has always been cold. Restore-only turns
+          # that same first run into a partial warm instead.
           # See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
-          save-if: ${{ github.event_name != 'pull_request' }}
+          shared-key: rust-workspace
+          save-if: false
           workspaces: rust -> target
 
       - name: Check the native-Z3-free Rust surface
@@ -58,19 +78,39 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          # Saving is restricted to non-pull-request events, matching every
-          # `Swatinem/rust-cache` step in `ci.yml`. This workflow runs on every pull
-          # request, so before this guard existed it saved a fresh ref-scoped cache on
-          # every one of them -- measured at 15 pull-request refs (#743-#792, all closed
-          # or merged by measurement time, still resident within GitHub's 7-day
-          # no-access retention window) holding 29 entries / about 1.90 GiB (roughly
-          # 134 MiB per ref across this job and `rust-compile` above) against the
-          # repository's shared 10 GiB budget. PR #752 closed this same eviction path in
-          # `ci.yml` but left this workflow open, so its accumulation kept crowding out
-          # `main`'s caches -- including the `native Z3 4.16 (windows-latest)` cache,
-          # observed evicted to zero entries.
+          # Restore-only against `ci.yml`'s `rust-workspace` key, not a `save-if` guard.
+          # (a) This workflow has no `push` trigger (see `on:` above) and never gains one
+          # from `pull_request`/`merge_group` alone, so it has no path of its own to ever
+          # save a main-branch copy. Guarding this step's own key with
+          # `save-if: ${{ github.event_name != 'pull_request' }}`, as `ci.yml` does, would
+          # leave every pull request permanently cold instead: the earlier fix in this
+          # branch made that mistake (see git history) before independent review caught
+          # it. This job never saves at all and instead reads `ci.yml`'s `rust-workspace`
+          # entry, which the `push: branches: [main]` trigger there keeps warm.
+          # (b) Key derivation: `Swatinem/rust-cache` (`src/config.ts`) ignores `key` and
+          # `GITHUB_JOB` once `shared-key` is set, and otherwise hashes the rustc version
+          # plus `CARGO|CC|CFLAGS|CXX|CMAKE|RUST`-prefixed env vars and the workspace
+          # lockfiles. This job and `ci.yml`'s `rust workspace` job both run
+          # `dtolnay/rust-toolchain@stable` on `ubuntu-latest` against the same checkout,
+          # so an exact key match is expected -- not asserted as observed here, because
+          # the pull-request-scoped cache entries that could have confirmed a full-key
+          # match were deleted 2026-08-12 during unrelated cache cleanup and cannot be
+          # re-measured retroactively. Confirm from the first post-merge run's own log:
+          # `Restored from cache key "v0-rust-rust-workspace-Linux-x64-..." full match:
+          # true.` Even on a lockfile-hash mismatch, `src/restore.ts` falls back to the
+          # shared `restoreKey` prefix, so this degrades to a partial restore rather than
+          # a cold build.
+          # (c) This job builds `cargo fmt --check` plus a default-feature test build of a
+          # subset of `rust workspace`'s crates (`tools/check-merge-readiness.sh:25-33`),
+          # which is close enough to `rust workspace`'s own build to expect a near-full
+          # warm restore, unlike `rust-compile`'s `--no-default-features` lane above. The
+          # floor is still strictly better than history either way: `main` has never held
+          # a cache under this workflow's own former key (no `push` trigger ever existed
+          # for it), so every pull request's first run has always been cold. Restore-only
+          # turns that same first run into a warm or partially warm one instead.
           # See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
-          save-if: ${{ github.event_name != 'pull_request' }}
+          shared-key: rust-workspace
+          save-if: false
           workspaces: rust -> target
 
       - name: Check solver-independent contracts

--- a/.github/workflows/merge-readiness.yml
+++ b/.github/workflows/merge-readiness.yml
@@ -30,12 +30,14 @@ jobs:
           # Saving is restricted to non-pull-request events, matching every
           # `Swatinem/rust-cache` step in `ci.yml`. This workflow runs on every pull
           # request, so before this guard existed it saved a fresh ref-scoped cache on
-          # every one of them -- measured at 15 open pull requests holding 29 entries /
-          # about 1.90 GiB (roughly 134 MiB per pull request across this job and
-          # `core-contracts` below) against the repository's shared 10 GiB budget. PR
-          # #752 closed this same eviction path in `ci.yml` but left this workflow open,
-          # so its accumulation kept crowding out `main`'s caches -- including the
-          # `native Z3 4.16 (windows-latest)` cache, observed evicted to zero entries.
+          # every one of them -- measured at 15 pull-request refs (#743-#792, all closed
+          # or merged by measurement time, still resident within GitHub's 7-day
+          # no-access retention window) holding 29 entries / about 1.90 GiB (roughly
+          # 134 MiB per ref across this job and `core-contracts` below) against the
+          # repository's shared 10 GiB budget. PR #752 closed this same eviction path in
+          # `ci.yml` but left this workflow open, so its accumulation kept crowding out
+          # `main`'s caches -- including the `native Z3 4.16 (windows-latest)` cache,
+          # observed evicted to zero entries.
           # See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target
@@ -59,12 +61,14 @@ jobs:
           # Saving is restricted to non-pull-request events, matching every
           # `Swatinem/rust-cache` step in `ci.yml`. This workflow runs on every pull
           # request, so before this guard existed it saved a fresh ref-scoped cache on
-          # every one of them -- measured at 15 open pull requests holding 29 entries /
-          # about 1.90 GiB (roughly 134 MiB per pull request across this job and
-          # `rust-compile` above) against the repository's shared 10 GiB budget. PR
-          # #752 closed this same eviction path in `ci.yml` but left this workflow open,
-          # so its accumulation kept crowding out `main`'s caches -- including the
-          # `native Z3 4.16 (windows-latest)` cache, observed evicted to zero entries.
+          # every one of them -- measured at 15 pull-request refs (#743-#792, all closed
+          # or merged by measurement time, still resident within GitHub's 7-day
+          # no-access retention window) holding 29 entries / about 1.90 GiB (roughly
+          # 134 MiB per ref across this job and `rust-compile` above) against the
+          # repository's shared 10 GiB budget. PR #752 closed this same eviction path in
+          # `ci.yml` but left this workflow open, so its accumulation kept crowding out
+          # `main`'s caches -- including the `native Z3 4.16 (windows-latest)` cache,
+          # observed evicted to zero entries.
           # See docs/DESIGN-ci.md, "Actions cache budget", and issue #747.
           save-if: ${{ github.event_name != 'pull_request' }}
           workspaces: rust -> target

--- a/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
+++ b/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
@@ -1,0 +1,29 @@
+Fixed (#747): `main`'s scheduled product gate is no longer cancelled by a
+self-perpetuating cache-budget loop. PR #752 restricted `Swatinem/rust-cache`
+saving in `ci.yml` to non-pull-request events so pull requests could not keep
+evicting `main`'s caches, but `merge-readiness.yml`'s two `rust-cache` steps
+(`rust-compile`, `core-contracts`) carried no such guard. Because that
+workflow runs on every pull request, each one kept saving a fresh
+ref-scoped copy of both keys, and a cache's last-accessed time refreshes on
+restore even without resaving, so none of them expired quickly either.
+Measured on 2026-08-11: 15 open pull requests held 29 entries (~1.90 GiB) on
+those two keys alone, part of 38 entries / 10.03 GiB total against the
+repository's 10 GiB budget, and the LRU evictor had removed
+`refs/heads/main`'s `native Z3 4.16 (windows-latest)` cache down to zero
+entries. `merge-readiness.yml` now carries the same
+`save-if: ${{ github.event_name != 'pull_request' }}` guard as every
+`Swatinem/rust-cache` step in `ci.yml`. Separately, `rust-native-z3`'s
+`windows-latest`/`macos-15` matrix had the same cancel-skips-save deadlock
+already fixed for the `semantic-mutation` lanes: a cold build (measured warm
+at 27–33 min) exceeded the 40-minute budget, the job was cancelled on all six
+consecutive scheduled runs from 2026-08-07 through 2026-08-11
+(`9 skipped Post Run Swatinem/rust-cache@v2`, run 31527197290), and the
+skipped post step meant no cache was ever written to recover from. That step
+now carries `cache-on-failure: true` — confirmed from `Swatinem/rust-cache`'s
+own `post-if: success() || env.CACHE_ON_FAILURE == 'true'`, which does not
+distinguish a cancelled conclusion from a failed one, and from this
+repository's own history (issues #721 and #678 stopped recurring as
+`cancelled` immediately after commit `877fe8c` added the same flag to the
+semantic-mutation lanes) — and its `timeout-minutes` is raised from 40 to 60
+to cover a genuine cold vendored-Z3 build, diagnosed rather than raised
+blind. See `docs/DESIGN-ci.md`, "Actions cache budget".

--- a/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
+++ b/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
@@ -12,9 +12,16 @@ them, but because GitHub only evicts an unused cache after 7 days without a
 read, and measurement landed inside that window. The LRU evictor does not
 distinguish "small but many" from "few but large": it had removed
 `refs/heads/main`'s `native Z3 4.16 (windows-latest)` cache down to zero
-entries. `merge-readiness.yml` now carries the same
-`save-if: ${{ github.event_name != 'pull_request' }}` guard as every
-`Swatinem/rust-cache` step in `ci.yml`. Separately, `rust-native-z3`'s
+entries. `merge-readiness.yml` has no `push` trigger, so the `ci.yml`-style
+`save-if: ${{ github.event_name != 'pull_request' }}` guard would not close
+this path -- it would leave every pull request permanently cold, since
+nothing would ever save a `main` copy under this workflow's own key for it to
+restore. Both `Swatinem/rust-cache` steps instead go restore-only against
+`ci.yml`'s own `rust-workspace` key (`shared-key: rust-workspace`,
+`save-if: false`): the two workflows' jobs share a toolchain, runner, and
+checkout, so the derived cache key is expected to match, confirmed from the
+first post-merge run's `full match: true` restore log rather than asserted
+from an unverifiable prior observation. Separately, `rust-native-z3`'s
 `windows-latest`/`macos-15` matrix had the same cancel-skips-save deadlock
 already fixed for the `semantic-mutation` lanes: a cold build (measured warm
 at 27–33 min) exceeded the 40-minute budget, the job was cancelled on all six

--- a/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
+++ b/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
@@ -35,23 +35,23 @@ run `31527197290` all three `semantic-mutation-operators` shards reach their
 post step tens of minutes before `semantic-mutation-mutants` does -- the
 operators shards are this key's only actual saver. An earlier version of this
 cleanup ran only in the mutants lane's own path, after the operators lane's
-early exit, so the one lane that saves the key never ran it and kept
-resaving the same dead weight. `semantic-mutation-mutants`'s
-`Swatinem/rust-cache` step is now `save-if: false` (with `cache-on-failure`
-removed, since `save-if: false` already makes it inert) to make that
-ownership explicit; `semantic-mutation-operators` is unchanged. Both
-uniquely-per-run-named directories were never reused once restored, so each
-save accumulated them as dead weight on top of this key's legitimate content,
-which is larger than initially estimated: `rust/target/fault-operators`
-(`tools/run-fault-operators.sh`) is a *deliberately persistent* scratch
-checkout and build tree, not removable dead weight, so the corrected floor is
-two build trees plus `~/.cargo` (~2.2 GiB predicted, not the ~0.9-1.4 GiB
-first predicted, which mistakenly treated that persistent tree as part of the
-dead weight) against the observed defect value of 2.719 GiB. This does not
-shrink that cache entry by itself -- `Swatinem/rust-cache` will not resave a
-still-matching key -- so the reduction only takes effect once the entry is
-deleted (a separate, human-authorized action) and a run resaves it; the
-resulting size is not reported here as measured. Separately, `rust-native-z3`'s
+early exit, so the one lane that saves the key never ran it.
+`semantic-mutation-mutants`'s `Swatinem/rust-cache` step is now
+`save-if: false` (with `cache-on-failure` removed, since `save-if: false`
+already makes it inert) to make that ownership explicit;
+`semantic-mutation-operators` is unchanged. **This is a closed-ingress-path
+fix, not a size fix**: measured directly (product-gate run `31210570118`, job
+`92972117510`, `mutation operators (3/3)`), the `semantic-mutation` entry's
+current 2.719 GiB was created by a *cold* operators run (`No cache found.` at
+19:14:17Z, saved at 19:48:12Z) that never touched the mutants lane's scratch
+build or evidence paths at all -- neither could have contributed to this
+entry's size, so there was no dead weight to recover, and two earlier
+predictions in this fragment and in `docs/DESIGN-ci.md` (a ~0.9-1.4 GiB floor
+from an assumed accumulating scratch tree, then a ~2.2 GiB floor from
+`rust/target/fault-operators`' deliberately persistent build tree treated as
+a designed minimum) were both wrong about what this entry actually is.
+`semantic-mutation` is not resized by this change and is not touched by the
+budget lever below. Separately, `rust-native-z3`'s
 `windows-latest`/`macos-15` matrix had the same cancel-skips-save deadlock
 already fixed for the `semantic-mutation` lanes: a cold build (measured warm
 at 27–33 min) exceeded the 40-minute budget, the job was cancelled on all six
@@ -86,11 +86,29 @@ future workflow's unguarded `Swatinem/rust-cache` step (and, retroactively,
 for `merge-readiness.yml`'s own now-removed per-job keys, which this audit
 never flagged for the same reason).
 
-A single oversized cache entry is now its own finding (`entry-oversized`,
-`SINGLE_ENTRY_WARN_BYTES = 2.5 GiB`, calibrated between `semantic-mutation`'s
-corrected ~2.2 GiB floor and its observed 2.719 GiB defect value) rather than
-waiting for the whole-budget `budget-exhausted` check to trip -- an added
-control, not a change to `BUDGET_WARN_FRACTION`. Separately, the shared-key
+An earlier revision of this change added an `entry-oversized` finding
+(`SINGLE_ENTRY_WARN_BYTES = 2.5 GiB`) calibrated against the wrong ~2.2 GiB
+floor above; since the real floor is 2.719 GiB, that control would have fired
+on a healthy `semantic-mutation` entry and has been removed rather than
+recalibrated, since no measured defect signature exists to calibrate it
+against (raising the threshold to paper over this would only be guessing at
+an unmeasured defect). The actual budget lever is `ci.yml`'s `fsl-logic` job,
+which now goes restore-only against `rust-workspace`
+(`shared-key: rust-workspace`, `save-if: false`) instead of saving its own
+key: its entire build (`cargo test -p fslc-rust --test typed_agreement
+--locked`) is a strict subset of what `rust workspace` already builds, and
+`Swatinem/rust-cache` prunes workspace-member artifacts at save time regardless
+of which job saves, so every lane's cache is substantively the same external
+dependency set. Measured main-branch entries (2026-08-12): `rust-workspace`
+1,605,761,517 B, `fsl-logic` 1,470,489,603 B, `wasm` 1,452,450,563 B,
+`rust-native-z3` Darwin 1,239,235,056 B, `semantic-mutation` 2,919,716,751 B,
+plus ~41 MB of tool-binary caches -- 8.130 GiB total. Deleting the now-orphaned
+`fsl-logic` entry (separate, human-authorized) and re-adding Windows
+native-z3 (historical 0.577 GiB) gives 8.130 − 1.369 + 0.577 = **7.338 GiB
+(73.4%)**, under the 8.5 GiB warn threshold. `CI_SHARED_KEYS` and
+`REQUIRED_MAIN_ENTRIES` both drop `fsl-logic` accordingly; the generic
+pull-request-rust-cache rule covers any regression the same way it already
+covers `merge-readiness.yml`'s former per-job keys. Separately, the shared-key
 regex now parses from the tail of the cache key (anchored at the end) instead
 of lazily from the head: a reviewer reproduced a case where a shared key
 containing a platform-like substring earlier in its name (e.g. a hypothetical

--- a/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
+++ b/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
@@ -21,7 +21,18 @@ restore. Both `Swatinem/rust-cache` steps instead go restore-only against
 `save-if: false`): the two workflows' jobs share a toolchain, runner, and
 checkout, so the derived cache key is expected to match, confirmed from the
 first post-merge run's `full match: true` restore log rather than asserted
-from an unverifiable prior observation. Separately, `rust-native-z3`'s
+from an unverifiable prior observation. `tools/run-semantic-mutation-gate.sh`'s
+mutants lane also moves its per-run scratch `CARGO_TARGET_DIR` out from under
+`rust/target` (to `${RUNNER_TEMP:-${TMPDIR:-/tmp}}`) and now clears any
+`rust/target/semantic-mutation.*`/`semantic-mutation-build` left by a restored
+cache before creating its own evidence directory: both were previously
+uniquely named per run and never reused, so each cache save accumulated them
+as dead weight, measured at `semantic-mutation` 2.719 GiB against sibling
+shared keys around 1.3-1.5 GiB. This does not shrink that cache entry by
+itself -- `Swatinem/rust-cache` will not resave a still-matching key -- so the
+reduction only takes effect once the entry is deleted (a separate,
+human-authorized action) and a run resaves it; the resulting size is not
+reported here as measured. Separately, `rust-native-z3`'s
 `windows-latest`/`macos-15` matrix had the same cancel-skips-save deadlock
 already fixed for the `semantic-mutation` lanes: a cold build (measured warm
 at 27–33 min) exceeded the 40-minute budget, the job was cancelled on all six

--- a/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
+++ b/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
@@ -19,9 +19,12 @@ nothing would ever save a `main` copy under this workflow's own key for it to
 restore. Both `Swatinem/rust-cache` steps instead go restore-only against
 `ci.yml`'s own `rust-workspace` key (`shared-key: rust-workspace`,
 `save-if: false`): the two workflows' jobs share a toolchain, runner, and
-checkout, so the derived cache key is expected to match, confirmed from the
-first post-merge run's `full match: true` restore log rather than asserted
-from an unverifiable prior observation. `tools/run-semantic-mutation-gate.sh`'s
+checkout, so the derived cache key is expected to match -- an expectation
+still pending confirmation from a post-merge run's own `full match: true`
+restore log, not something already observed, since this branch had not yet
+merged as of this writing and the pull-request-scoped entries that could have
+confirmed it were deleted 2026-08-12 during unrelated cleanup.
+`tools/run-semantic-mutation-gate.sh`'s
 mutants lane also moves its per-run scratch `CARGO_TARGET_DIR` out from under
 `rust/target` (to `${RUNNER_TEMP:-${TMPDIR:-/tmp}}`), and the script now
 clears any `rust/target/semantic-mutation.*`/`semantic-mutation-build` left by

--- a/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
+++ b/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
@@ -45,13 +45,15 @@ fix, not a size fix**: measured directly (product-gate run `31210570118`, job
 current 2.719 GiB was created by a *cold* operators run (`No cache found.` at
 19:14:17Z, saved at 19:48:12Z) that never touched the mutants lane's scratch
 build or evidence paths at all -- neither could have contributed to this
-entry's size, so there was no dead weight to recover, and two earlier
-predictions in this fragment and in `docs/DESIGN-ci.md` (a ~0.9-1.4 GiB floor
-from an assumed accumulating scratch tree, then a ~2.2 GiB floor from
+entry's size, so there was no dead weight to recover, and two earlier size
+predictions in this fragment and in `docs/DESIGN-ci.md` (~0.9-1.4 GiB from an
+assumed accumulating scratch tree, then ~2.2 GiB from
 `rust/target/fault-operators`' deliberately persistent build tree treated as
-a designed minimum) were both wrong about what this entry actually is.
-`semantic-mutation` is not resized by this change and is not touched by the
-budget lever below. Separately, `rust-native-z3`'s
+a designed minimum size) were both wrong about what this entry actually is.
+This one cold-start save is evidence of what this key can legitimately hold,
+not a proven minimum across every shard and revision. `semantic-mutation` is
+not resized by this change and is not touched by the budget lever below.
+Separately, `rust-native-z3`'s
 `windows-latest`/`macos-15` matrix had the same cancel-skips-save deadlock
 already fixed for the `semantic-mutation` lanes: a cold build (measured warm
 at 27–33 min) exceeded the 40-minute budget, the job was cancelled on all six
@@ -88,8 +90,8 @@ never flagged for the same reason).
 
 An earlier revision of this change added an `entry-oversized` finding
 (`SINGLE_ENTRY_WARN_BYTES = 2.5 GiB`) calibrated against the wrong ~2.2 GiB
-floor above; since the real floor is 2.719 GiB, that control would have fired
-on a healthy `semantic-mutation` entry and has been removed rather than
+size above; since the observed clean size is 2.719 GiB, that control would
+have fired on a healthy `semantic-mutation` entry and has been removed rather than
 recalibrated, since no measured defect signature exists to calibrate it
 against (raising the threshold to paper over this would only be guessing at
 an unmeasured defect). The actual budget lever is `ci.yml`'s `fsl-logic` job,

--- a/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
+++ b/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
@@ -4,11 +4,13 @@ saving in `ci.yml` to non-pull-request events so pull requests could not keep
 evicting `main`'s caches, but `merge-readiness.yml`'s two `rust-cache` steps
 (`rust-compile`, `core-contracts`) carried no such guard. Because that
 workflow runs on every pull request, each one kept saving a fresh
-ref-scoped copy of both keys, and a cache's last-accessed time refreshes on
-restore even without resaving, so none of them expired quickly either.
-Measured on 2026-08-11: 15 open pull requests held 29 entries (~1.90 GiB) on
-those two keys alone, part of 38 entries / 10.03 GiB total against the
-repository's 10 GiB budget, and the LRU evictor had removed
+ref-scoped copy of both keys. Measured on 2026-08-11: 15 pull-request refs
+(#743-#792, all closed or merged by then) still held 29 entries (~1.90 GiB)
+on those two keys alone, part of 38 entries / 10.03 GiB total against the
+repository's 10 GiB budget -- retained not because anything kept restoring
+them, but because GitHub only evicts an unused cache after 7 days without a
+read, and measurement landed inside that window. The LRU evictor does not
+distinguish "small but many" from "few but large": it had removed
 `refs/heads/main`'s `native Z3 4.16 (windows-latest)` cache down to zero
 entries. `merge-readiness.yml` now carries the same
 `save-if: ${{ github.event_name != 'pull_request' }}` guard as every
@@ -19,11 +21,14 @@ at 27–33 min) exceeded the 40-minute budget, the job was cancelled on all six
 consecutive scheduled runs from 2026-08-07 through 2026-08-11
 (`9 skipped Post Run Swatinem/rust-cache@v2`, run 31527197290), and the
 skipped post step meant no cache was ever written to recover from. That step
-now carries `cache-on-failure: true` — confirmed from `Swatinem/rust-cache`'s
-own `post-if: success() || env.CACHE_ON_FAILURE == 'true'`, which does not
-distinguish a cancelled conclusion from a failed one, and from this
-repository's own history (issues #721 and #678 stopped recurring as
-`cancelled` immediately after commit `877fe8c` added the same flag to the
-semantic-mutation lanes) — and its `timeout-minutes` is raised from 40 to 60
-to cover a genuine cold vendored-Z3 build, diagnosed rather than raised
-blind. See `docs/DESIGN-ci.md`, "Actions cache budget".
+now carries `cache-on-failure: true`. `Swatinem/rust-cache`'s own
+`post-if: success() || env.CACHE_ON_FAILURE == 'true'` reads as supporting a
+save through cancellation, not only ordinary failure, but this repository has
+not directly observed a cache written specifically after a timeout
+cancellation: the semantic-mutation lanes' `cancelled` recurrences (issues
+#721, #678) stopped after commit `877fe8c` added the same flag, but that
+commit simultaneously raised those lanes' timeouts, confounding the two
+causes, and the eventual recovery run saved after reaching `success`, not
+after a cancellation. `timeout-minutes` is separately raised from 40 to 60,
+diagnosed from measured warm/cold durations rather than raised blind. See
+`docs/DESIGN-ci.md`, "Actions cache budget".

--- a/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
+++ b/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
@@ -48,5 +48,22 @@ cancellation: the semantic-mutation lanes' `cancelled` recurrences (issues
 commit simultaneously raised those lanes' timeouts, confounding the two
 causes, and the eventual recovery run saved after reaching `success`, not
 after a cancellation. `timeout-minutes` is separately raised from 40 to 60,
-diagnosed from measured warm/cold durations rather than raised blind. See
-`docs/DESIGN-ci.md`, "Actions cache budget".
+diagnosed from measured warm/cold durations rather than raised blind.
+
+`.github/scripts/audit-cache-budget.mjs`'s `sharedKeyOf` regex matched the
+GitHub Actions `runner.os` platform spellings (`Linux`/`macOS`/`Windows`), but
+`Swatinem/rust-cache` derives its key from `os.type()`, which reports
+`Linux`/`Darwin`/`Windows_NT` -- so `rust-native-z3`'s cache, on either
+platform, was invisible to every rule in this audit, including the one that
+should have reported `main`'s Windows entry evicted to zero during this
+incident. The regex is corrected (matching `Windows_NT` before the `Windows`
+it is a strict superset of), and the default-branch requirement is now
+per-`{key, platform}` pair rather than per-key, so `rust-native-z3` must be
+present on both `Windows_NT` and `Darwin` independently -- one platform's
+cache can no longer hide the other's absence. A new general rule also flags
+any `v0-rust-*`-prefixed cache on a pull-request ref regardless of whether its
+shared key is one `ci.yml` declares, closing the same blind spot for any
+future workflow's unguarded `Swatinem/rust-cache` step (and, retroactively,
+for `merge-readiness.yml`'s own now-removed per-job keys, which this audit
+never flagged for the same reason). See `docs/DESIGN-ci.md`,
+"Actions cache budget".

--- a/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
+++ b/changelog.d/747-cache-budget-self-perpetuating-loop.fixed.md
@@ -23,16 +23,32 @@ checkout, so the derived cache key is expected to match, confirmed from the
 first post-merge run's `full match: true` restore log rather than asserted
 from an unverifiable prior observation. `tools/run-semantic-mutation-gate.sh`'s
 mutants lane also moves its per-run scratch `CARGO_TARGET_DIR` out from under
-`rust/target` (to `${RUNNER_TEMP:-${TMPDIR:-/tmp}}`) and now clears any
-`rust/target/semantic-mutation.*`/`semantic-mutation-build` left by a restored
-cache before creating its own evidence directory: both were previously
-uniquely named per run and never reused, so each cache save accumulated them
-as dead weight, measured at `semantic-mutation` 2.719 GiB against sibling
-shared keys around 1.3-1.5 GiB. This does not shrink that cache entry by
-itself -- `Swatinem/rust-cache` will not resave a still-matching key -- so the
-reduction only takes effect once the entry is deleted (a separate,
-human-authorized action) and a run resaves it; the resulting size is not
-reported here as measured. Separately, `rust-native-z3`'s
+`rust/target` (to `${RUNNER_TEMP:-${TMPDIR:-/tmp}}`), and the script now
+clears any `rust/target/semantic-mutation.*`/`semantic-mutation-build` left by
+a restored cache unconditionally, right after mode validation, before either
+lane runs. That placement matters: `Swatinem/rust-cache` saves a key once and
+whichever job reaches its post step first wins, and measured on product-gate
+run `31527197290` all three `semantic-mutation-operators` shards reach their
+post step tens of minutes before `semantic-mutation-mutants` does -- the
+operators shards are this key's only actual saver. An earlier version of this
+cleanup ran only in the mutants lane's own path, after the operators lane's
+early exit, so the one lane that saves the key never ran it and kept
+resaving the same dead weight. `semantic-mutation-mutants`'s
+`Swatinem/rust-cache` step is now `save-if: false` (with `cache-on-failure`
+removed, since `save-if: false` already makes it inert) to make that
+ownership explicit; `semantic-mutation-operators` is unchanged. Both
+uniquely-per-run-named directories were never reused once restored, so each
+save accumulated them as dead weight on top of this key's legitimate content,
+which is larger than initially estimated: `rust/target/fault-operators`
+(`tools/run-fault-operators.sh`) is a *deliberately persistent* scratch
+checkout and build tree, not removable dead weight, so the corrected floor is
+two build trees plus `~/.cargo` (~2.2 GiB predicted, not the ~0.9-1.4 GiB
+first predicted, which mistakenly treated that persistent tree as part of the
+dead weight) against the observed defect value of 2.719 GiB. This does not
+shrink that cache entry by itself -- `Swatinem/rust-cache` will not resave a
+still-matching key -- so the reduction only takes effect once the entry is
+deleted (a separate, human-authorized action) and a run resaves it; the
+resulting size is not reported here as measured. Separately, `rust-native-z3`'s
 `windows-latest`/`macos-15` matrix had the same cancel-skips-save deadlock
 already fixed for the `semantic-mutation` lanes: a cold build (measured warm
 at 27–33 min) exceeded the 40-minute budget, the job was cancelled on all six
@@ -65,5 +81,16 @@ any `v0-rust-*`-prefixed cache on a pull-request ref regardless of whether its
 shared key is one `ci.yml` declares, closing the same blind spot for any
 future workflow's unguarded `Swatinem/rust-cache` step (and, retroactively,
 for `merge-readiness.yml`'s own now-removed per-job keys, which this audit
-never flagged for the same reason). See `docs/DESIGN-ci.md`,
-"Actions cache budget".
+never flagged for the same reason).
+
+A single oversized cache entry is now its own finding (`entry-oversized`,
+`SINGLE_ENTRY_WARN_BYTES = 2.5 GiB`, calibrated between `semantic-mutation`'s
+corrected ~2.2 GiB floor and its observed 2.719 GiB defect value) rather than
+waiting for the whole-budget `budget-exhausted` check to trip -- an added
+control, not a change to `BUDGET_WARN_FRACTION`. Separately, the shared-key
+regex now parses from the tail of the cache key (anchored at the end) instead
+of lazily from the head: a reviewer reproduced a case where a shared key
+containing a platform-like substring earlier in its name (e.g. a hypothetical
+`foo-Linux-bar`) misparsed into the wrong shared key, which caused a real,
+present main-branch entry to be reported `main-cache-absent`. See
+`docs/DESIGN-ci.md`, "Actions cache budget".

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -586,19 +586,21 @@ no headroom for `rust workspace` — compile is only ~3.5 min of ~33 min **on a 
 remains true warm, and it is exactly the premise that fails under concurrency: the question is not
 how much a better hit rate buys, but whether a hit happens at all.
 
-**`semantic-mutation`'s measured 2.719 GiB is a clean floor, not accumulated dead weight -- two
-successive predictions to the contrary were both wrong, and this document previously carried both.**
-Direct measurement settled it: on product-gate run `31210570118`, job `92972117510`
+**`semantic-mutation`'s measured 2.719 GiB is an observed clean size, not accumulated dead weight --
+two successive size predictions to the contrary were both wrong, and this document previously
+carried both.** Direct measurement settled it: on product-gate run `31210570118`, job `92972117510`
 (`mutation operators (3/3)`) restored with `No cache found.` at 19:14:17Z -- a fully cold start, so it
 carried forward nothing from any prior run -- built for ~35 minutes, and saved the cache at 19:48:12Z.
 `gh api actions/caches` shows the resulting entry, `v0-rust-semantic-mutation-Linux-x64-...`, created
 at exactly `2026-08-07T19:48:56Z` and sized 2,919,716,751 bytes (2.719 GiB). That run never ran the
 mutants lane's scratch build or evidence generation at all, so neither could have contributed a
 single byte to this entry: there is no dead weight here to recover, and both the ~0.9-1.4 GiB and
-~2.2 GiB floors this document previously predicted (attributing the size to, respectively, an
+~2.2 GiB sizes this document previously predicted (attributing the size to, respectively, an
 accumulating scratch-build tree and to `fault-operators`' persistent build tree as a designed
-minimum) do not describe what this entry actually is. `semantic-mutation` is not touched by this
-fix and is not a lever in the budget arithmetic below.
+minimum size) do not describe what this entry actually is. This one cold-start save on one shard is
+evidence of what this key *can* legitimately hold, not a proven minimum across every shard and every
+future revision -- `semantic-mutation` is not touched by this fix and is not a lever in the budget
+arithmetic below.
 
 **The scratch-build-tree and evidence-path changes in this branch are a closed-ingress-path fix, not
 a size fix, and are kept for that reason alone.** `tools/run-semantic-mutation-gate.sh`'s mutants
@@ -642,9 +644,15 @@ plus ~41 MB of small tool-binary caches -- **8.130 GiB total**. Removing the now
 entry (a separate, human-authorized deletion) and re-adding Windows native-z3 (historical size
 0.577 GiB, to be re-measured after recreation) gives
 **8.130 − 1.369 + 0.577 = 7.338 GiB (73.4%)**, under the 8.5 GiB warn threshold with headroom to
-spare. `fsl-logic`'s own job goes cold on its first restore-only run; baseline warm duration is
-2m48s-2m53s (scheduled runs 2026-08-09/10/11) against a 30-minute budget, so the risk is bounded even
-if the first run underperforms the ±seconds this predicts. A `cache-targets: false` lever on the
+spare. `rust-workspace` and the former dedicated `fsl-logic` key already share the same
+`Linux-x64-e8b3ee54-09fbaf53` suffix, so `shared-key: rust-workspace` is expected to hit exactly, not
+merely restore a compatible prefix -- an exact-hit restore is expected to cost about what `fsl-logic`'s
+own key already did. If the shared `rust-workspace` cache were ever missing or evicted on some future
+run, that run would build cold instead; how long that would take is not observed here (this job has
+never run cold under this configuration), so the baseline warm duration of 2m48s-2m53s (scheduled
+runs 2026-08-09/10/11) is cited only as this job's typical wall-clock cost, not as a bound on cold-run
+time. Either way the risk is contained by the job's existing 30-minute budget. A `cache-targets: false`
+lever on the
 mutation lanes was considered and rejected: it would cost the operators shards a cold build every
 run (~35 min measured cold vs. ~5 min warm) for less budget relief than `fsl-logic` gives for
 near-zero cost.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -581,6 +581,27 @@ no headroom for `rust workspace` — compile is only ~3.5 min of ~33 min **on a 
 remains true warm, and it is exactly the premise that fails under concurrency: the question is not
 how much a better hit rate buys, but whether a hit happens at all.
 
+**The cache-object path and the disposable-build-tree path must stay separated, or the cached path
+absorbs dead weight it can never reuse.** `tools/run-semantic-mutation-gate.sh`'s mutants lane needs
+a scratch `CARGO_TARGET_DIR` per run, isolated from the real workspace `target` so a stale mutant
+artifact's timestamp can never look newer than a freshly copied baseline checkout. That scratch
+directory used to be created under `rust/target/semantic-mutation-build/run.XXXXXX` — inside the
+same tree `ci.yml`'s `Swatinem/rust-cache` step (`workspaces: rust -> target`) saves wholesale — and
+because each run's `mktemp` name is unique, a restored copy of a past run's scratch tree could never
+be reused by anything; it was pure accumulation. The evidence directory
+(`rust/target/semantic-mutation.${mode}.XXXXXX`, which the artifact-upload glob
+`rust/target/semantic-mutation.*/**` in `ci.yml` requires to stay under `rust/target`) compounded
+this the same way: it holds a full rsynced checkout copy, and old runs' copies survived a cache
+restore into the working tree right alongside the new run's own. The scratch build tree now lives
+under `${RUNNER_TEMP:-${TMPDIR:-/tmp}}` instead, outside anything `Swatinem/rust-cache` saves, and
+the script clears any leftover `rust/target/semantic-mutation.*` and
+`rust/target/semantic-mutation-build` directories from a restored cache before creating its own new
+evidence directory, so at most one run's evidence is ever present at save time. This does not shrink
+the existing `semantic-mutation` cache entry by itself — `Swatinem/rust-cache` does not resave a
+key that still primary-matches — so the reduction only lands once that entry is deleted (a separate,
+human-authorized action) and re-created by a subsequent run; the predicted size after that point is
+not asserted here as measured.
+
 **Eviction started this; `cache-on-failure: false` made it unrecoverable.** The
 `semantic mutation` lane fell into a closed loop, measured on `main` and on three pull requests:
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -544,16 +544,19 @@ in `ci.yml` carried `save-if: ${{ github.event_name != 'pull_request' }}`. Pull 
 request gives up is a warm second run of itself; what it gains is that `main`'s caches stay resident,
 which is the only cache any pull request could ever share.
 
-**That is no longer a description of every step -- the current contract has two shapes, not one.**
-Later decisions in this branch (below) took `ci.yml`'s `fsl-logic` and `semantic-mutation-mutants`
-jobs, and both of `merge-readiness.yml`'s jobs, restore-only: each carries `save-if: false`
-unconditionally and saves nothing, ever, reading `rust-workspace`'s cache instead of owning a key of
-its own. The two shapes present today are: a step that saves its own declared key carries the
-event guard above (`save-if: ${{ github.event_name != 'pull_request' }}`); a step that is
-restore-only carries `save-if: false` and never saves under any event. `CI_SHARED_KEYS` in
-`audit-cache-budget.mjs` lists the keys actually saved this way: `rust-workspace`, `wasm`,
-`semantic-mutation` -- three, not the four this section originally measured, since `fsl-logic`'s
-dedicated key was retired when that job went restore-only.
+**That is no longer a description of every step -- the current contract has two shapes, not one, and
+which key a restore-only step reads is not the same for all of them.** A step that saves its own
+declared key still carries the event guard above (`save-if: ${{ github.event_name != 'pull_request'
+}}`); a step below carries `save-if: false` unconditionally and saves nothing, ever, instead. Naming
+each: `merge-readiness.yml`'s `rust-compile` job reads `rust-workspace` (`shared-key: rust-workspace`,
+`save-if: false`). `merge-readiness.yml`'s `core-contracts` job reads `rust-workspace` the same way.
+`ci.yml`'s `fsl-logic` job reads `rust-workspace` the same way again. `ci.yml`'s
+`semantic-mutation-mutants` job is different: it reads `semantic-mutation`
+(`shared-key: semantic-mutation`, `save-if: false`), the key `semantic-mutation-operators` owns and
+saves (below), not `rust-workspace`. `CI_SHARED_KEYS` in `audit-cache-budget.mjs` lists the keys
+actually saved today: `rust-workspace`, `wasm`, `semantic-mutation` -- three, not the four this
+section originally measured, since `fsl-logic`'s dedicated key was retired when that job went
+restore-only.
 
 `merge-readiness.yml` was deliberately left unchanged at that point: its two keys total about
 131 MiB, they were not *that* incident's pressure, and its lanes are the sub-minute fast path —

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -543,9 +543,21 @@ because `main` is the default branch and therefore readable from every ref. What
 gives up is a warm second run of itself; what it gains is that `main`'s caches stay resident, which
 is the only cache any pull request could ever share.
 
-`merge-readiness.yml` is deliberately **not** changed. Its two keys total about 131 MiB, they are not
-the pressure, and its lanes are the sub-minute fast path — making them cold would defeat the reason
-that workflow exists.
+`merge-readiness.yml` was deliberately left unchanged at that point: its two keys total about
+131 MiB, they were not *that* incident's pressure, and its lanes are the sub-minute fast path —
+making them cold would defeat the reason that workflow exists. That reasoning held for concurrent
+pressure from a handful of pull requests at once; it did not hold over time. `merge-readiness.yml`
+runs on every pull request and had no `save-if` guard, so every pull request saved its own
+ref-scoped copy of both keys and none of them ever expired quickly, because each restore refreshes
+a cache's last-accessed time even without resaving it. By 2026-08-11 this had accumulated to 15 open
+pull requests holding 29 cache entries — about 1.90 GiB — entirely on the merge-readiness keys, on
+top of pull-request-scoped residue that predated PR #752's `ci.yml`-only fix, for **38 entries /
+10.03 GiB** total against the 10 GiB budget. The LRU evictor does not distinguish "small but many"
+from "few but large": it evicted `refs/heads/main`'s `native Z3 4.16 (windows-latest)` cache down to
+**zero entries**, observed via `gh api actions/caches`. `merge-readiness.yml` now carries the same
+`save-if: ${{ github.event_name != 'pull_request' }}` guard as every `ci.yml` step, closing the
+eviction path PR #752 left open. Its lanes still restore on every pull request from `main`'s copy,
+same as before; only the self-multiplying save on pull requests stops.
 
 This also qualifies a claim made elsewhere in this document. Cache hit rates were measured to have
 no headroom for `rust workspace` — compile is only ~3.5 min of ~33 min **on a warm cache**. That
@@ -577,6 +589,32 @@ This is also the most likely explanation for `main`'s standing post-merge failur
 (`mutation mutants`) and #678 (`semantic mutation (complete)`), whose cancellations sit exactly at
 the old budgets. Whether they clear once this lands is the test of that reading, and #747's
 acceptance criteria record it as such.
+
+**That test resolved, and confirms `cache-on-failure` saves through a timeout-driven cancellation,
+not only an ordinary step failure.** Both issues recurred with `Conclusion: cancelled` repeatedly
+before commit `877fe8c` (#752, which added `cache-on-failure: true` to both semantic-mutation
+lanes) — and neither recurred as `cancelled` again afterward; their remaining occurrences before
+final recovery were `Conclusion: failure`, an unrelated test defect fixed separately. This matches
+`Swatinem/rust-cache`'s own `action.yml`: the save (post) step's condition is `post-if: success() ||
+env.CACHE_ON_FAILURE == 'true'`, which does not distinguish a cancelled job from a failed one —
+whenever the flag is set, the save runs regardless of which non-success conclusion the job reaches.
+
+**The same closed loop was independently live in `rust-native-z3`'s `windows-latest`/`macos-15`
+matrix, and is fixed the same way.** That job's `Swatinem/rust-cache` step carried `save-if` but not
+`cache-on-failure`. Warm runs measured 32m56s / 32m45s (2026-08-04) and 31m49s / 29m44s / 26m56s
+(2026-08-05), comfortably inside the 40-minute budget; the scheduled `windows-latest` run then hit
+exactly 40m0x and was cancelled on all six consecutive scheduled runs from 2026-08-07 00:23 through
+2026-08-11 — a step change coincident with the cache-budget eviction above, not gradual drift, a
+regression, or added test volume. The last successful run (2026-08-05) restored the cache
+(`Cache hit for: v0-rust-rust-native-z3-Windows_NT-x64-...`, 591 MiB); the 2026-08-11 cancellation
+reported `No cache found.` instead, and its job steps show
+`9 skipped Post Run Swatinem/rust-cache@v2` (run 31527197290) — the same cancel-skips-save mechanism
+documented above, independently confirmed on a different job. `rust-native-z3` now carries
+`cache-on-failure: true` as well, and its `timeout-minutes` is raised from 40 to 60 for the same
+reason `production-native-z3-linux`'s budget was raised rather than narrowed: a gate that runs out
+of wall clock reports a failure it did not observe, and 60 minutes covers a genuine cold vendored-Z3
+build on this matrix without approaching the Linux promotion lane's 90-minute allowance for the same
+build from scratch.
 
 **The control.** `.github/scripts/audit-cache-budget.mjs` is a pure function over a fetched cache
 listing; `.github/workflows/cache-budget-audit.yml` fetches and runs it on a schedule, on dispatch,

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -553,10 +553,15 @@ each: `merge-readiness.yml`'s `rust-compile` job reads `rust-workspace` (`shared
 `ci.yml`'s `fsl-logic` job reads `rust-workspace` the same way again. `ci.yml`'s
 `semantic-mutation-mutants` job is different: it reads `semantic-mutation`
 (`shared-key: semantic-mutation`, `save-if: false`), the key `semantic-mutation-operators` owns and
-saves (below), not `rust-workspace`. `CI_SHARED_KEYS` in `audit-cache-budget.mjs` lists the keys
-actually saved today: `rust-workspace`, `wasm`, `semantic-mutation` -- three, not the four this
-section originally measured, since `fsl-logic`'s dedicated key was retired when that job went
-restore-only.
+saves (below), not `rust-workspace`. `CI_SHARED_KEYS` in `audit-cache-budget.mjs` lists the
+identities rule 3 attributes by name today: `rust-workspace`, `wasm`, `semantic-mutation` -- three,
+not the four this section originally measured, since `fsl-logic`'s dedicated key was retired when
+that job went restore-only. That is not the complete list of keys any workflow actually saves:
+`ci.yml`'s own `rust-native-z3` job also saves, on non-pull-request events, one key per platform
+(`Windows_NT` and `Darwin`) -- it just is not one of `CI_SHARED_KEYS`' three named identities. Its
+presence on `main` is required separately, by `REQUIRED_MAIN_ENTRIES`'s per-`{key, platform}` check;
+a leak of it onto a pull-request ref is caught separately too, by rule 4's generic `/^v\d+-rust-/`
+detection rather than rule 3's name-based one.
 
 `merge-readiness.yml` was deliberately left unchanged at that point: its two keys total about
 131 MiB, they were not *that* incident's pressure, and its lanes are the sub-minute fast path —

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -548,13 +548,16 @@ is the only cache any pull request could ever share.
 making them cold would defeat the reason that workflow exists. That reasoning held for concurrent
 pressure from a handful of pull requests at once; it did not hold over time. `merge-readiness.yml`
 runs on every pull request and had no `save-if` guard, so every pull request saved its own
-ref-scoped copy of both keys and none of them ever expired quickly, because each restore refreshes
-a cache's last-accessed time even without resaving it. By 2026-08-11 this had accumulated to 15 open
-pull requests holding 29 cache entries — about 1.90 GiB — entirely on the merge-readiness keys, on
-top of pull-request-scoped residue that predated PR #752's `ci.yml`-only fix, for **38 entries /
-10.03 GiB** total against the 10 GiB budget. The LRU evictor does not distinguish "small but many"
-from "few but large": it evicted `refs/heads/main`'s `native Z3 4.16 (windows-latest)` cache down to
-**zero entries**, observed via `gh api actions/caches`. `merge-readiness.yml` now carries the same
+ref-scoped copy of both keys. By 2026-08-11 this had accumulated to 15 pull-request refs (#743-#792,
+all closed or merged by measurement time) holding 29 cache entries — about 1.90 GiB — entirely on
+the merge-readiness keys, on top of pull-request-scoped residue that predated PR #752's
+`ci.yml`-only fix, for **38 entries / 10.03 GiB** total against the 10 GiB budget. None of these
+refs were being re-run any longer to refresh their own last-accessed time; they persisted simply
+because GitHub only evicts a cache for staleness after **7 days without a read**, and measurement
+landed inside that window for refs that closed more recently than that. The LRU evictor does not
+distinguish "small but many" from "few but large": it evicted `refs/heads/main`'s
+`native Z3 4.16 (windows-latest)` cache down to **zero entries**, observed via
+`gh api actions/caches`. `merge-readiness.yml` now carries the same
 `save-if: ${{ github.event_name != 'pull_request' }}` guard as every `ci.yml` step, closing the
 eviction path PR #752 left open. Its lanes still restore on every pull request from `main`'s copy,
 same as before; only the self-multiplying save on pull requests stops.
@@ -590,31 +593,42 @@ This is also the most likely explanation for `main`'s standing post-merge failur
 the old budgets. Whether they clear once this lands is the test of that reading, and #747's
 acceptance criteria record it as such.
 
-**That test resolved, and confirms `cache-on-failure` saves through a timeout-driven cancellation,
-not only an ordinary step failure.** Both issues recurred with `Conclusion: cancelled` repeatedly
-before commit `877fe8c` (#752, which added `cache-on-failure: true` to both semantic-mutation
-lanes) — and neither recurred as `cancelled` again afterward; their remaining occurrences before
-final recovery were `Conclusion: failure`, an unrelated test defect fixed separately. This matches
-`Swatinem/rust-cache`'s own `action.yml`: the save (post) step's condition is `post-if: success() ||
-env.CACHE_ON_FAILURE == 'true'`, which does not distinguish a cancelled job from a failed one —
-whenever the flag is set, the save runs regardless of which non-success conclusion the job reaches.
+**That test resolved, but what it establishes is narrower than a direct confirmation that
+`cache-on-failure` saves through a timeout-driven cancellation.** Both issues recurred with
+`Conclusion: cancelled` repeatedly before commit `877fe8c` (#752, which added
+`cache-on-failure: true` to both semantic-mutation lanes) and neither recurred as `cancelled` again
+afterward; their remaining occurrences before final recovery were `Conclusion: failure`, an
+unrelated test defect fixed separately. But `877fe8c` raised those lanes' timeouts in the same
+commit, so the disappearance of `cancelled` conclusions is confounded with more budget and does not
+isolate `cache-on-failure`'s contribution. The eventual recovery run (`31097824729`) also saved its
+cache after the job reached `success`, which is `post-if`'s ordinary `success()` branch, not a
+saved-after-cancellation case. No run in this repository's observed history has a cache written
+specifically following a timeout-triggered cancellation. What supports `cache-on-failure` working
+for cancellation, not just ordinary failure, is a reading of `Swatinem/rust-cache`'s own
+`action.yml`: the save (post) step's condition is
+`post-if: success() || env.CACHE_ON_FAILURE == 'true'`, and that expression's `env.CACHE_ON_FAILURE`
+branch does not itself test which non-success conclusion the job reached. That is inference from the
+condition's text, not an observed cancel-then-save run, and is recorded as such.
 
-**The same closed loop was independently live in `rust-native-z3`'s `windows-latest`/`macos-15`
-matrix, and is fixed the same way.** That job's `Swatinem/rust-cache` step carried `save-if` but not
-`cache-on-failure`. Warm runs measured 32m56s / 32m45s (2026-08-04) and 31m49s / 29m44s / 26m56s
-(2026-08-05), comfortably inside the 40-minute budget; the scheduled `windows-latest` run then hit
-exactly 40m0x and was cancelled on all six consecutive scheduled runs from 2026-08-07 00:23 through
-2026-08-11 — a step change coincident with the cache-budget eviction above, not gradual drift, a
-regression, or added test volume. The last successful run (2026-08-05) restored the cache
+**The same closed loop appeared independently in `rust-native-z3`'s `windows-latest`/`macos-15`
+matrix, and is addressed the same way, on the same inference-not-observation basis above.** That
+job's `Swatinem/rust-cache` step carried `save-if` but not `cache-on-failure`. Warm runs measured
+32m56s / 32m45s (2026-08-04) and 31m49s / 29m44s / 26m56s (2026-08-05), comfortably inside the
+40-minute budget; the scheduled `windows-latest` run then hit exactly 40m0x and was cancelled on all
+six consecutive scheduled runs from 2026-08-07 00:23 through 2026-08-11 — a step change coincident
+with the cache-budget eviction above, not gradual drift, a regression, or added test volume. The
+last successful run (2026-08-05) restored the cache
 (`Cache hit for: v0-rust-rust-native-z3-Windows_NT-x64-...`, 591 MiB); the 2026-08-11 cancellation
 reported `No cache found.` instead, and its job steps show
 `9 skipped Post Run Swatinem/rust-cache@v2` (run 31527197290) — the same cancel-skips-save mechanism
-documented above, independently confirmed on a different job. `rust-native-z3` now carries
-`cache-on-failure: true` as well, and its `timeout-minutes` is raised from 40 to 60 for the same
-reason `production-native-z3-linux`'s budget was raised rather than narrowed: a gate that runs out
-of wall clock reports a failure it did not observe, and 60 minutes covers a genuine cold vendored-Z3
-build on this matrix without approaching the Linux promotion lane's 90-minute allowance for the same
-build from scratch.
+as the semantic-mutation lanes, on a different job. `rust-native-z3` now carries
+`cache-on-failure: true` as well; whether it actually saves through the next timeout cancellation
+(if any) is unobserved and is a live run's evidence to produce, not something claimed here. Its
+`timeout-minutes` is raised from 40 to 60 for a reason independent of that open question:
+`production-native-z3-linux`'s budget was raised rather than narrowed for the same stated reason —
+a gate that runs out of wall clock reports a failure it did not observe — and 60 minutes covers a
+genuine cold vendored-Z3 build on this matrix without approaching the Linux promotion lane's
+90-minute allowance for the same build from scratch.
 
 **The control.** `.github/scripts/audit-cache-budget.mjs` is a pure function over a fetched cache
 listing; `.github/workflows/cache-budget-audit.yml` fetches and runs it on a schedule, on dispatch,

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -586,72 +586,68 @@ no headroom for `rust workspace` — compile is only ~3.5 min of ~33 min **on a 
 remains true warm, and it is exactly the premise that fails under concurrency: the question is not
 how much a better hit rate buys, but whether a hit happens at all.
 
-**The cache-object path and the disposable-build-tree path must stay separated, or the cached path
-absorbs dead weight it can never reuse.** `tools/run-semantic-mutation-gate.sh`'s mutants lane needs
-a scratch `CARGO_TARGET_DIR` per run, isolated from the real workspace `target` so a stale mutant
-artifact's timestamp can never look newer than a freshly copied baseline checkout. That scratch
-directory used to be created under `rust/target/semantic-mutation-build/run.XXXXXX` — inside the
-same tree `ci.yml`'s `Swatinem/rust-cache` step (`workspaces: rust -> target`) saves wholesale — and
-because each run's `mktemp` name is unique, a restored copy of a past run's scratch tree could never
-be reused by anything; it was pure accumulation. The evidence directory
-(`rust/target/semantic-mutation.${mode}.XXXXXX`, which the artifact-upload glob
-`rust/target/semantic-mutation.*/**` in `ci.yml` requires to stay under `rust/target`) compounded
-this the same way: it holds a full rsynced checkout copy, and old runs' copies survived a cache
-restore into the working tree right alongside the new run's own. The scratch build tree now lives
-under `${RUNNER_TEMP:-${TMPDIR:-/tmp}}` instead, outside anything `Swatinem/rust-cache` saves.
+**`semantic-mutation`'s measured 2.719 GiB is a clean floor, not accumulated dead weight -- two
+successive predictions to the contrary were both wrong, and this document previously carried both.**
+Direct measurement settled it: on product-gate run `31210570118`, job `92972117510`
+(`mutation operators (3/3)`) restored with `No cache found.` at 19:14:17Z -- a fully cold start, so it
+carried forward nothing from any prior run -- built for ~35 minutes, and saved the cache at 19:48:12Z.
+`gh api actions/caches` shows the resulting entry, `v0-rust-semantic-mutation-Linux-x64-...`, created
+at exactly `2026-08-07T19:48:56Z` and sized 2,919,716,751 bytes (2.719 GiB). That run never ran the
+mutants lane's scratch build or evidence generation at all, so neither could have contributed a
+single byte to this entry: there is no dead weight here to recover, and both the ~0.9-1.4 GiB and
+~2.2 GiB floors this document previously predicted (attributing the size to, respectively, an
+accumulating scratch-build tree and to `fault-operators`' persistent build tree as a designed
+minimum) do not describe what this entry actually is. `semantic-mutation` is not touched by this
+fix and is not a lever in the budget arithmetic below.
 
-**The first fix for the leftover-evidence cleanup was necessary but not sufficient, because it ran
-after the wrong lane's early exit.** `Swatinem/rust-cache` saves a key once, and whichever job
-reaches its post step first wins the save for that key -- measured on product-gate run
-`31527197290`, all three `semantic-mutation-operators` shards reached their post step
-(19:23:20 / 19:23:34 / 19:23:55) well before `semantic-mutation-mutants` did (20:33:31), so the
-`semantic-mutation` key's saver is always an operators shard, never the mutants job. The cleanup
-that clears leftover `rust/target/semantic-mutation.*`/`semantic-mutation-build` directories was
-first placed only in the mutants lane's own path, below `run_operators_lane`'s early `exit 0` for
-`--lane operators` invocations -- so the one lane that actually saves the key never ran the cleanup
-at all, restored the old dead weight every time, and resaved it unchanged. The cleanup now runs
-unconditionally right after mode validation, before either lane does anything, so it applies
-regardless of which lane -- or, unsharded, which order of both lanes -- ends up saving.
-
-**`rust/target/fault-operators` (`tools/run-fault-operators.sh:74-79`) is not dead weight and must
-not be removed.** It is a deliberately persistent scratch checkout and dedicated `CARGO_TARGET_DIR`
-that survives between runs by design -- the comment there says so explicitly -- and is the actual
-mechanism that runs the operators shards in ~5 minutes instead of a 15-20 minute cold build each.
-Combined with the dependency build every lane produces under `rust/target/debug` via
-`run_manifest_test`, `semantic-mutation`'s legitimate steady-state content is **two build trees**
-(`rust/target/debug`'s deps and `rust/target/fault-operators/target`'s deps) plus `~/.cargo` --
-structurally larger than any single-tree shared key such as `rust-workspace` (1.495 GiB). The
-corrected floor is **~2.2 GiB (predicted)**, not the ~0.9-1.4 GiB this section previously predicted;
-that earlier number came from treating `fault-operators`' persistent tree as removable dead weight,
-which it is not. `SINGLE_ENTRY_WARN_BYTES` in `audit-cache-budget.mjs` is calibrated to this
-corrected floor. Confirming the actual post-fix size, not just the mechanism, requires a `main` save
-after the stale `semantic-mutation` entry is deleted (a separate, human-authorized action) --
-nothing in this branch asserts that number as already measured.
+**The scratch-build-tree and evidence-path changes in this branch are a closed-ingress-path fix, not
+a size fix, and are kept for that reason alone.** `tools/run-semantic-mutation-gate.sh`'s mutants
+lane's scratch `CARGO_TARGET_DIR` (isolated per run so a stale mutant artifact's timestamp can never
+look newer than a freshly copied baseline checkout) used to be created under
+`rust/target/semantic-mutation-build/run.XXXXXX`, inside the tree `Swatinem/rust-cache` saves
+wholesale, and now lives under `${RUNNER_TEMP:-${TMPDIR:-/tmp}}` instead. The script also clears any
+`rust/target/semantic-mutation.*`/`semantic-mutation-build` a restored cache may carry forward,
+unconditionally and before either lane does anything -- an earlier version of this cleanup ran only
+in the mutants lane's own path, below `run_operators_lane`'s early `exit 0` for `--lane operators`
+invocations, so the one lane that actually saves this key (see below) never ran it. Both changes
+close a path by which a *future* run could let leftover scratch/evidence ride into a save; neither
+changes what the entry, as actually observed, already contains.
 
 **Ownership: the operators shards are this key's only saver; the mutants job is restore-only.**
-`semantic-mutation-mutants`'s `Swatinem/rust-cache` step carries `save-if: false`. It never wins the
-save race today (see the timing measurement above), so this changes nothing about what actually gets
-cached; it only makes explicit that the mutants job's sole `rust/target`-scoped output -- its
-evidence directory, kept under `rust/target` solely because the artifact-upload glob requires it --
-must never be allowed into a future save if the timing ever changed. `cache-on-failure: true` was
-removed from the same step: `Swatinem/rust-cache`'s `save.ts` returns before evaluating it once
-`save-if` is `false`, so it was already inert. `semantic-mutation-operators` is unchanged
-(`save-if` on non-pull-request events, `cache-on-failure: true`) and remains this key's sole owner
-and recovery path. Splitting the key so each lane has its own (`shared-key` per job) was considered
-and rejected: it would add a second entry (~1 GiB predicted for the mutants-only content) for no
-warm-value gain, since the mutants job has essentially none of its own -- `~/.cargo/bin/cargo-mutants`
-is already rebuilt every run today because operators always wins the race first, so restore-only
-changes nothing there either.
+`Swatinem/rust-cache` saves a key once, and whichever job reaches its post step first wins --
+measured on product-gate run `31527197290`, all three `semantic-mutation-operators` shards reached
+their post step (19:23:20 / 19:23:34 / 19:23:55) well before `semantic-mutation-mutants` did
+(20:33:31), so the saver is always an operators shard, never the mutants job.
+`semantic-mutation-mutants`'s `Swatinem/rust-cache` step carries `save-if: false`, which changes
+nothing about what actually gets cached today (it never won the race) but makes explicit that its
+sole `rust/target`-scoped output -- its evidence directory, kept under `rust/target` solely because
+the artifact-upload glob requires it -- must never be allowed into a future save if the timing ever
+changed. `semantic-mutation-operators` is unchanged (`save-if` on non-pull-request events,
+`cache-on-failure: true`) and remains this key's sole owner and recovery path. Splitting the key so
+each lane has its own was considered and rejected: the mutants job has essentially no warm value of
+its own to protect -- `~/.cargo/bin/cargo-mutants` is already rebuilt every run today because
+operators always wins the race first -- so a second entry would cost budget for no gain.
 
-**Budget with the corrected floor**: 8.130 (main-only, post-#752-residue-cleanup) − 2.719
-(defect `semantic-mutation`) + 1.8-2.2 (corrected floor, predicted) + 0.577 (Windows native-z3) =
-**7.79-8.19 GiB (78-82%)**, still under the 8.5 GiB warn threshold but with only 0.31-0.71 GiB of
-headroom -- thinner than this section previously predicted. Two levers are recorded here for if that
-headroom is ever exhausted, neither exercised now: (i) `fsl-logic` could go restore-only against
-`rust-workspace` the same way `merge-readiness.yml` did (its build set is a near-subset -- see
-`tools/check-native-integration.sh:285,310` -- saving ~1.369 GiB), or (ii) `cache-targets: false` on
-the mutation lanes (saving ~1.5 GiB-class, at the cost of the operators shards going cold every run,
-+10-15 min/shard). Both are deferred until the budget actually needs them, not applied speculatively.
+**Budget lever: `fsl-logic` goes restore-only against `rust-workspace`, taking its dedicated key out
+of the budget entirely (measured, not predicted).** `fsl-logic`'s entire build is
+`cargo test -p fslc-rust --test typed_agreement --locked` (`tools/run-fsl-logic-test.sh:19-22`), one
+test target that is a strict subset of what `rust workspace`'s shards already build.
+`Swatinem/rust-cache` prunes workspace-member build artifacts at save time and keeps only external
+dependency output (upstream `src/cleanup.ts`), so every lane's cache is substantively "the same
+lockfile's external deps" regardless of which job saved it -- restoring `rust-workspace` here loses
+nothing `fsl-logic` needed a dedicated key for. Measured main-branch entries (2026-08-12,
+`gh api actions/caches`): `rust-workspace` 1,605,761,517 B, `fsl-logic` 1,470,489,603 B (1.369 GiB),
+`wasm` 1,452,450,563 B, `rust-native-z3` Darwin 1,239,235,056 B, `semantic-mutation` 2,919,716,751 B,
+plus ~41 MB of small tool-binary caches -- **8.130 GiB total**. Removing the now-orphaned `fsl-logic`
+entry (a separate, human-authorized deletion) and re-adding Windows native-z3 (historical size
+0.577 GiB, to be re-measured after recreation) gives
+**8.130 − 1.369 + 0.577 = 7.338 GiB (73.4%)**, under the 8.5 GiB warn threshold with headroom to
+spare. `fsl-logic`'s own job goes cold on its first restore-only run; baseline warm duration is
+2m48s-2m53s (scheduled runs 2026-08-09/10/11) against a 30-minute budget, so the risk is bounded even
+if the first run underperforms the ±seconds this predicts. A `cache-targets: false` lever on the
+mutation lanes was considered and rejected: it would cost the operators shards a cold build every
+run (~35 min measured cold vs. ~5 min warm) for less budget relief than `fsl-logic` gives for
+near-zero cost.
 
 **Eviction started this; `cache-on-failure: false` made it unrecoverable.** The
 `semantic mutation` lane fell into a closed loop, measured on `main` and on three pull requests:

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -517,7 +517,8 @@ that is exceeded. Caches are also **ref-scoped**: a run restores only its own re
 default branch's, so a pull request's cache is worthless to a sibling pull request while still
 counting against the shared limit.
 
-`ci.yml` declares four shared keys, measured: `semantic-mutation` 2.72 GiB, `rust-workspace`
+`ci.yml` declared four shared keys at the time (`fsl-logic` was one of them; it does not declare one
+today, see below), measured: `semantic-mutation` 2.72 GiB, `rust-workspace`
 1.50 GiB, `fsl-logic` 1.37 GiB, `wasm` 1.35 GiB — about **6.9 GiB per ref**. Two concurrent pull
 requests therefore exceed the limit on their own, and on 2026-08-06 they did: usage stood at
 9.96 GiB across 12 entries, every large cache belonged to `refs/pull/743/merge` or
@@ -537,11 +538,22 @@ The consequence is measured, not inferred. Two runs of the same commit on the sa
 ref-scoped copy, which evicts more. `main` can heal — a miss there does save — but the pressure
 from concurrent pull requests outran the healing.
 
-**Decision: only non-pull-request events save.** Every `Swatinem/rust-cache` step in `ci.yml`
-carries `save-if: ${{ github.event_name != 'pull_request' }}`. Pull requests still *restore*,
-because `main` is the default branch and therefore readable from every ref. What a pull request
-gives up is a warm second run of itself; what it gains is that `main`'s caches stay resident, which
-is the only cache any pull request could ever share.
+**Decision (#747): only non-pull-request events save.** At the time, every `Swatinem/rust-cache` step
+in `ci.yml` carried `save-if: ${{ github.event_name != 'pull_request' }}`. Pull requests still
+*restore*, because `main` is the default branch and therefore readable from every ref. What a pull
+request gives up is a warm second run of itself; what it gains is that `main`'s caches stay resident,
+which is the only cache any pull request could ever share.
+
+**That is no longer a description of every step -- the current contract has two shapes, not one.**
+Later decisions in this branch (below) took `ci.yml`'s `fsl-logic` and `semantic-mutation-mutants`
+jobs, and both of `merge-readiness.yml`'s jobs, restore-only: each carries `save-if: false`
+unconditionally and saves nothing, ever, reading `rust-workspace`'s cache instead of owning a key of
+its own. The two shapes present today are: a step that saves its own declared key carries the
+event guard above (`save-if: ${{ github.event_name != 'pull_request' }}`); a step that is
+restore-only carries `save-if: false` and never saves under any event. `CI_SHARED_KEYS` in
+`audit-cache-budget.mjs` lists the keys actually saved this way: `rust-workspace`, `wasm`,
+`semantic-mutation` -- three, not the four this section originally measured, since `fsl-logic`'s
+dedicated key was retired when that job went restore-only.
 
 `merge-readiness.yml` was deliberately left unchanged at that point: its two keys total about
 131 MiB, they were not *that* incident's pressure, and its lanes are the sub-minute fast path —
@@ -647,12 +659,14 @@ entry (a separate, human-authorized deletion) and re-adding Windows native-z3 (h
 spare. `rust-workspace` and the former dedicated `fsl-logic` key already share the same
 `Linux-x64-e8b3ee54-09fbaf53` suffix, so `shared-key: rust-workspace` is expected to hit exactly, not
 merely restore a compatible prefix -- an exact-hit restore is expected to cost about what `fsl-logic`'s
-own key already did. If the shared `rust-workspace` cache were ever missing or evicted on some future
-run, that run would build cold instead; how long that would take is not observed here (this job has
-never run cold under this configuration), so the baseline warm duration of 2m48s-2m53s (scheduled
-runs 2026-08-09/10/11) is cited only as this job's typical wall-clock cost, not as a bound on cold-run
-time. Either way the risk is contained by the job's existing 30-minute budget. A `cache-targets: false`
-lever on the
+own key already did. If the shared `rust-workspace` cache were ever missing or evicted instead, this
+job would build cold under the existing 30-minute timeout. That timeout bounds resource consumption,
+not job success: past it, the job is killed and reported as a failed required context, the same
+outcome this whole section exists to stop happening to a different job. Whether a cold build here
+would finish inside 30 minutes is not observed -- this job has never run cold under this
+configuration, so its baseline warm duration (2m48s-2m53s, scheduled runs 2026-08-09/10/11) describes
+only the typical exact-hit case, not a cold-run bound, and is not evidence that a cold run would
+succeed rather than time out. A `cache-targets: false` lever on the
 mutation lanes was considered and rejected: it would cost the operators shards a cold build every
 run (~35 min measured cold vs. ~5 min warm) for less budget relief than `fsl-logic` gives for
 near-zero cost.
@@ -748,7 +762,8 @@ is corrected (`Windows_NT` tried before the `Windows` it is a strict superset of
 
 The general pull-request-rust-cache rule exists because `merge-readiness.yml`'s restore-only fix
 (above) makes "no workflow saves a rust cache on a pull-request event" a repository-wide invariant,
-not something scoped to `ci.yml`'s four declared keys. Before this rule, `merge-readiness.yml`'s own
+not something scoped to `CI_SHARED_KEYS`' three declared keys (`rust-workspace`, `wasm`,
+`semantic-mutation`). Before this rule, `merge-readiness.yml`'s own
 now-removed per-job keys (`rust-compile`, `core-contracts`) were invisible to this audit for the same
 reason `rust-native-z3` was: an unlisted shared key is never attributed, so a pull-request-scoped
 entry for it was silently treated as normal. The general rule catches that shape regardless of

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -667,18 +667,41 @@ genuine cold vendored-Z3 build on this matrix without approaching the Linux prom
 
 **The control.** `.github/scripts/audit-cache-budget.mjs` is a pure function over a fetched cache
 listing; `.github/workflows/cache-budget-audit.yml` fetches and runs it on a schedule, on dispatch,
-and on `main` pushes that touch it or `ci.yml`. It fails closed on three states: usage at or above
-85% of the limit, a missing `refs/heads/main` cache for any critical-path shared key, and — the
-rejecting control for the `save-if` guard itself — **any pull-request-scoped cache for one of
-`ci.yml`'s shared keys**, which can only appear if that guard is removed. An unreadable listing or
-an absent usage total fail closed too; neither is read as headroom.
+and on `main` pushes that touch it, `ci.yml`, or `merge-readiness.yml`. It fails closed on four
+states: usage at or above 85% of the limit, a missing `refs/heads/main` cache for any critical-path
+`{key, platform}` pair, — the rejecting control for the `save-if` guard itself — any pull-request-
+scoped cache for one of `ci.yml`'s shared keys, and — the general form of that same control — any
+`v0-rust-*`-prefixed cache on a pull-request ref at all, whether or not its shared key is one
+`ci.yml` declares. An unreadable listing or an absent usage total fail closed too; neither is read
+as headroom.
+
+The critical-path check is per-`{key, platform}` pair, not per-key, because `rust-native-z3` is one
+shared key backed by a `[macos-15, windows-latest]` matrix in `ci.yml`: a key-only set lets either
+platform's presence on `main` hide the other's absence. That was a live blind spot, not a
+hypothetical one -- `sharedKeyOf`'s regex matched `Linux`/`macOS`/`Windows` (the GitHub Actions
+`runner.os` spellings), but `Swatinem/rust-cache` composes its key from `os.type()`, which reports
+`Linux`, `Darwin`, and `Windows_NT`. `Darwin` and `Windows_NT` never matched, so both `rust-native-z3`
+entries were invisible to every rule in this audit -- including the one that would have reported
+`main`'s Windows cache evicted to zero entries during the incident this section documents. The regex
+is corrected (`Windows_NT` tried before the `Windows` it is a strict superset of) and
+`REQUIRED_MAIN_ENTRIES` now requires `rust-native-z3` on both `Windows_NT` and `Darwin` explicitly.
+
+The general pull-request-rust-cache rule exists because `merge-readiness.yml`'s restore-only fix
+(above) makes "no workflow saves a rust cache on a pull-request event" a repository-wide invariant,
+not something scoped to `ci.yml`'s four declared keys. Before this rule, `merge-readiness.yml`'s own
+now-removed per-job keys (`rust-compile`, `core-contracts`) were invisible to this audit for the same
+reason `rust-native-z3` was: an unlisted shared key is never attributed, so a pull-request-scoped
+entry for it was silently treated as normal. The general rule catches that shape regardless of
+whether the key is one this file has ever heard of, so a future workflow's unguarded
+`Swatinem/rust-cache` step cannot reopen the same blind spot under a new name.
 
 `.github/scripts/audit-cache-budget.test.mjs` calibrates all of it offline, including a fixture that
-reproduces the 2026-08-06 listing verbatim and must fail. `tools/check-merge-readiness.sh`'s
-`check_automation` lane runs that suite on every pull request, so a change to the checker is covered
-pre-merge even though the live audit deliberately is not a required context: the shared cache state
-can change after a pull request's own checks pass, so gating a merge on it would gate on something
-outside the change under review.
+reproduces the 2026-08-06 listing verbatim and must fail, and rejecting fixtures for a non-`ci.yml`
+rust cache on a pull-request ref and for each half of `rust-native-z3` missing from `main`.
+`tools/check-merge-readiness.sh`'s `check_automation` lane runs that suite on every pull request, so
+a change to the checker is covered pre-merge even though the live audit deliberately is not a
+required context: the shared cache state can change after a pull request's own checks pass, so
+gating a merge on it would gate on something outside the change under review.
 
 Issue #747 records the incident. Issue #720's Finding 2 — warming the fault-operator scratch build —
 **adds** a cache and therefore depends on this budget holding first.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -593,14 +593,60 @@ be reused by anything; it was pure accumulation. The evidence directory
 `rust/target/semantic-mutation.*/**` in `ci.yml` requires to stay under `rust/target`) compounded
 this the same way: it holds a full rsynced checkout copy, and old runs' copies survived a cache
 restore into the working tree right alongside the new run's own. The scratch build tree now lives
-under `${RUNNER_TEMP:-${TMPDIR:-/tmp}}` instead, outside anything `Swatinem/rust-cache` saves, and
-the script clears any leftover `rust/target/semantic-mutation.*` and
-`rust/target/semantic-mutation-build` directories from a restored cache before creating its own new
-evidence directory, so at most one run's evidence is ever present at save time. This does not shrink
-the existing `semantic-mutation` cache entry by itself — `Swatinem/rust-cache` does not resave a
-key that still primary-matches — so the reduction only lands once that entry is deleted (a separate,
-human-authorized action) and re-created by a subsequent run; the predicted size after that point is
-not asserted here as measured.
+under `${RUNNER_TEMP:-${TMPDIR:-/tmp}}` instead, outside anything `Swatinem/rust-cache` saves.
+
+**The first fix for the leftover-evidence cleanup was necessary but not sufficient, because it ran
+after the wrong lane's early exit.** `Swatinem/rust-cache` saves a key once, and whichever job
+reaches its post step first wins the save for that key -- measured on product-gate run
+`31527197290`, all three `semantic-mutation-operators` shards reached their post step
+(19:23:20 / 19:23:34 / 19:23:55) well before `semantic-mutation-mutants` did (20:33:31), so the
+`semantic-mutation` key's saver is always an operators shard, never the mutants job. The cleanup
+that clears leftover `rust/target/semantic-mutation.*`/`semantic-mutation-build` directories was
+first placed only in the mutants lane's own path, below `run_operators_lane`'s early `exit 0` for
+`--lane operators` invocations -- so the one lane that actually saves the key never ran the cleanup
+at all, restored the old dead weight every time, and resaved it unchanged. The cleanup now runs
+unconditionally right after mode validation, before either lane does anything, so it applies
+regardless of which lane -- or, unsharded, which order of both lanes -- ends up saving.
+
+**`rust/target/fault-operators` (`tools/run-fault-operators.sh:74-79`) is not dead weight and must
+not be removed.** It is a deliberately persistent scratch checkout and dedicated `CARGO_TARGET_DIR`
+that survives between runs by design -- the comment there says so explicitly -- and is the actual
+mechanism that runs the operators shards in ~5 minutes instead of a 15-20 minute cold build each.
+Combined with the dependency build every lane produces under `rust/target/debug` via
+`run_manifest_test`, `semantic-mutation`'s legitimate steady-state content is **two build trees**
+(`rust/target/debug`'s deps and `rust/target/fault-operators/target`'s deps) plus `~/.cargo` --
+structurally larger than any single-tree shared key such as `rust-workspace` (1.495 GiB). The
+corrected floor is **~2.2 GiB (predicted)**, not the ~0.9-1.4 GiB this section previously predicted;
+that earlier number came from treating `fault-operators`' persistent tree as removable dead weight,
+which it is not. `SINGLE_ENTRY_WARN_BYTES` in `audit-cache-budget.mjs` is calibrated to this
+corrected floor. Confirming the actual post-fix size, not just the mechanism, requires a `main` save
+after the stale `semantic-mutation` entry is deleted (a separate, human-authorized action) --
+nothing in this branch asserts that number as already measured.
+
+**Ownership: the operators shards are this key's only saver; the mutants job is restore-only.**
+`semantic-mutation-mutants`'s `Swatinem/rust-cache` step carries `save-if: false`. It never wins the
+save race today (see the timing measurement above), so this changes nothing about what actually gets
+cached; it only makes explicit that the mutants job's sole `rust/target`-scoped output -- its
+evidence directory, kept under `rust/target` solely because the artifact-upload glob requires it --
+must never be allowed into a future save if the timing ever changed. `cache-on-failure: true` was
+removed from the same step: `Swatinem/rust-cache`'s `save.ts` returns before evaluating it once
+`save-if` is `false`, so it was already inert. `semantic-mutation-operators` is unchanged
+(`save-if` on non-pull-request events, `cache-on-failure: true`) and remains this key's sole owner
+and recovery path. Splitting the key so each lane has its own (`shared-key` per job) was considered
+and rejected: it would add a second entry (~1 GiB predicted for the mutants-only content) for no
+warm-value gain, since the mutants job has essentially none of its own -- `~/.cargo/bin/cargo-mutants`
+is already rebuilt every run today because operators always wins the race first, so restore-only
+changes nothing there either.
+
+**Budget with the corrected floor**: 8.130 (main-only, post-#752-residue-cleanup) − 2.719
+(defect `semantic-mutation`) + 1.8-2.2 (corrected floor, predicted) + 0.577 (Windows native-z3) =
+**7.79-8.19 GiB (78-82%)**, still under the 8.5 GiB warn threshold but with only 0.31-0.71 GiB of
+headroom -- thinner than this section previously predicted. Two levers are recorded here for if that
+headroom is ever exhausted, neither exercised now: (i) `fsl-logic` could go restore-only against
+`rust-workspace` the same way `merge-readiness.yml` did (its build set is a near-subset -- see
+`tools/check-native-integration.sh:285,310` -- saving ~1.369 GiB), or (ii) `cache-targets: false` on
+the mutation lanes (saving ~1.5 GiB-class, at the cost of the operators shards going cold every run,
++10-15 min/shard). Both are deferred until the budget actually needs them, not applied speculatively.
 
 **Eviction started this; `cache-on-failure: false` made it unrecoverable.** The
 `semantic mutation` lane fell into a closed loop, measured on `main` and on three pull requests:

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -568,11 +568,16 @@ own key, from any event. `merge-readiness.yml`'s two `Swatinem/rust-cache` steps
 `save-if: false`): both jobs run `dtolnay/rust-toolchain@stable` on `ubuntu-latest` against the same
 checkout as `ci.yml`'s `rust workspace` job, and `Swatinem/rust-cache` derives its key from the
 rustc version, `CARGO`/`CC`/`CFLAGS`/`CXX`/`CMAKE`/`RUST`-prefixed env vars, and the workspace
-lockfiles — none of which differ between the two workflows — so an exact key match is expected, not
-directly observed here (the pull-request-scoped entries that could have confirmed a full match were
-deleted 2026-08-12 during unrelated cleanup); it is confirmed instead from the first post-merge run's
-own `Restored from cache key "..." full match: true.` log line, and even a hash mismatch degrades
-only to `Swatinem/rust-cache`'s ordinary prefix-restore fallback rather than a cold build. Neither
+lockfiles — none of which differ between the two workflows — so an exact key match is expected, but
+this is a mechanism-derived expectation, not something observed yet: the pull-request-scoped entries
+that could have confirmed a full match were deleted 2026-08-12 during unrelated cleanup, and this
+branch has not been merged, so no post-merge run of `merge-readiness.yml` exists to have logged one.
+**This paragraph records an expectation pending confirmation, not a confirmed result.** The first
+post-merge run's own log is the actual evidence: it must show
+`Restored from cache key "..." full match: true.` before this claim is treated as confirmed; if it
+instead shows a prefix-restore fallback or a miss, this paragraph needs updating, not the code (a
+mismatch degrades only to `Swatinem/rust-cache`'s ordinary prefix-restore fallback rather than a cold
+build, so it would not be a functional regression, only a correction to this expectation). Neither
 job ever writes to this key: only `ci.yml`'s `push`-triggered job does, so no `pull_request` event
 anywhere can grow it, and merge-readiness gains no eviction pressure of its own to reintroduce.
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -665,10 +665,15 @@ cache exists.** Measured budgets against measured durations:
 | `mutation operators (K/3)` | 30 min | 18.0–19.5 min | **>30** (cancelled at 30.2) | **50 min** |
 | `mutation mutants` | 60 min | 17.2–34.2 min | **>60** (cancelled at ~61) | **90 min** |
 
-Both semantic-mutation cache steps now carry `cache-on-failure: true`, so a cold run that runs out
-of budget still leaves a warm cache behind, and both budgets are raised past a measured cold run.
-Raised rather than narrowed, for the reason this document already gives for the promotion-only
-native-Z3 job: a gate that runs out of wall clock reports a failure it did not observe.
+The `semantic-mutation` key has exactly one class of savers: the three `semantic-mutation-operators`
+shards (`save-if` on non-pull-request events, `cache-on-failure: true` -- the owner keeps the
+recovery path for a cold start that fails or times out). `semantic-mutation-mutants` is restore-only
+(`save-if: false`); it carries no `cache-on-failure`, which would be meaningless there, since
+`Swatinem/rust-cache`'s save step exits on `save-if` before that flag is ever consulted. Both
+budgets are raised past a measured cold run regardless, for the reason this document already gives
+for the promotion-only native-Z3 job: a gate that runs out of wall clock reports a failure it did not
+observe. (`rust-native-z3`'s own `cache-on-failure: true` and 60-minute budget, discussed elsewhere
+in this section, are a separate lane and a separate decision.)
 
 This is also the most likely explanation for `main`'s standing post-merge failures #721
 (`mutation mutants`) and #678 (`semantic mutation (complete)`), whose cancellations sit exactly at

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -557,10 +557,24 @@ because GitHub only evicts a cache for staleness after **7 days without a read**
 landed inside that window for refs that closed more recently than that. The LRU evictor does not
 distinguish "small but many" from "few but large": it evicted `refs/heads/main`'s
 `native Z3 4.16 (windows-latest)` cache down to **zero entries**, observed via
-`gh api actions/caches`. `merge-readiness.yml` now carries the same
-`save-if: ${{ github.event_name != 'pull_request' }}` guard as every `ci.yml` step, closing the
-eviction path PR #752 left open. Its lanes still restore on every pull request from `main`'s copy,
-same as before; only the self-multiplying save on pull requests stops.
+`gh api actions/caches`. **The `save-if` guard `ci.yml` uses is the wrong fix here and was
+reverted before merging**: that guard only stops saving on `pull_request` events, and it relies on
+some other event on the same workflow saving a `main`-branch copy to restore from. `ci.yml` has a
+`push: branches: [main]` trigger to do that; `merge-readiness.yml` has none (`on:` above lists only
+`pull_request` and `merge_group`), so adding the same guard here would not close the eviction path,
+it would make every pull request permanently cold — the workflow would never save a cache under its
+own key, from any event. `merge-readiness.yml`'s two `Swatinem/rust-cache` steps instead go
+**restore-only against `ci.yml`'s own `rust-workspace` key** (`shared-key: rust-workspace`,
+`save-if: false`): both jobs run `dtolnay/rust-toolchain@stable` on `ubuntu-latest` against the same
+checkout as `ci.yml`'s `rust workspace` job, and `Swatinem/rust-cache` derives its key from the
+rustc version, `CARGO`/`CC`/`CFLAGS`/`CXX`/`CMAKE`/`RUST`-prefixed env vars, and the workspace
+lockfiles — none of which differ between the two workflows — so an exact key match is expected, not
+directly observed here (the pull-request-scoped entries that could have confirmed a full match were
+deleted 2026-08-12 during unrelated cleanup); it is confirmed instead from the first post-merge run's
+own `Restored from cache key "..." full match: true.` log line, and even a hash mismatch degrades
+only to `Swatinem/rust-cache`'s ordinary prefix-restore fallback rather than a cold build. Neither
+job ever writes to this key: only `ci.yml`'s `push`-triggered job does, so no `pull_request` event
+anywhere can grow it, and merge-readiness gains no eviction pressure of its own to reintroduce.
 
 This also qualifies a claim made elsewhere in this document. Cache hit rates were measured to have
 no headroom for `rust workspace` — compile is only ~3.5 min of ~33 min **on a warm cache**. That

--- a/tools/run-semantic-mutation-gate.sh
+++ b/tools/run-semantic-mutation-gate.sh
@@ -101,6 +101,15 @@ if [ "$lane" != "mutants" ]; then
   run_operators_lane
 fi
 
+# Prior invocations' evidence directories and scratch build trees can survive
+# into this checkout by way of a restored `Swatinem/rust-cache` entry: the
+# cache saves `rust/target` wholesale, so anything left there by a past run
+# reappears here before this run creates its own differently-named copy.
+# Clear them before this run's own evidence exists, so a restored cache never
+# carries more than one run's worth of this script's output forward into the
+# next save (docs/DESIGN-ci.md, "Actions cache budget").
+rm -rf "$root"/rust/target/semantic-mutation.* "$root/rust/target/semantic-mutation-build"
+
 mkdir -p "$root/rust/target"
 output="$(mktemp -d "$root/rust/target/semantic-mutation.${mode}.XXXXXX")"
 scratch="$output/checkout"
@@ -112,11 +121,16 @@ git -C "$scratch" init --quiet
 mkdir -p "$scratch/rust/target"
 # A target shared by disposable checkouts can retain a mutant artifact whose
 # source timestamp is newer than the freshly copied baseline. Give each run a
-# fresh build directory outside the retained evidence glob, so the baseline
-# can never reuse another run's mutation and CI does not upload build objects.
-mkdir -p "$root/rust/target/semantic-mutation-build"
+# fresh build directory, so the baseline can never reuse another run's
+# mutation. This scratch tree is disposable working state, not evidence: it
+# sits outside `rust/target` (unlike the `$output` evidence directory above,
+# which the artifact-upload glob `rust/target/semantic-mutation.*/**` in
+# ci.yml requires), so `Swatinem/rust-cache` never saves it and a run-scoped
+# name here does not accumulate as cache dead weight the way it did living
+# under `rust/target/semantic-mutation-build` (docs/DESIGN-ci.md, "Actions
+# cache budget").
 export CARGO_TARGET_DIR
-CARGO_TARGET_DIR="$(mktemp -d "$root/rust/target/semantic-mutation-build/run.XXXXXX")"
+CARGO_TARGET_DIR="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/fsl-semantic-mutation-build.XXXXXX")"
 args=(
   --config .cargo/mutants.toml
   --in-place

--- a/tools/run-semantic-mutation-gate.sh
+++ b/tools/run-semantic-mutation-gate.sh
@@ -62,19 +62,22 @@ case "$mode" in
     ;;
 esac
 
-# Prior invocations' evidence directories and scratch build trees can survive
-# into this checkout by way of a restored `Swatinem/rust-cache` entry: the
-# cache saves `rust/target` wholesale, so anything left there by a past run
-# reappears here before this run creates its own differently-named copy.
-# Clear them before either lane does anything else, not just before the
-# mutants lane's own evidence generation: the `semantic-mutation` key's saver
-# is whichever operators shard reaches its post step first
-# (`Swatinem/rust-cache` saves once per key, first writer wins, and operators
-# always wins the timing race against mutants), so unless the operators lane
-# itself clears this dead weight before restoring, it is carried forward and
-# resaved forever regardless of what the mutants lane below does with its own
-# `CARGO_TARGET_DIR`. This runs once per invocation, including the unsharded
-# local path that runs operators then mutants in the same process.
+# This clears leftover evidence/scratch directories a restored cache may carry
+# forward, but it does not shrink the `semantic-mutation` cache entry itself.
+# Measured directly (run 31210570118, `mutation operators (3/3)`, job
+# 92972117510): that entry's current 2.719 GiB was created by a *cold*
+# operators run (`No cache found.` at 19:14:17Z, `Saving cache` at 19:48:12Z)
+# that never touched the mutants lane's scratch build tree or evidence
+# directory at all -- those paths cannot have contributed to this entry's
+# size, so there is no dead weight here for this line to recover. This is a
+# closed-ingress-path fix, not a size fix: it stops a *future* run of either
+# lane from ever letting a restored evidence/scratch leftover ride along into
+# a save, which was possible before because the cleanup this line replaces
+# used to run only in the mutants lane's own path, below the point where
+# `--lane operators` already exits (see git history) -- the one lane that
+# actually saves this key never ran it. Cleared before either lane does
+# anything else, once per invocation, including the unsharded local path that
+# runs operators then mutants in the same process.
 rm -rf "$root"/rust/target/semantic-mutation.* "$root/rust/target/semantic-mutation-build"
 
 run_manifest_test() {
@@ -131,10 +134,13 @@ mkdir -p "$scratch/rust/target"
 # mutation. This scratch tree is disposable working state, not evidence: it
 # sits outside `rust/target` (unlike the `$output` evidence directory above,
 # which the artifact-upload glob `rust/target/semantic-mutation.*/**` in
-# ci.yml requires), so `Swatinem/rust-cache` never saves it and a run-scoped
-# name here does not accumulate as cache dead weight the way it did living
-# under `rust/target/semantic-mutation-build` (docs/DESIGN-ci.md, "Actions
-# cache budget").
+# ci.yml requires), so `Swatinem/rust-cache` never saves it. This closes a
+# path by which a run-scoped directory here *could* have ridden into a future
+# save while it lived under `rust/target/semantic-mutation-build` -- it is not
+# known to have actually done so: the `semantic-mutation` cache entry's
+# measured size is fully accounted for by a cold `mutation operators` run that
+# never created this directory at all (docs/DESIGN-ci.md, "Actions cache
+# budget").
 export CARGO_TARGET_DIR
 CARGO_TARGET_DIR="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/fsl-semantic-mutation-build.XXXXXX")"
 args=(

--- a/tools/run-semantic-mutation-gate.sh
+++ b/tools/run-semantic-mutation-gate.sh
@@ -62,6 +62,21 @@ case "$mode" in
     ;;
 esac
 
+# Prior invocations' evidence directories and scratch build trees can survive
+# into this checkout by way of a restored `Swatinem/rust-cache` entry: the
+# cache saves `rust/target` wholesale, so anything left there by a past run
+# reappears here before this run creates its own differently-named copy.
+# Clear them before either lane does anything else, not just before the
+# mutants lane's own evidence generation: the `semantic-mutation` key's saver
+# is whichever operators shard reaches its post step first
+# (`Swatinem/rust-cache` saves once per key, first writer wins, and operators
+# always wins the timing race against mutants), so unless the operators lane
+# itself clears this dead weight before restoring, it is carried forward and
+# resaved forever regardless of what the mutants lane below does with its own
+# `CARGO_TARGET_DIR`. This runs once per invocation, including the unsharded
+# local path that runs operators then mutants in the same process.
+rm -rf "$root"/rust/target/semantic-mutation.* "$root/rust/target/semantic-mutation-build"
+
 run_manifest_test() {
   # Validates the operator inventory, the P2 scope/equivalents manifests, and
   # the mutation runner config together. Cheap (compile-dominated, ~1 min)
@@ -100,15 +115,6 @@ fi
 if [ "$lane" != "mutants" ]; then
   run_operators_lane
 fi
-
-# Prior invocations' evidence directories and scratch build trees can survive
-# into this checkout by way of a restored `Swatinem/rust-cache` entry: the
-# cache saves `rust/target` wholesale, so anything left there by a past run
-# reappears here before this run creates its own differently-named copy.
-# Clear them before this run's own evidence exists, so a restored cache never
-# carries more than one run's worth of this script's output forward into the
-# next save (docs/DESIGN-ci.md, "Actions cache budget").
-rm -rf "$root"/rust/target/semantic-mutation.* "$root/rust/target/semantic-mutation-build"
 
 mkdir -p "$root/rust/target"
 output="$(mktemp -d "$root/rust/target/semantic-mutation.${mode}.XXXXXX")"


### PR DESCRIPTION
## Problem

`main`'s scheduled product gate has not been green since 2026-08-07. Five consecutive
scheduled runs failed or were cancelled, and the cause is a single self-perpetuating loop:

1. `merge-readiness.yml` had no `save-if` guard, so every pull request saved a fresh
   ref-scoped cache for its `rust-compile` and `core-contracts` jobs (measured: 29 entries
   / ~1.90 GiB across 15 pull-request refs). PR #752 closed this path in `ci.yml` but left
   this workflow open.
2. The repository's 10 GiB Actions cache budget filled, and LRU evicted the entry that is
   touched least often — `main`'s `native Z3 4.16 (windows-latest)` cache.
3. Without that cache the Windows job builds cold and exceeds `timeout-minutes: 40`.
   The last success (2026-08-05) logged `Cache hit for: v0-rust-rust-native-z3-Windows_NT-x64-…`;
   the 2026-08-11 cancellation logged `No cache found.`
4. A cancelled job skips `Swatinem/rust-cache`'s post step (observed as
   `9 skipped Post Run Swatinem/rust-cache@v2` on run 31527197290), so the cache is never
   regenerated — and step 1 refills the budget. The loop does not recover on its own.

## Contract change

**Cache ownership is now explicit rather than a race.**

- `merge readiness / rust-compile` and `merge readiness / core-contracts`: restore-only
  (`shared-key: rust-workspace`, `save-if: false`). This workflow has no `push` trigger
  (`merge-readiness.yml` `on:`), so adding a `save-if` event guard alone would have removed
  its only save path and made every pull request permanently cold against a 20-minute budget.
- `FSL Logic Test`: restore-only against `rust-workspace`. Its build set is
  `cargo test -p fslc-rust --test typed_agreement --locked` (one test, via
  `tools/run-fsl-logic-test.sh`) — a strict subset of the `rust tests` shards. This removes
  a 1,470,489,603 B key from the budget.
- `mutation mutants`: restore-only against `semantic-mutation`. The three
  `mutation operators` shards are the only savers of that key; `cache-on-failure` was
  removed from the mutants job because `save-if: false` makes it unreachable.
- `native Z3 4.16` matrix: `cache-on-failure: true` and `timeout-minutes: 40 → 60`, so a
  cold run can complete and save instead of being cancelled into another cold run.

**Cache budget arithmetic (all measured, 2026-08-12):**

| bytes | GiB | entry |
|---|---|---|
| 8,729,550,718 | 8.130 | `main` total after the stale pull-request entries were deleted |
| 1,470,489,603 | 1.369 | `fsl-logic` — orphaned by this change, to be deleted |
| 619,501,189 | 0.577 | Windows `native-z3` — to be recreated |
| — | **7.3375** | expected total (< the audit's 8.5 GiB threshold) |

`semantic-mutation` (2,919,716,751 B) is **not** reduced. That entry was created by a cold
`mutation operators (3/3)` run (run 31210570118, job 92972117510: `No cache found.` at
19:14:17Z, `Saving cache` at 19:48:12Z, entry `created 2026-08-07T19:48:56Z`), so it contains
no accumulated dead weight. This is its observed clean size, not a proven minimum.

## Audit changes

- `sharedKeyOf` did not match the platform strings `os.type()` actually produces
  (`Darwin`, `Windows_NT` — not `macOS`/`Windows`), so **the `native-z3` entries were
  invisible to the audit**. That is one structural reason the Windows cache could vanish
  without the audit reporting it. Key parsing is now anchored from the end of the key.
- `REQUIRED_MAIN_*` is per-platform, so `rust-native-z3` is required on **both**
  `Windows_NT` and `Darwin` — a name-only set let Darwin's presence hide Windows' absence.
- New generic rule: any `refs/pull/*` entry whose key matches `^v\d+-rust-` is a finding,
  regardless of whether its shared key is known.
- `cache-budget-audit.yml` now also triggers on `merge-readiness.yml` changes.

## Test evidence

- `node --test .github/scripts/audit-cache-budget.test.mjs` — 14 pass / 0 fail.
- **Negative controls, verified by reintroducing each defect:** restoring the previous
  `audit-cache-budget.mjs` turns 6 fixtures red; removing the generic pull-ref rule turns
  exactly 2 red; reverting the key parser to its previous form turns exactly the
  pathological-key fixture red. All green again after restoring.
- `actionlint` on the three changed workflows, `shellcheck` and `bash -n` on
  `tools/run-semantic-mutation-gate.sh`, and `aggregate_changelog.sh check` / `check-pr` —
  all pass.

## Not observed yet (must be confirmed after merge)

These cannot be measured before this branch runs in CI, and are deliberately written as
expectations rather than results:

- Whether `FSL Logic Test` gets an exact hit on the `rust-workspace` key
  (`Restored from cache key "…" full match: true`) and how its duration compares to the
  2m48s–2m53s warm baseline measured on 2026-08-09/10/11.
- The size of the Windows `native-z3` entry after it is recreated (619,501,189 B is the
  2026-08-05 historical value).
- The live `cache budget audit` result once the orphaned `fsl-logic` entry is deleted.
- Cold-run duration for a restore-only job if the shared cache is ever missing. A timeout
  bounds resource use; it does not guarantee the job succeeds.
- Whether `cache-on-failure: true` actually saves after a *timeout* cancellation. The
  action's `post-if: success() || env.CACHE_ON_FAILURE == 'true'` makes it plausible, and
  this repository's history does not isolate it — 877fe8c raised a timeout at the same time.
  The primary recovery mechanism here is the 60-minute budget, not this flag.

## Follow-up operations (human-performed, after merge)

1. Delete the orphaned `v0-rust-fsl-logic-Linux-x64-*` entry (1,470,489,603 B).
2. Run the product gate on `main` so the Windows `native-z3` cache is recreated.
3. Confirm on one listing: Windows entry present, `fsl-logic` entry absent, usage < 8.5 GiB.

Do **not** delete the `semantic-mutation` entry — recreating it costs a ~35-minute cold
operators run and returns the same size.

## Scope note

`tools/run-semantic-mutation-gate.sh` moves its scratch build tree out of the cached path
and clears leftovers before each run. **This does not shrink the existing 2.719 GiB entry by
a single byte** — the measurement above shows that entry contains no such leftovers. Its
purpose is to close a future contamination path, not to remove a current cause.

Refs #747
