### PR TITLE
fix(domain): validate analyze and expand through the checked Kernel

### DIFF
--- a/changelog.d/724-domain-findings-contract.documented.md
+++ b/changelog.d/724-domain-findings-contract.documented.md
@@ -2,7 +2,7 @@ Documented (#724): `docs/DESIGN-domain.md`'s Findings section restated to
 match the native `fslc domain check`/`domain replay` implementation instead
 of the 7-kind list it previously claimed as implemented. Native
 `fslc domain check` implements exactly 4 finding kinds
-(`rust/fsl-tools/src/domain.rs:34-66`):
+(`rust/fsl-tools/src/domain.rs`'s `effect_findings`):
 `irreversible_effect_without_idempotency_key`,
 `pending_effect_without_timeout_or_fallback`,
 `missing_compensation_for_irreversible_effect`, and

--- a/changelog.d/796-domain-analyze-expand-validation.fixed.md
+++ b/changelog.d/796-domain-analyze-expand-validation.fixed.md
@@ -1,0 +1,3 @@
+Fixed (#796): `domain analyze` and `domain expand` now reject unresolved domain
+identifiers with the same located semantic diagnostic as `check`, instead of
+returning a false-green analysis or an unusable generated Kernel.

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -513,11 +513,13 @@ tests, or external evidence.
 `lower_domain` (typed `KernelSpec`, used by `check`/`verify`) and
 `domain_kernel_source` (rendered `.fsl` text, used by `domain expand` and
 by `check_domain` to validate renderability; only its hard-finding envelope
-includes the generated `kernel_source`). The CLI validates source through
-`load_kernel_model` before `domain analyze` returns its projection or `domain
-expand` returns rendered text; that is the same checked path `domain generate`
-uses, so neither command can emit success for a document typed lowering rejects
-(#796).
+includes the generated `kernel_source`). At command entry, `domain analyze`
+and `domain expand` read one source `String` and derive both their `DomainSpec`
+projection and checked Kernel through `load_kernel_model_from_source` from that
+same string. An atomic replacement of the path therefore cannot make either
+command validate a different source version before returning success (#796).
+`domain generate` uses the same typed lowering but does not yet provide this
+single-snapshot contract; #808 tracks that separate TOCTOU follow-up.
 `rust/fsl-core/tests/domain_render_agreement.rs` projects both through
 `public_kernel_contract` for the full domain corpus and requires them to match
 except on source spans (#664). Building that gate found the two

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -514,10 +514,11 @@ tests, or external evidence.
 `domain_kernel_source` (rendered `.fsl` text, used by `domain expand` and
 by `check_domain` to validate renderability; only its hard-finding envelope
 includes the generated `kernel_source`). At command entry, `domain analyze`
-and `domain expand` read one source `String` and derive both their `DomainSpec`
-projection and checked Kernel through `load_kernel_model_from_source` from that
-same string. An atomic replacement of the path therefore cannot make either
-command validate a different source version before returning success (#796).
+and `domain expand` read one source `String`, parse their `DomainSpec`
+projection from it with `parse_domain_document_from_source`, and pass that same
+string to `load_kernel_model_from_source` to construct the checked Kernel. An
+atomic replacement of the path therefore cannot make either command validate a
+different source version before returning success (#796).
 `domain generate` uses the same typed lowering but does not yet provide this
 single-snapshot contract; #808 tracks that separate TOCTOU follow-up.
 `rust/fsl-core/tests/domain_render_agreement.rs` projects both through

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -513,7 +513,11 @@ tests, or external evidence.
 `lower_domain` (typed `KernelSpec`, used by `check`/`verify`) and
 `domain_kernel_source` (rendered `.fsl` text, used by `domain expand` and
 by `check_domain` to validate renderability; only its hard-finding envelope
-includes the generated `kernel_source`).
+includes the generated `kernel_source`). The CLI validates source through
+`load_kernel_model` before `domain analyze` returns its projection or `domain
+expand` returns rendered text; that is the same checked path `domain generate`
+uses, so neither command can emit success for a document typed lowering rejects
+(#796).
 `rust/fsl-core/tests/domain_render_agreement.rs` projects both through
 `public_kernel_contract` for the full domain corpus and requires them to match
 except on source spans (#664). Building that gate found the two
@@ -521,9 +525,13 @@ implementations already disagree: `Context::normalize`/`Context::default`
 (`domain.rs`) render text with `str::replace` and no syntax tree, so they
 cannot be scope-aware the way `lower_domain`'s typed AST composition is. #690
 fixed the known `can(...)` precedence false green by parenthesizing each joined
-piece; its scope-aware substitution and generated-name symptoms remain open.
+piece. #798 tracks the remaining scope-aware substitution and generated-name
+renderer gaps. #796 validates the CLI source before returning its renderer
+output, so the #798 generated-name misuse is rejected at the command boundary
+rather than being emitted as a seemingly valid Kernel; it does not make the
+two lowerings agree.
 `domain_render_agreement.rs`'s `KNOWN_DIVERGENT_DOMAIN_FIXTURES` pins the
-currently known instances as regression fixtures; #690 owns the remaining
+currently known instances as regression fixtures; #798 owns the remaining
 `Context::normalize` scope and generated-name gaps. #691 (a separate root cause --
 `Context::default` had a catch-all arm reachable for every container type,
 not `Context::normalize`'s substitution-order problem) is fixed:

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -323,7 +323,10 @@ supported semantics」)。per-key init は `Map` 値型に対して選べる既�
 安定した fsl-domain findings とネストされたカーネル結果(成功時は
 `verified_under_assumptions`)には `fslc domain check` を、aggregate/effect の
 サマリーには `fslc domain analyze` を、生成されたカーネル FSL のデバッグビューの
-確認には `fslc domain expand` を、Functional DDD スキャフォールドには
+確認には `fslc domain expand` を使います。`domain analyze` と `domain expand` は
+いずれも `check`、`verify`、`domain generate` と同じ typed lowering path で、結果を
+返す前に著者が記述した domain source を検証します。未解決識別子は部分的な分析や
+使用不能な Kernel text を出力せず、元の source location 付きで棄却されます。Functional DDD スキャフォールドには
 `fslc domain generate --target typescript|python|kotlin|swift|rust` を、
 アダプタ/コンフォーマンスのスキャフォールドには `fslc domain testgen` を、
 ランタイムの command / event / effect エビデンスには

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -325,12 +325,13 @@ supported semantics」)。per-key init は `Map` 値型に対して選べる既�
 サマリーには `fslc domain analyze` を、生成されたカーネル FSL のデバッグビューの
 確認には `fslc domain expand` を使います。`domain analyze` と `domain expand` は
 コマンド開始時に著者が記述した domain source を一つの `String` として読み、その
-同じ snapshot から typed lowering により `DomainSpec` のサマリーまたは生成 Kernel
-text と検査済み Kernel を導出します。atomic な path replacement が起きても、出力前に
-別の source version を検証することはありません。未解決識別子は部分的な分析や
-使用不能な Kernel text を出力せず、元の source location 付きで棄却されます。
-`domain generate` は同じ typed lowering を使いますが、この single-snapshot 契約は
-まだ持ちません。別個の TOCTOU follow-up は #808 が追跡します。Functional DDD スキャフォールドには
+同じ snapshot を `parse_domain_document_from_source` に渡して `DomainSpec` を
+parse し、さらにその同じ String を `load_kernel_model_from_source` に渡して検査済み
+Kernel を構築します。atomic な path replacement が起きても、出力前に別の source
+version を検証することはありません。未解決識別子は部分的な分析や使用不能な Kernel
+text を出力せず、元の source location 付きで棄却されます。`domain generate` は同じ
+typed lowering を使いますが、この single-snapshot 契約はまだ持ちません。別個の
+TOCTOU follow-up は #808 が追跡します。Functional DDD スキャフォールドには
 `fslc domain generate --target typescript|python|kotlin|swift|rust` を、
 アダプタ/コンフォーマンスのスキャフォールドには `fslc domain testgen` を、
 ランタイムの command / event / effect エビデンスには

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -324,9 +324,13 @@ supported semantics」)。per-key init は `Map` 値型に対して選べる既�
 `verified_under_assumptions`)には `fslc domain check` を、aggregate/effect の
 サマリーには `fslc domain analyze` を、生成されたカーネル FSL のデバッグビューの
 確認には `fslc domain expand` を使います。`domain analyze` と `domain expand` は
-いずれも `check`、`verify`、`domain generate` と同じ typed lowering path で、結果を
-返す前に著者が記述した domain source を検証します。未解決識別子は部分的な分析や
-使用不能な Kernel text を出力せず、元の source location 付きで棄却されます。Functional DDD スキャフォールドには
+コマンド開始時に著者が記述した domain source を一つの `String` として読み、その
+同じ snapshot から typed lowering により `DomainSpec` のサマリーまたは生成 Kernel
+text と検査済み Kernel を導出します。atomic な path replacement が起きても、出力前に
+別の source version を検証することはありません。未解決識別子は部分的な分析や
+使用不能な Kernel text を出力せず、元の source location 付きで棄却されます。
+`domain generate` は同じ typed lowering を使いますが、この single-snapshot 契約は
+まだ持ちません。別個の TOCTOU follow-up は #808 が追跡します。Functional DDD スキャフォールドには
 `fslc domain generate --target typescript|python|kotlin|swift|rust` を、
 アダプタ/コンフォーマンスのスキャフォールドには `fslc domain testgen` を、
 ランタイムの command / event / effect エビデンスには

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -333,13 +333,14 @@ Use `fslc domain check` for stable fsl-domain findings and the nested kernel
 result (`verified_under_assumptions` on success), `fslc domain analyze` for the
 aggregate/effect summary, `fslc domain expand` to inspect a generated kernel FSL
 debug view. At command entry, both `domain analyze` and `domain expand` read
-one authored-source `String` and derive their `DomainSpec` summary or generated
-Kernel text and checked Kernel from that same snapshot through typed lowering.
-An atomic path replacement cannot make either command validate a different
-source version before returning output. They reject unresolved identifiers with
-the original source location instead of emitting a partial analysis or unusable
-Kernel text. `domain generate` uses the same typed lowering but does not yet
-have this single-snapshot contract; #808 tracks that separate TOCTOU follow-up.
+one authored-source `String`, parse their `DomainSpec` with
+`parse_domain_document_from_source`, and pass that same string to
+`load_kernel_model_from_source` to construct the checked Kernel. An atomic path
+replacement cannot make either command validate a different source version
+before returning output. They reject unresolved identifiers with the original
+source location instead of emitting a partial analysis or unusable Kernel text.
+`domain generate` uses the same typed lowering but does not yet have this
+single-snapshot contract; #808 tracks that separate TOCTOU follow-up.
 `fslc domain generate --target typescript|python|kotlin|swift|rust` for
 Functional DDD scaffolds, `fslc domain testgen` for adapter/conformance
 scaffolds, and `fslc domain replay --logs events.jsonl` for runtime command /

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -332,7 +332,11 @@ supported semantics") because the per-key init has no default to select for a
 Use `fslc domain check` for stable fsl-domain findings and the nested kernel
 result (`verified_under_assumptions` on success), `fslc domain analyze` for the
 aggregate/effect summary, `fslc domain expand` to inspect a generated kernel FSL
-debug view,
+debug view. Both `domain analyze` and `domain expand` validate the authored
+domain source through the same typed lowering path as `check`, `verify`, and
+`domain generate` before returning a summary or Kernel text; they reject
+unresolved identifiers with the original source location instead of emitting a
+partial analysis or unusable Kernel text.
 `fslc domain generate --target typescript|python|kotlin|swift|rust` for
 Functional DDD scaffolds, `fslc domain testgen` for adapter/conformance
 scaffolds, and `fslc domain replay --logs events.jsonl` for runtime command /

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -332,11 +332,14 @@ supported semantics") because the per-key init has no default to select for a
 Use `fslc domain check` for stable fsl-domain findings and the nested kernel
 result (`verified_under_assumptions` on success), `fslc domain analyze` for the
 aggregate/effect summary, `fslc domain expand` to inspect a generated kernel FSL
-debug view. Both `domain analyze` and `domain expand` validate the authored
-domain source through the same typed lowering path as `check`, `verify`, and
-`domain generate` before returning a summary or Kernel text; they reject
-unresolved identifiers with the original source location instead of emitting a
-partial analysis or unusable Kernel text.
+debug view. At command entry, both `domain analyze` and `domain expand` read
+one authored-source `String` and derive their `DomainSpec` summary or generated
+Kernel text and checked Kernel from that same snapshot through typed lowering.
+An atomic path replacement cannot make either command validate a different
+source version before returning output. They reject unresolved identifiers with
+the original source location instead of emitting a partial analysis or unusable
+Kernel text. `domain generate` uses the same typed lowering but does not yet
+have this single-snapshot contract; #808 tracks that separate TOCTOU follow-up.
 `fslc domain generate --target typescript|python|kotlin|swift|rust` for
 Functional DDD scaffolds, `fslc domain testgen` for adapter/conformance
 scaffolds, and `fslc domain replay --logs events.jsonl` for runtime command /

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -363,11 +363,14 @@ supported semantics") because the per-key init has no default to select for a
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
 aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL
-debug view. Both <code>domain analyze</code> and <code>domain expand</code> validate the authored
-domain source through the same typed lowering path as <code>check</code>, <code>verify</code>, and
-<code>domain generate</code> before returning a summary or Kernel text; they reject
-unresolved identifiers with the original source location instead of emitting a
-partial analysis or unusable Kernel text.
+debug view. At command entry, both <code>domain analyze</code> and <code>domain expand</code> read
+one authored-source <code>String</code> and derive their <code>DomainSpec</code> summary or generated
+Kernel text and checked Kernel from that same snapshot through typed lowering.
+An atomic path replacement cannot make either command validate a different
+source version before returning output. They reject unresolved identifiers with
+the original source location instead of emitting a partial analysis or unusable
+Kernel text. <code>domain generate</code> uses the same typed lowering but does not yet
+have this single-snapshot contract; #808 tracks that separate TOCTOU follow-up.
 <code>fslc domain generate --target typescript|python|kotlin|swift|rust</code> for
 Functional DDD scaffolds, <code>fslc domain testgen</code> for adapter/conformance
 scaffolds, and <code>fslc domain replay --logs events.jsonl</code> for runtime command /

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -364,13 +364,14 @@ supported semantics") because the per-key init has no default to select for a
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
 aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL
 debug view. At command entry, both <code>domain analyze</code> and <code>domain expand</code> read
-one authored-source <code>String</code> and derive their <code>DomainSpec</code> summary or generated
-Kernel text and checked Kernel from that same snapshot through typed lowering.
-An atomic path replacement cannot make either command validate a different
-source version before returning output. They reject unresolved identifiers with
-the original source location instead of emitting a partial analysis or unusable
-Kernel text. <code>domain generate</code> uses the same typed lowering but does not yet
-have this single-snapshot contract; #808 tracks that separate TOCTOU follow-up.
+one authored-source <code>String</code>, parse their <code>DomainSpec</code> with
+<code>parse_domain_document_from_source</code>, and pass that same string to
+<code>load_kernel_model_from_source</code> to construct the checked Kernel. An atomic path
+replacement cannot make either command validate a different source version
+before returning output. They reject unresolved identifiers with the original
+source location instead of emitting a partial analysis or unusable Kernel text.
+<code>domain generate</code> uses the same typed lowering but does not yet have this
+single-snapshot contract; #808 tracks that separate TOCTOU follow-up.
 <code>fslc domain generate --target typescript|python|kotlin|swift|rust</code> for
 Functional DDD scaffolds, <code>fslc domain testgen</code> for adapter/conformance
 scaffolds, and <code>fslc domain replay --logs events.jsonl</code> for runtime command /

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -363,7 +363,11 @@ supported semantics") because the per-key init has no default to select for a
 <p>Use <code>fslc domain check</code> for stable fsl-domain findings and the nested kernel
 result (<code>verified_under_assumptions</code> on success), <code>fslc domain analyze</code> for the
 aggregate/effect summary, <code>fslc domain expand</code> to inspect a generated kernel FSL
-debug view,
+debug view. Both <code>domain analyze</code> and <code>domain expand</code> validate the authored
+domain source through the same typed lowering path as <code>check</code>, <code>verify</code>, and
+<code>domain generate</code> before returning a summary or Kernel text; they reject
+unresolved identifiers with the original source location instead of emitting a
+partial analysis or unusable Kernel text.
 <code>fslc domain generate --target typescript|python|kotlin|swift|rust</code> for
 Functional DDD scaffolds, <code>fslc domain testgen</code> for adapter/conformance
 scaffolds, and <code>fslc domain replay --logs events.jsonl</code> for runtime command /

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -358,12 +358,13 @@ supported semantics」)。per-key init は <code>Map</code> 値型に対して�
 サマリーには <code>fslc domain analyze</code> を、生成されたカーネル FSL のデバッグビューの
 確認には <code>fslc domain expand</code> を使います。<code>domain analyze</code> と <code>domain expand</code> は
 コマンド開始時に著者が記述した domain source を一つの <code>String</code> として読み、その
-同じ snapshot から typed lowering により <code>DomainSpec</code> のサマリーまたは生成 Kernel
-text と検査済み Kernel を導出します。atomic な path replacement が起きても、出力前に
-別の source version を検証することはありません。未解決識別子は部分的な分析や
-使用不能な Kernel text を出力せず、元の source location 付きで棄却されます。
-<code>domain generate</code> は同じ typed lowering を使いますが、この single-snapshot 契約は
-まだ持ちません。別個の TOCTOU follow-up は #808 が追跡します。Functional DDD スキャフォールドには
+同じ snapshot を <code>parse_domain_document_from_source</code> に渡して <code>DomainSpec</code> を
+parse し、さらにその同じ String を <code>load_kernel_model_from_source</code> に渡して検査済み
+Kernel を構築します。atomic な path replacement が起きても、出力前に別の source
+version を検証することはありません。未解決識別子は部分的な分析や使用不能な Kernel
+text を出力せず、元の source location 付きで棄却されます。<code>domain generate</code> は同じ
+typed lowering を使いますが、この single-snapshot 契約はまだ持ちません。別個の
+TOCTOU follow-up は #808 が追跡します。Functional DDD スキャフォールドには
 <code>fslc domain generate --target typescript|python|kotlin|swift|rust</code> を、
 アダプタ/コンフォーマンスのスキャフォールドには <code>fslc domain testgen</code> を、
 ランタイムの command / event / effect エビデンスには

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -356,7 +356,10 @@ supported semantics」)。per-key init は <code>Map</code> 値型に対して�
 <p>安定した fsl-domain findings とネストされたカーネル結果(成功時は
 <code>verified_under_assumptions</code>)には <code>fslc domain check</code> を、aggregate/effect の
 サマリーには <code>fslc domain analyze</code> を、生成されたカーネル FSL のデバッグビューの
-確認には <code>fslc domain expand</code> を、Functional DDD スキャフォールドには
+確認には <code>fslc domain expand</code> を使います。<code>domain analyze</code> と <code>domain expand</code> は
+いずれも <code>check</code>、<code>verify</code>、<code>domain generate</code> と同じ typed lowering path で、結果を
+返す前に著者が記述した domain source を検証します。未解決識別子は部分的な分析や
+使用不能な Kernel text を出力せず、元の source location 付きで棄却されます。Functional DDD スキャフォールドには
 <code>fslc domain generate --target typescript|python|kotlin|swift|rust</code> を、
 アダプタ/コンフォーマンスのスキャフォールドには <code>fslc domain testgen</code> を、
 ランタイムの command / event / effect エビデンスには

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -357,9 +357,13 @@ supported semantics」)。per-key init は <code>Map</code> 値型に対して�
 <code>verified_under_assumptions</code>)には <code>fslc domain check</code> を、aggregate/effect の
 サマリーには <code>fslc domain analyze</code> を、生成されたカーネル FSL のデバッグビューの
 確認には <code>fslc domain expand</code> を使います。<code>domain analyze</code> と <code>domain expand</code> は
-いずれも <code>check</code>、<code>verify</code>、<code>domain generate</code> と同じ typed lowering path で、結果を
-返す前に著者が記述した domain source を検証します。未解決識別子は部分的な分析や
-使用不能な Kernel text を出力せず、元の source location 付きで棄却されます。Functional DDD スキャフォールドには
+コマンド開始時に著者が記述した domain source を一つの <code>String</code> として読み、その
+同じ snapshot から typed lowering により <code>DomainSpec</code> のサマリーまたは生成 Kernel
+text と検査済み Kernel を導出します。atomic な path replacement が起きても、出力前に
+別の source version を検証することはありません。未解決識別子は部分的な分析や
+使用不能な Kernel text を出力せず、元の source location 付きで棄却されます。
+<code>domain generate</code> は同じ typed lowering を使いますが、この single-snapshot 契約は
+まだ持ちません。別個の TOCTOU follow-up は #808 が追跡します。Functional DDD スキャフォールドには
 <code>fslc domain generate --target typescript|python|kotlin|swift|rust</code> を、
 アダプタ/コンフォーマンスのスキャフォールドには <code>fslc domain testgen</code> を、
 ランタイムの command / event / effect エビデンスには

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
  "fsl-tools",
  "fsl-verifier",
  "jsonschema",
+ "libc",
  "serde",
  "serde_json",
  "sha2",

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -220,12 +220,13 @@ struct KnownDivergence {
 /// a review transcript (AGENTS.md: "do not let the finding survive only in
 /// chat, a review transcript, or agent memory").
 ///
-/// **#690** <https://github.com/ymm-oss/fsl/issues/690> covers both entries
-/// below as one root cause: `domain.rs`'s `Context::normalize`
-/// (`rust/fsl-core/src/domain.rs:301`) is a chain of `str::replace` calls
+/// **#798** <https://github.com/ymm-oss/fsl/issues/798> tracks the two
+/// remaining symptoms caused by `domain.rs`'s `Context::normalize`
+/// (`rust/fsl-core/src/domain.rs:301`), a chain of `str::replace` calls
 /// over rendered text with no syntax tree, so it cannot be scope-aware
 /// (entry 2's `quantity` shadowing) or precedence-aware (entry 2's
-/// `can(...)` expansion) the way a typed AST composition can. Entry 1's
+/// `can(...)` expansion) the way a typed AST composition can. #690 fixed the
+/// precedence symptom; entry 1's
 /// generated-name leak is a symptom of the same string-level substitution
 /// having no notion of what is and is not a legal domain-level reference.
 ///
@@ -258,7 +259,8 @@ struct KnownDivergence {
 ///    valid kernel spec.
 ///
 /// 2. `expressions_valid.fsl` both paths accept, but the projected
-///    contracts still disagree at one point (name-shadowing, #690 symptom
+///    contracts still disagree at one point (name-shadowing, the #798
+///    continuation of #690 symptom
 ///    2). A second point that used to disagree here -- `can(...)`
 ///    operator-precedence misgrouping, #690 symptom 1 -- was fixed and is
 ///    described below, after this list, rather than removed from the
@@ -278,7 +280,8 @@ struct KnownDivergence {
 ///      mis-substitution reaches the `decide Approve` guard
 ///      `quantity >= 0`, which refers to the *command input* `quantity`,
 ///      not the state field. This needs a scope-aware substitution (design
-///      option B/C in #690) and is out of scope for the `can(...)` fix.
+///      option B/C recorded for #690) and is out of scope for the `can(...)`
+///      fix.
 ///
 ///    Before #690's fix, this fixture's
 ///    `invariant legacyImplication { status == Cancelled -> not can(Cancel) }`
@@ -321,7 +324,7 @@ const KNOWN_DIVERGENT_DOMAIN_FIXTURES: &[KnownDivergence] = &[
         fixture: "rust/fslc/tests/fixtures/domain_characterization/ai_internal_name_misuse.fsl",
         shape: DivergenceShape::PathARejects,
         expected_contains: &["unknown domain symbol 'Status_Draft'"],
-        tracking_issue: "https://github.com/ymm-oss/fsl/issues/690",
+        tracking_issue: "https://github.com/ymm-oss/fsl/issues/798",
     },
     KnownDivergence {
         fixture: "rust/fslc/tests/fixtures/domain_characterization/expressions_valid.fsl",
@@ -331,11 +334,11 @@ const KNOWN_DIVERGENT_DOMAIN_FIXTURES: &[KnownDivergence] = &[
         // \"or\""`) is fixed: `Context::normalize` now parenthesizes each
         // `requires`/`rejects` piece individually before joining, so this
         // fixture's `can(Cancel)` projection no longer disagrees with path
-        // A. Only #690 symptom 2 remains here: the name-shadowing rewrite
-        // still needs a scope-aware substitution (design option B/C, still
-        // open), so `quantity`/`order_quantity` still disagrees.
+        // A. #798 tracks the remaining #690 symptom 2: the name-shadowing
+        // rewrite still needs a scope-aware substitution (design option B/C,
+        // still open), so `quantity`/`order_quantity` still disagrees.
         expected_contains: &["path A = \"quantity\", path B = \"order_quantity\""],
-        tracking_issue: "https://github.com/ymm-oss/fsl/issues/690",
+        tracking_issue: "https://github.com/ymm-oss/fsl/issues/798",
     },
 ];
 

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -221,14 +221,13 @@ struct KnownDivergence {
 /// chat, a review transcript, or agent memory").
 ///
 /// **#798** <https://github.com/ymm-oss/fsl/issues/798> tracks the two
-/// remaining symptoms caused by `domain.rs`'s `Context::normalize`
-/// (`rust/fsl-core/src/domain.rs:301`), a chain of `str::replace` calls
-/// over rendered text with no syntax tree, so it cannot be scope-aware
-/// (entry 2's `quantity` shadowing) or precedence-aware (entry 2's
-/// `can(...)` expansion) the way a typed AST composition can. #690 fixed the
-/// precedence symptom; entry 1's
-/// generated-name leak is a symptom of the same string-level substitution
-/// having no notion of what is and is not a legal domain-level reference.
+/// remaining symptoms: the generated-name leak (entry 1) and the
+/// scope-insensitive `quantity` shadowing (entry 2). They arise from
+/// `domain.rs`'s `Context::normalize` (`rust/fsl-core/src/domain.rs:301`), a
+/// chain of `str::replace` calls over rendered text with no syntax tree, so it
+/// cannot distinguish legal domain-level references or respect lexical scope
+/// the way a typed AST composition can. Separately, #690 fixed the
+/// `can(...)` precedence symptom by parenthesizing each joined piece.
 ///
 /// **#691** <https://github.com/ymm-oss/fsl/issues/691> covered a third,
 /// now-resolved entry (`lvalues_surface.fsl`, a `Map<K, V>` domain state

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -223,7 +223,7 @@ struct KnownDivergence {
 /// **#798** <https://github.com/ymm-oss/fsl/issues/798> tracks the two
 /// remaining symptoms: the generated-name leak (entry 1) and the
 /// scope-insensitive `quantity` shadowing (entry 2). They arise from
-/// `domain.rs`'s `Context::normalize` (`rust/fsl-core/src/domain.rs:301`), a
+/// `domain.rs`'s `Context::normalize`, a
 /// chain of `str::replace` calls over rendered text with no syntax tree, so it
 /// cannot distinguish legal domain-level references or respect lexical scope
 /// the way a typed AST composition can. Separately, #690 fixed the
@@ -285,8 +285,8 @@ struct KnownDivergence {
 ///    Before #690's fix, this fixture's
 ///    `invariant legacyImplication { status == Cancelled -> not can(Cancel) }`
 ///    also disagreed at the projected `and`/`or` operator shape:
-///    `domain.rs`'s `can(...)` expansion (path B, `Context::normalize`
-///    around line 328) joined the requires/rejects pieces with literal
+///    `domain.rs`'s `can(...)` expansion (path B, `Context::normalize`) joined
+///    the requires/rejects pieces with literal
 ///    `" and "` without individually parenthesizing each piece, so the
 ///    rendered text read
 ///    `status == Draft or status == Approved and not (status == Cancelled)`

--- a/rust/fslc/Cargo.toml
+++ b/rust/fslc/Cargo.toml
@@ -41,6 +41,7 @@ sha2.workspace = true
 
 [dev-dependencies]
 jsonschema = { version = "0.48.0", default-features = false }
+libc = "0.2"
 
 [lints]
 workspace = true

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5918,9 +5918,11 @@ fn apply_domain_edition(
     (output, status)
 }
 
-fn parse_surface_document(path: &Path) -> Result<fsl_syntax::SurfaceDocument, String> {
-    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
-    fsl_syntax::parse_surface_document(&source).map_err(|error| {
+fn parse_surface_document_from_source(
+    path: &Path,
+    source: &str,
+) -> Result<fsl_syntax::SurfaceDocument, String> {
+    fsl_syntax::parse_surface_document(source).map_err(|error| {
         format!(
             "{} at {}:{}:{}",
             error.message,
@@ -5929,6 +5931,11 @@ fn parse_surface_document(path: &Path) -> Result<fsl_syntax::SurfaceDocument, St
             error.span.start.column
         )
     })
+}
+
+fn parse_surface_document(path: &Path) -> Result<fsl_syntax::SurfaceDocument, String> {
+    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    parse_surface_document_from_source(path, &source)
 }
 
 fn validate_specialized_document(path: &Path) -> Result<(), String> {
@@ -6740,10 +6747,29 @@ fn ai_compat_profile_block(profile: &Value) -> String {
 }
 
 fn parse_domain_document(path: &Path) -> Result<fsl_syntax::DomainSpec, String> {
-    match parse_surface_document(path)? {
+    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    parse_domain_document_from_source(path, &source)
+}
+
+fn parse_domain_document_from_source(
+    path: &Path,
+    source: &str,
+) -> Result<fsl_syntax::DomainSpec, String> {
+    match parse_surface_document_from_source(path, source)? {
         fsl_syntax::SurfaceDocument::Domain(domain) => Ok(domain),
         _ => Err("expected a domain document".to_owned()),
     }
+}
+
+/// Capture the one source snapshot that a domain projection command may use.
+///
+/// The AST projected by `domain analyze` / `domain expand` and the checked
+/// Kernel validation must originate from this same string. Re-reading `path`
+/// after parsing would permit an atomic save to validate different content.
+fn read_domain_command_input(path: &Path) -> Result<(String, fsl_syntax::DomainSpec), String> {
+    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    let domain = parse_domain_document_from_source(path, &source)?;
+    Ok((source, domain))
 }
 
 fn domain_scaffold_inputs(
@@ -6769,8 +6795,8 @@ fn domain_scaffold_inputs(
 /// `domain analyze` and `domain expand` still consume their specialized
 /// projections below, but must never return success for a document direct
 /// lowering rejects (#796).
-fn validate_domain_command_input(path: &Path) -> Result<(), (Value, i32)> {
-    load_kernel_model(path)
+fn validate_domain_command_input(path: &Path, source: &str) -> Result<(), (Value, i32)> {
+    load_kernel_model_from_source(path, source)
         .map(|_| ())
         .map_err(|error| (spec_load_error_output(&error), 2))
 }
@@ -6822,13 +6848,13 @@ fn run_domain_check(
 }
 
 fn run_domain_analyze(path: &Path) -> (Value, i32) {
-    match parse_domain_document(path) {
+    match read_domain_command_input(path) {
         // Preserve #726's renderer-side fail-closed guard and its established
         // diagnostics first. A successful raw-`DomainSpec` projection must
         // then also clear the checked direct-lowering path before it can be
         // returned (#796).
-        Ok(domain) => match fsl_tools::analyze_domain(&domain) {
-            Ok(result) => match validate_domain_command_input(path) {
+        Ok((source, domain)) => match fsl_tools::analyze_domain(&domain) {
+            Ok(result) => match validate_domain_command_input(path, &source) {
                 Ok(()) => wrap_specialized(result),
                 Err(error) => error,
             },
@@ -6839,15 +6865,15 @@ fn run_domain_analyze(path: &Path) -> (Value, i32) {
 }
 
 fn run_domain_expand(path: &Path, output_path: Option<&Path>) -> (Value, i32) {
-    let domain = match parse_domain_document(path) {
-        Ok(domain) => domain,
+    let (input_source, domain) = match read_domain_command_input(path) {
+        Ok(input) => input,
         Err(error) => return (semantic_error_output(&error), 2),
     };
     let source = match fsl_tools::domain_kernel_source(&domain) {
         Ok(source) => source,
         Err(error) => return (core_error_output(&error), 2),
     };
-    if let Err(error) = validate_domain_command_input(path) {
+    if let Err(error) = validate_domain_command_input(path, &input_source) {
         return error;
     }
     if let Some(output_path) = output_path
@@ -15560,16 +15586,29 @@ fn load_model(path: &Path) -> Result<KernelModel, SpecLoadError> {
 
 fn load_kernel_model(path: &Path) -> Result<(String, KernelSpec, KernelModel), SpecLoadError> {
     let source = read_spec_source(path)?;
+    let (kernel, model) = load_kernel_model_from_source(path, &source)?;
+    Ok((source, kernel, model))
+}
+
+/// Build a checked Kernel/model from a caller-owned source snapshot.
+///
+/// `load_kernel_model` remains the path-reading compatibility entry point;
+/// callers that also need a specialized surface projection must use this
+/// variant to avoid a second filesystem read.
+fn load_kernel_model_from_source(
+    path: &Path,
+    source: &str,
+) -> Result<(KernelSpec, KernelModel), SpecLoadError> {
     let base = path.parent().unwrap_or_else(|| Path::new("."));
     let resolver = fsl_core::FsResolver::new(base);
     let kernel =
-        match fsl_core::parse_kernel_source_with_file(&source, &resolver, path.to_string_lossy()) {
+        match fsl_core::parse_kernel_source_with_file(source, &resolver, path.to_string_lossy()) {
             Ok(kernel) => kernel,
-            Err(error) => return Err(kernel_load_error(&source, &error)),
+            Err(error) => return Err(kernel_load_error(source, &error)),
         };
     let model = fsl_core::build_model(kernel.clone())
         .map_err(|error| SpecLoadError::Semantic(SemanticDiagnostic::from_model_error(&error)))?;
-    Ok((source, kernel, model))
+    Ok((kernel, model))
 }
 
 /// Read a spec file, classifying a read failure as `io` rather than letting the
@@ -16111,5 +16150,48 @@ spec InitTraceability {
             assert!(nodes.contains(edge["from"].as_str().unwrap()));
             assert!(nodes.contains(edge["to"].as_str().unwrap()));
         }
+    }
+
+    /// Deterministic TOCTOU control for #796. The first read captures an
+    /// authored-invalid domain, then an atomic rename replaces the path with
+    /// a valid document. Both specialized projections can still complete from
+    /// the original AST, but their checked Kernel validation must reject the
+    /// original snapshot. Reverting validation to `load_kernel_model(path)`
+    /// makes this test fail because that second read accepts the replacement.
+    #[test]
+    fn domain_projection_validation_uses_the_original_source_snapshot() {
+        let directory =
+            std::env::temp_dir().join(format!("fslc-domain-snapshot-{}", std::process::id()));
+        std::fs::create_dir_all(&directory).expect("create temporary fixture directory");
+        let path = directory.join("domain.fsl");
+        let replacement = directory.join("replacement.fsl");
+        std::fs::write(
+            &path,
+            include_str!("../tests/fixtures/domain_characterization/invalid_unknown_name.fsl"),
+        )
+        .expect("write invalid source");
+        std::fs::write(
+            &replacement,
+            include_str!("../tests/fixtures/domain_characterization/expressions_valid.fsl"),
+        )
+        .expect("write valid replacement");
+
+        let (source, domain) = read_domain_command_input(&path).expect("capture invalid snapshot");
+        std::fs::rename(&replacement, &path).expect("atomically replace input after first read");
+
+        assert!(
+            fsl_tools::analyze_domain(&domain).is_ok(),
+            "the specialized analysis must reach the checked validation"
+        );
+        assert!(
+            fsl_tools::domain_kernel_source(&domain).is_ok(),
+            "the specialized expansion must reach the checked validation"
+        );
+        assert!(
+            validate_domain_command_input(&path, &source).is_err(),
+            "validation must use the initially-read invalid source, not its valid replacement"
+        );
+
+        std::fs::remove_dir_all(&directory).expect("remove temporary fixture directory");
     }
 }

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6763,6 +6763,18 @@ fn domain_scaffold_inputs(
     Ok((contract, fsl_tools::domain_scaffold_metadata(domain)))
 }
 
+/// Validate a domain command's source through the checked Kernel path shared
+/// by `check`, `verify`, and `domain generate`.
+///
+/// `domain analyze` and `domain expand` still consume their specialized
+/// projections below, but must never return success for a document direct
+/// lowering rejects (#796).
+fn validate_domain_command_input(path: &Path) -> Result<(), (Value, i32)> {
+    load_kernel_model(path)
+        .map(|_| ())
+        .map_err(|error| (spec_load_error_output(&error), 2))
+}
+
 fn snake_case(value: &str) -> String {
     let characters = value.chars().collect::<Vec<_>>();
     let mut output = String::new();
@@ -6811,12 +6823,15 @@ fn run_domain_check(
 
 fn run_domain_analyze(path: &Path) -> (Value, i32) {
     match parse_domain_document(path) {
-        // Issue #726: `fsl_tools::analyze_domain` itself is now fail-closed
-        // (it routes through the same lowerable-construct guard
-        // `check`/`domain expand` reach via `domain_kernel_source`), so this
-        // call site no longer needs its own guard call.
+        // Preserve #726's renderer-side fail-closed guard and its established
+        // diagnostics first. A successful raw-`DomainSpec` projection must
+        // then also clear the checked direct-lowering path before it can be
+        // returned (#796).
         Ok(domain) => match fsl_tools::analyze_domain(&domain) {
-            Ok(result) => wrap_specialized(result),
+            Ok(result) => match validate_domain_command_input(path) {
+                Ok(()) => wrap_specialized(result),
+                Err(error) => error,
+            },
             Err(error) => (core_error_output(&error), 2),
         },
         Err(error) => (semantic_error_output(&error), 2),
@@ -6832,6 +6847,9 @@ fn run_domain_expand(path: &Path, output_path: Option<&Path>) -> (Value, i32) {
         Ok(source) => source,
         Err(error) => return (core_error_output(&error), 2),
     };
+    if let Err(error) = validate_domain_command_input(path) {
+        return error;
+    }
     if let Some(output_path) = output_path
         && let Err(error) = std::fs::write(output_path, &source)
     {

--- a/rust/fslc/tests/error_envelope_parity.rs
+++ b/rust/fslc/tests/error_envelope_parity.rs
@@ -716,10 +716,6 @@ struct JsonExpectation {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum Expectation {
     Json(JsonExpectation),
-    Text {
-        exit: i32,
-        exact_stdout: &'static str,
-    },
 }
 
 const PARSE_JSON: JsonExpectation = JsonExpectation {
@@ -790,46 +786,6 @@ const LITERATE_UNIFORM: Expectation = Expectation::Json(JsonExpectation {
     dialect: ExpectedField::Absent,
     message: MessageExpectation::MentionsInput,
 });
-
-/// #796 pins a product false negative: an invalid spec exits 0 and is accepted.
-/// This is a soundness defect, not an endorsed behavior; the pin detects
-/// regressions or changes until the first follow-up queue item, #796, fixes it.
-/// It may share a root with `KNOWN_DIVERGENT_DOMAIN_FIXTURES` entry 1 (#690):
-/// #690 is closed, but its symptom 2 divergence remained live when measured
-/// on 2026-08-13 and is now tracked by open #798.
-const ANALYZED_NAME_FALSE_GREEN: Expectation = Expectation::Json(JsonExpectation {
-    result: ExpectedField::Exact("analyzed"),
-    kind: ExpectedField::Absent,
-    location: LocationShape::Absent,
-    diagnostic: Diagnostic::None,
-    exit: 0,
-    dialect: ExpectedField::Exact("fsl-domain-effect.v0"),
-    message: MessageExpectation::Absent,
-});
-
-/// See [`ANALYZED_NAME_FALSE_GREEN`]: this is the same #796 false-negative
-/// soundness defect and is pinned solely to detect change, not to approve it.
-const EXPANDED_NAME_FALSE_GREEN: Expectation = Expectation::Text {
-    exit: 0,
-    exact_stdout: r#"spec InvalidUnknownName "domain: generated from fsl-domain/fsl-effect" {
-  enum Status { Status_Draft, Status_Approved }
-  state {
-    order_status: Status,
-    event_Touched: Bool,
-  }
-  init {
-    order_status = Status_Draft
-    event_Touched = false
-  }
-  action order_touch() {
-    event_Touched = true
-    order_status = order_status
-  }
-  invariant Order_unknownName "DOMAIN-INVARIANT: Order.unknownName" { missing_status == Status_Draft }
-  terminal { false }
-}
-"#,
-};
 
 const CAUSAL_PARSE_WITHOUT_DIAGNOSTIC: Expectation = Expectation::Json(JsonExpectation {
     diagnostic: Diagnostic::None,
@@ -1815,20 +1771,6 @@ const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
     ),
     pin!(
         FailureClass::Name,
-        "domain analyze",
-        NAME_FIXTURE,
-        ANALYZED_NAME_FALSE_GREEN,
-        "#796"
-    ),
-    pin!(
-        FailureClass::Name,
-        "domain expand",
-        NAME_FIXTURE,
-        EXPANDED_NAME_FALSE_GREEN,
-        "#796"
-    ),
-    pin!(
-        FailureClass::Name,
         "domain generate",
         NAME_FIXTURE,
         SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
@@ -2550,9 +2492,6 @@ fn run(command: &str, fixture: &str) -> Actual {
 
 fn matches_expectation(actual: &Actual, expected: Expectation, fixture: &str) -> bool {
     match expected {
-        Expectation::Text { exit, exact_stdout } => {
-            actual.exit == exit && actual.json.is_none() && actual.stdout == exact_stdout
-        }
         Expectation::Json(expected) => {
             if actual.exit != expected.exit {
                 return false;
@@ -3022,7 +2961,7 @@ fn approval_diff_zero_digest_negative_control_stops_before_the_diff() {
 }
 
 #[test]
-fn name_matrix_keeps_five_uniform_countercontrols_and_three_pins() {
+fn name_matrix_keeps_seven_uniform_countercontrols_and_one_pin() {
     let bounded_commands = [
         "check",
         "verify",
@@ -3053,11 +2992,11 @@ fn name_matrix_keeps_five_uniform_countercontrols_and_three_pins() {
         8,
         "Name matrix must keep eight countercontrols"
     );
-    assert_eq!(pinned, 3, "Name matrix must keep three self-retiring pins");
+    assert_eq!(pinned, 1, "Name matrix must keep one self-retiring pin");
     assert_eq!(
         name_cells.len() - pinned,
-        5,
-        "Name matrix must keep five uniform countercontrols"
+        7,
+        "Name matrix must keep seven uniform countercontrols"
     );
 }
 

--- a/rust/fslc/tests/issue_796_domain_command_validation.rs
+++ b/rust/fslc/tests/issue_796_domain_command_validation.rs
@@ -51,7 +51,7 @@ fn run_text(args: &[&str]) -> (String, i32) {
 }
 
 #[cfg(unix)]
-fn fifo_path() -> PathBuf {
+fn fifo_fixture_directory() -> PathBuf {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     static NEXT_FIFO: AtomicUsize = AtomicUsize::new(0);
@@ -66,97 +66,252 @@ fn fifo_path() -> PathBuf {
         NEXT_FIFO.fetch_add(1, Ordering::Relaxed),
     ));
     std::fs::create_dir(&directory).expect("create FIFO fixture directory");
-    directory.join("domain.fsl")
+    directory
 }
 
-/// Runs a command against a FIFO that serves a rejecting domain source on its
-/// first open and an accepting source on its second open.
-///
-/// The writer's second open blocks until a reader exists. Thus the CLI either
-/// validates the first source snapshot and exits before that open (the fixed
-/// behavior), or it performs a second path read and necessarily consumes the
-/// accepting replacement (the pre-fix mutant). No scheduling delay is used.
 #[cfg(unix)]
-fn run_against_two_snapshot_fifo(command: &str) -> (String, i32) {
-    use std::io::{Read, Write};
-    use std::sync::mpsc;
-
-    let fifo = fifo_path();
+fn create_fifo(path: &Path) {
     let status = Command::new("mkfifo")
-        .arg(&fifo)
+        .arg(path)
         .status()
         .expect("run mkfifo");
     assert!(status.success(), "mkfifo failed with {status}");
+}
 
-    let invalid =
-        include_str!("fixtures/domain_characterization/invalid_unknown_name.fsl").to_owned();
-    let valid = include_str!("fixtures/domain_characterization/expressions_valid.fsl").to_owned();
-    let writer_fifo = fifo.clone();
-    let (second_opened, second_opened_receiver) = mpsc::channel();
-    let writer = std::thread::spawn(move || {
-        let mut first = std::fs::OpenOptions::new()
-            .write(true)
-            .open(&writer_fifo)
-            .expect("open FIFO for invalid source");
-        first
-            .write_all(invalid.as_bytes())
-            .expect("write invalid source");
-        drop(first);
+/// A two-inode FIFO fixture that proves a command's source-read count.
+///
+/// The writer atomically replaces the path with a second FIFO *before* closing
+/// the writer on the first FIFO. The command's initial reader is consequently
+/// still connected to the old inode and must observe its EOF. Only a later
+/// path open can reach the replacement FIFO, so the two sources cannot be
+/// concatenated by scheduling.
+#[cfg(unix)]
+struct TwoSnapshotFifo {
+    directory: PathBuf,
+    fifo: PathBuf,
+    second_opened: std::sync::mpsc::Receiver<()>,
+    phase: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    writer: Option<std::thread::JoinHandle<()>>,
+    second_writer_opened: bool,
+}
 
-        let mut second = std::fs::OpenOptions::new()
-            .write(true)
-            .open(&writer_fifo)
-            .expect("open FIFO for valid source");
-        // A second CLI read cannot finish until this signal has been sent, so
-        // `try_recv` below distinguishes the mutant without a timing race.
-        second_opened
-            .send(())
-            .expect("test must retain second-open receiver");
-        second
-            .write_all(valid.as_bytes())
-            .expect("write valid source");
-    });
+#[cfg(unix)]
+impl TwoSnapshotFifo {
+    const FIRST_WRITER_OPENING: usize = 1;
+    const REPLACED: usize = 2;
+    const SECOND_WRITER_OPENING: usize = 3;
 
-    let fifo_argument = fifo.to_string_lossy().into_owned();
-    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
-        .args(["domain", command, &fifo_argument])
-        .current_dir(root())
-        .output()
-        .expect("run native fslc against FIFO");
+    fn new() -> Self {
+        use std::io::Write;
+        use std::sync::atomic::Ordering;
+        use std::sync::{Arc, mpsc};
 
-    match second_opened_receiver.try_recv() {
-        Ok(()) => {
-            writer.join().expect("join second FIFO writer");
-        }
-        Err(mpsc::TryRecvError::Empty) => {
-            // The fixed command has no second read. Open once solely to drain
-            // and join the intentionally blocked writer; this is after the
-            // CLI has exited and cannot affect its observed input.
-            let mut drain = std::fs::OpenOptions::new()
-                .read(true)
-                .open(&fifo)
-                .expect("open FIFO to drain unused valid source");
-            let mut valid_source = String::new();
-            drain
-                .read_to_string(&mut valid_source)
-                .expect("drain unused valid source");
-            assert!(
-                valid_source.starts_with("domain "),
-                "cleanup must receive the valid second source"
-            );
-            writer.join().expect("join FIFO writer");
-        }
-        Err(mpsc::TryRecvError::Disconnected) => {
-            panic!("FIFO writer stopped before opening the valid source");
+        let directory = fifo_fixture_directory();
+        let fifo = directory.join("domain.fsl");
+        let replacement = directory.join("domain-replacement.fsl");
+        create_fifo(&fifo);
+        create_fifo(&replacement);
+
+        let invalid =
+            include_str!("fixtures/domain_characterization/invalid_unknown_name.fsl").to_owned();
+        let valid =
+            include_str!("fixtures/domain_characterization/expressions_valid.fsl").to_owned();
+        let writer_fifo = fifo.clone();
+        let phase = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let writer_phase = Arc::clone(&phase);
+        let (second_opened, second_opened_receiver) = mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            writer_phase.store(Self::FIRST_WRITER_OPENING, Ordering::SeqCst);
+            let mut first = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&writer_fifo)
+                .expect("open first FIFO for invalid source");
+            first
+                .write_all(invalid.as_bytes())
+                .expect("write invalid source");
+
+            // `rename` replaces the directory entry, while `first` remains
+            // connected to the old FIFO inode until this explicit drop.
+            std::fs::rename(&replacement, &writer_fifo).expect("replace FIFO path");
+            writer_phase.store(Self::REPLACED, Ordering::SeqCst);
+            drop(first);
+
+            writer_phase.store(Self::SECOND_WRITER_OPENING, Ordering::SeqCst);
+            let mut second = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&writer_fifo)
+                .expect("open replacement FIFO for valid source");
+            second_opened
+                .send(())
+                .expect("test must retain second-open receiver");
+            second
+                .write_all(valid.as_bytes())
+                .expect("write valid source");
+        });
+
+        Self {
+            directory,
+            fifo,
+            second_opened: second_opened_receiver,
+            phase,
+            writer: Some(writer),
+            second_writer_opened: false,
         }
     }
 
-    std::fs::remove_file(&fifo).expect("remove FIFO");
-    std::fs::remove_dir(
-        fifo.parent()
-            .expect("FIFO fixture must have a parent directory"),
-    )
-    .expect("remove FIFO fixture directory");
+    fn assert_no_second_open(&mut self) {
+        use std::sync::mpsc::TryRecvError;
+
+        match self.second_opened.try_recv() {
+            Err(TryRecvError::Empty) => {}
+            Ok(()) => {
+                self.second_writer_opened = true;
+                panic!("the CLI opened the replacement FIFO, proving a second path read");
+            }
+            Err(TryRecvError::Disconnected) => {
+                panic!("FIFO writer stopped before opening the replacement source");
+            }
+        }
+    }
+
+    fn drain_current_fifo(&self) -> std::io::Result<()> {
+        use std::io::Read;
+
+        let mut reader = std::fs::OpenOptions::new().read(true).open(&self.fifo)?;
+        let mut source = String::new();
+        reader.read_to_string(&mut source)?;
+        Ok(())
+    }
+
+    fn release_writer(&mut self) {
+        use std::sync::atomic::Ordering;
+
+        let Some(writer) = self.writer.take() else {
+            return;
+        };
+
+        if !self.second_writer_opened {
+            // A timed-out multi-read mutant may already have consumed and
+            // closed the replacement source. Do not open a FIFO reader with
+            // no writer in that case.
+            if self.second_opened.try_recv().is_ok() {
+                self.second_writer_opened = true;
+            }
+            // This only releases test-owned blocked writers after the child
+            // exits. It does not contribute evidence about the child's reads.
+            if !self.second_writer_opened && self.phase.load(Ordering::SeqCst) < Self::REPLACED {
+                self.drain_current_fifo()
+                    .expect("drain first FIFO during cleanup");
+                if self.second_opened.try_recv().is_ok() {
+                    self.second_writer_opened = true;
+                }
+            }
+            if !self.second_writer_opened {
+                self.drain_current_fifo()
+                    .expect("drain replacement FIFO during cleanup");
+                self.second_writer_opened = true;
+            }
+        }
+
+        writer.join().expect("join FIFO writer");
+    }
+}
+
+#[cfg(unix)]
+impl Drop for TwoSnapshotFifo {
+    fn drop(&mut self) {
+        // This runs during assertion unwinding as well, so the fixture cannot
+        // leave FIFOs behind merely because a check failed.
+        if self.writer.is_some() {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                self.release_writer();
+            }));
+        }
+        let _ = std::fs::remove_file(&self.fifo);
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_output_with_timeout(
+    child: &mut std::process::Child,
+    timeout: std::time::Duration,
+) -> std::process::Output {
+    use std::io::Read;
+
+    let deadline = std::time::Instant::now() + timeout;
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("poll FIFO child") {
+            break status;
+        }
+        if std::time::Instant::now() >= deadline {
+            child.kill().expect("kill timed-out FIFO child");
+            let status = child.wait().expect("reap timed-out FIFO child");
+            let mut stdout = Vec::new();
+            let mut stderr = Vec::new();
+            child
+                .stdout
+                .take()
+                .expect("capture FIFO child stdout")
+                .read_to_end(&mut stdout)
+                .expect("read timed-out FIFO child stdout");
+            child
+                .stderr
+                .take()
+                .expect("capture FIFO child stderr")
+                .read_to_end(&mut stderr)
+                .expect("read timed-out FIFO child stderr");
+            panic!(
+                "fslc against FIFO timed out after {timeout:?}; status={status}; stdout={}; stderr={}",
+                String::from_utf8_lossy(&stdout),
+                String::from_utf8_lossy(&stderr)
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    };
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    child
+        .stdout
+        .take()
+        .expect("capture FIFO child stdout")
+        .read_to_end(&mut stdout)
+        .expect("read FIFO child stdout");
+    child
+        .stderr
+        .take()
+        .expect("capture FIFO child stderr")
+        .read_to_end(&mut stderr)
+        .expect("read FIFO child stderr");
+    std::process::Output {
+        status,
+        stdout,
+        stderr,
+    }
+}
+
+/// Runs a command against a rejecting FIFO inode, then makes a valid source
+/// available only through a replacement inode for an illegal second path read.
+#[cfg(unix)]
+fn run_against_two_snapshot_fifo(command: &str) -> (String, i32) {
+    use std::process::Stdio;
+
+    let mut fixture = TwoSnapshotFifo::new();
+    let fifo_argument = fixture.fifo.to_string_lossy().into_owned();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(["domain", command, &fifo_argument])
+        .current_dir(root())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn native fslc against FIFO");
+    let output = wait_for_output_with_timeout(&mut child, std::time::Duration::from_secs(5));
+
+    // This assertion occurs before fixture cleanup opens the replacement FIFO.
+    // Receiving here is therefore proof that the CLI itself opened it.
+    fixture.assert_no_second_open();
+    fixture.release_writer();
 
     (
         String::from_utf8(output.stdout).expect("UTF-8 stdout"),

--- a/rust/fslc/tests/issue_796_domain_command_validation.rs
+++ b/rust/fslc/tests/issue_796_domain_command_validation.rs
@@ -50,42 +50,27 @@ fn run_text(args: &[&str]) -> (String, i32) {
     )
 }
 
-fn diagnostic_reason(output: &Value) -> &str {
-    output["message"]
-        .as_str()
-        .expect("semantic diagnostic message")
-        .split_once(" at ")
-        .map_or_else(
-            || {
-                output["message"]
-                    .as_str()
-                    .expect("semantic diagnostic message")
-            },
-            |(reason, _)| reason,
-        )
-}
-
 fn assert_rejected_like_check(fixture: &str) {
     let (check, check_status) = run(&["check", fixture]);
     assert_eq!(check_status, 2, "check: {check:#}");
+    assert_eq!(check["result"], "error", "check: {check:#}");
     assert_eq!(check["kind"], "semantics", "check: {check:#}");
     assert!(check.get("loc").is_some(), "check: {check:#}");
-    let reason = diagnostic_reason(&check);
+    assert!(
+        check.get("diagnostic_code").is_none(),
+        "check unexpectedly has a diagnostic code: {check:#}"
+    );
 
     for command in [["domain", "analyze"], ["domain", "expand"]] {
         let (actual, status) = run(&[command[0], command[1], fixture]);
         assert_eq!(status, 2, "{command:?}: {actual:#}");
-        assert_eq!(actual["result"], "error", "{command:?}: {actual:#}");
-        assert_eq!(actual["kind"], "semantics", "{command:?}: {actual:#}");
-        assert_eq!(
-            diagnostic_reason(&actual),
-            reason,
-            "{command:?} must share check's semantic diagnostic reason: actual={actual:#}, check={check:#}"
-        );
-        assert_eq!(
-            actual["loc"], check["loc"],
-            "{command:?} must preserve check's source location: actual={actual:#}, check={check:#}"
-        );
+        for field in ["result", "kind", "message", "loc", "diagnostic_code"] {
+            assert_eq!(
+                actual.get(field),
+                check.get(field),
+                "{command:?} must exactly match check's {field} field: actual={actual:#}, check={check:#}"
+            );
+        }
     }
 }
 

--- a/rust/fslc/tests/issue_796_domain_command_validation.rs
+++ b/rust/fslc/tests/issue_796_domain_command_validation.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Cross-command validation controls for #796.
+//!
+//! `domain analyze` projects the domain AST and `domain expand` renders
+//! generated Kernel text, but neither may accept a source document that typed
+//! domain lowering rejects. In particular, renderer string normalization can
+//! leave an unknown authored identifier unchanged and previously produced a
+//! Kernel source that `fslc check` rejected. Both commands must instead return
+//! the same located semantic diagnostic as `check`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+fn run_text(args: &[&str]) -> (String, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root())
+        .output()
+        .expect("run native fslc");
+    (
+        String::from_utf8(output.stdout).expect("UTF-8 stdout"),
+        output.status.code().expect("exit status"),
+    )
+}
+
+fn diagnostic_reason(output: &Value) -> &str {
+    output["message"]
+        .as_str()
+        .expect("semantic diagnostic message")
+        .split_once(" at ")
+        .map_or_else(
+            || {
+                output["message"]
+                    .as_str()
+                    .expect("semantic diagnostic message")
+            },
+            |(reason, _)| reason,
+        )
+}
+
+fn assert_rejected_like_check(fixture: &str) {
+    let (check, check_status) = run(&["check", fixture]);
+    assert_eq!(check_status, 2, "check: {check:#}");
+    assert_eq!(check["kind"], "semantics", "check: {check:#}");
+    assert!(check.get("loc").is_some(), "check: {check:#}");
+    let reason = diagnostic_reason(&check);
+
+    for command in [["domain", "analyze"], ["domain", "expand"]] {
+        let (actual, status) = run(&[command[0], command[1], fixture]);
+        assert_eq!(status, 2, "{command:?}: {actual:#}");
+        assert_eq!(actual["result"], "error", "{command:?}: {actual:#}");
+        assert_eq!(actual["kind"], "semantics", "{command:?}: {actual:#}");
+        assert_eq!(
+            diagnostic_reason(&actual),
+            reason,
+            "{command:?} must share check's semantic diagnostic reason: actual={actual:#}, check={check:#}"
+        );
+        assert_eq!(
+            actual["loc"], check["loc"],
+            "{command:?} must preserve check's source location: actual={actual:#}, check={check:#}"
+        );
+    }
+}
+
+/// Rejecting control: before #796 both commands returned exit 0 for this
+/// unknown state reference, while `check` rejected it at the authored
+/// expression. Keeping all three envelopes aligned prevents either command
+/// from again producing a false-green analysis or an invalid Kernel export.
+#[test]
+fn domain_analyze_and_expand_reject_unknown_names_like_check() {
+    assert_rejected_like_check(
+        "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl",
+    );
+}
+
+/// `domain expand --output` must validate before writing: an invalid document
+/// cannot create a partial Kernel file or overwrite an existing one.
+#[test]
+fn domain_expand_rejection_does_not_write_output() {
+    let fixture = "rust/fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl";
+    let output_path = std::env::temp_dir().join(format!(
+        "fslc-issue-796-{}-expand-output.fsl",
+        std::process::id()
+    ));
+    std::fs::write(&output_path, "existing output").expect("write sentinel");
+    let output = output_path.to_string_lossy().into_owned();
+
+    let (actual, status) = run(&["domain", "expand", fixture, "--output", &output]);
+
+    assert_eq!(status, 2, "{actual:#}");
+    assert_eq!(actual["result"], "error", "{actual:#}");
+    assert_eq!(actual["kind"], "semantics", "{actual:#}");
+    assert_eq!(
+        std::fs::read_to_string(&output_path).expect("read sentinel"),
+        "existing output",
+        "domain expand overwrote output after validation failed: {actual:#}"
+    );
+    std::fs::remove_file(&output_path).expect("remove sentinel");
+}
+
+/// #798 is the sibling generated-name case: direct lowering rejects authored
+/// use of a generated enum member, but the renderer formerly left that already
+/// qualified text in place, making a falsely valid Kernel. The shared lowering
+/// validation rejects it before either command emits a success envelope.
+#[test]
+fn domain_analyze_and_expand_reject_generated_kernel_names_like_check() {
+    assert_rejected_like_check(
+        "rust/fslc/tests/fixtures/domain_characterization/ai_internal_name_misuse.fsl",
+    );
+}
+
+/// Accepting control: valid documents retain both the structural analysis and
+/// inspectable generated Kernel source paths after validation is introduced.
+#[test]
+fn domain_analyze_and_expand_still_accept_valid_domain_specs() {
+    let fixture = "examples/domain/order_fulfillment_saga.fsl";
+
+    let (analyze, analyze_status) = run(&["domain", "analyze", fixture]);
+    assert_eq!(analyze_status, 0, "{analyze:#}");
+    assert_eq!(analyze["result"], "analyzed");
+
+    let (expand, expand_status) = run_text(&["domain", "expand", fixture]);
+    assert_eq!(expand_status, 0, "{expand}");
+    assert!(
+        expand.starts_with("spec "),
+        "domain expand must keep emitting raw Kernel source: {expand}"
+    );
+}

--- a/rust/fslc/tests/issue_796_domain_command_validation.rs
+++ b/rust/fslc/tests/issue_796_domain_command_validation.rs
@@ -93,7 +93,6 @@ struct TwoSnapshotFifo {
     writer_outcome: std::sync::mpsc::Receiver<WriterOutcome>,
     phase: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     writer: Option<std::thread::JoinHandle<()>>,
-    second_writer_opened: bool,
 }
 
 #[cfg(unix)]
@@ -188,7 +187,6 @@ impl TwoSnapshotFifo {
             writer_outcome: writer_outcome_receiver,
             phase,
             writer: Some(writer),
-            second_writer_opened: false,
         }
     }
 
@@ -198,7 +196,6 @@ impl TwoSnapshotFifo {
         match self.second_opened.try_recv() {
             Err(TryRecvError::Empty) => {}
             Ok(()) => {
-                self.second_writer_opened = true;
                 panic!("the CLI opened the replacement FIFO, proving a second path read");
             }
             Err(TryRecvError::Disconnected) => {

--- a/rust/fslc/tests/issue_796_domain_command_validation.rs
+++ b/rust/fslc/tests/issue_796_domain_command_validation.rs
@@ -50,6 +50,120 @@ fn run_text(args: &[&str]) -> (String, i32) {
     )
 }
 
+#[cfg(unix)]
+fn fifo_path() -> PathBuf {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static NEXT_FIFO: AtomicUsize = AtomicUsize::new(0);
+
+    let directory = std::env::temp_dir().join(format!(
+        "fslc-issue-796-fifo-{}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after Unix epoch")
+            .as_nanos(),
+        NEXT_FIFO.fetch_add(1, Ordering::Relaxed),
+    ));
+    std::fs::create_dir(&directory).expect("create FIFO fixture directory");
+    directory.join("domain.fsl")
+}
+
+/// Runs a command against a FIFO that serves a rejecting domain source on its
+/// first open and an accepting source on its second open.
+///
+/// The writer's second open blocks until a reader exists. Thus the CLI either
+/// validates the first source snapshot and exits before that open (the fixed
+/// behavior), or it performs a second path read and necessarily consumes the
+/// accepting replacement (the pre-fix mutant). No scheduling delay is used.
+#[cfg(unix)]
+fn run_against_two_snapshot_fifo(command: &str) -> (String, i32) {
+    use std::io::{Read, Write};
+    use std::sync::mpsc;
+
+    let fifo = fifo_path();
+    let status = Command::new("mkfifo")
+        .arg(&fifo)
+        .status()
+        .expect("run mkfifo");
+    assert!(status.success(), "mkfifo failed with {status}");
+
+    let invalid =
+        include_str!("fixtures/domain_characterization/invalid_unknown_name.fsl").to_owned();
+    let valid = include_str!("fixtures/domain_characterization/expressions_valid.fsl").to_owned();
+    let writer_fifo = fifo.clone();
+    let (second_opened, second_opened_receiver) = mpsc::channel();
+    let writer = std::thread::spawn(move || {
+        let mut first = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&writer_fifo)
+            .expect("open FIFO for invalid source");
+        first
+            .write_all(invalid.as_bytes())
+            .expect("write invalid source");
+        drop(first);
+
+        let mut second = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&writer_fifo)
+            .expect("open FIFO for valid source");
+        // A second CLI read cannot finish until this signal has been sent, so
+        // `try_recv` below distinguishes the mutant without a timing race.
+        second_opened
+            .send(())
+            .expect("test must retain second-open receiver");
+        second
+            .write_all(valid.as_bytes())
+            .expect("write valid source");
+    });
+
+    let fifo_argument = fifo.to_string_lossy().into_owned();
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(["domain", command, &fifo_argument])
+        .current_dir(root())
+        .output()
+        .expect("run native fslc against FIFO");
+
+    match second_opened_receiver.try_recv() {
+        Ok(()) => {
+            writer.join().expect("join second FIFO writer");
+        }
+        Err(mpsc::TryRecvError::Empty) => {
+            // The fixed command has no second read. Open once solely to drain
+            // and join the intentionally blocked writer; this is after the
+            // CLI has exited and cannot affect its observed input.
+            let mut drain = std::fs::OpenOptions::new()
+                .read(true)
+                .open(&fifo)
+                .expect("open FIFO to drain unused valid source");
+            let mut valid_source = String::new();
+            drain
+                .read_to_string(&mut valid_source)
+                .expect("drain unused valid source");
+            assert!(
+                valid_source.starts_with("domain "),
+                "cleanup must receive the valid second source"
+            );
+            writer.join().expect("join FIFO writer");
+        }
+        Err(mpsc::TryRecvError::Disconnected) => {
+            panic!("FIFO writer stopped before opening the valid source");
+        }
+    }
+
+    std::fs::remove_file(&fifo).expect("remove FIFO");
+    std::fs::remove_dir(
+        fifo.parent()
+            .expect("FIFO fixture must have a parent directory"),
+    )
+    .expect("remove FIFO fixture directory");
+
+    (
+        String::from_utf8(output.stdout).expect("UTF-8 stdout"),
+        output.status.code().expect("exit status"),
+    )
+}
+
 fn assert_rejected_like_check(fixture: &str) {
     let (check, check_status) = run(&["check", fixture]);
     assert_eq!(check_status, 2, "check: {check:#}");
@@ -137,4 +251,42 @@ fn domain_analyze_and_expand_still_accept_valid_domain_specs() {
         expand.starts_with("spec "),
         "domain expand must keep emitting raw Kernel source: {expand}"
     );
+}
+
+/// Deterministic external TOCTOU control for both #796 commands. A FIFO
+/// observes filesystem reads directly: the fixed implementation reads it
+/// once, so the first authored-invalid source must produce exit 2. Restoring
+/// `validate_domain_command_input` to `load_kernel_model(path)` performs the
+/// second read, receives the valid source, and makes this test fail.
+///
+/// This control is Unix-only because Windows has no FIFO equivalent. The
+/// non-Unix test below deliberately names that absence, so a Windows green
+/// result is not evidence that the FIFO read-count regression ran there.
+#[cfg(unix)]
+#[test]
+fn domain_commands_validate_their_single_fifo_source_snapshot() {
+    for command in ["analyze", "expand"] {
+        let (stdout, status) = run_against_two_snapshot_fifo(command);
+        assert_eq!(
+            status, 2,
+            "domain {command} must reject its first invalid FIFO snapshot; stdout={stdout}"
+        );
+        assert!(
+            !stdout.starts_with("spec "),
+            "domain {command} must not emit a Kernel for a rejected FIFO snapshot: {stdout}"
+        );
+        let output: Value =
+            serde_json::from_str(&stdout).expect("rejected command must retain its JSON envelope");
+        assert_eq!(output["result"], "error", "domain {command}: {output:#}");
+        assert_eq!(output["kind"], "semantics", "domain {command}: {output:#}");
+    }
+}
+
+/// Windows does not implement the FIFO read-count control above. This passing
+/// marker makes the platform exclusion visible in filtered test output; it
+/// does not claim the Unix TOCTOU control ran on this target.
+#[cfg(not(unix))]
+#[test]
+fn fifo_source_snapshot_control_is_unavailable_on_non_unix() {
+    assert!(cfg!(not(unix)));
 }

--- a/rust/fslc/tests/issue_796_domain_command_validation.rs
+++ b/rust/fslc/tests/issue_796_domain_command_validation.rs
@@ -90,9 +90,24 @@ struct TwoSnapshotFifo {
     directory: PathBuf,
     fifo: PathBuf,
     second_opened: std::sync::mpsc::Receiver<()>,
+    writer_outcome: std::sync::mpsc::Receiver<WriterOutcome>,
     phase: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     writer: Option<std::thread::JoinHandle<()>>,
     second_writer_opened: bool,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Eq, PartialEq)]
+enum WriterOutcome {
+    Finished,
+    Panicked,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy)]
+enum WriterMode {
+    Normal,
+    PanicBeforeRename,
 }
 
 #[cfg(unix)]
@@ -100,8 +115,13 @@ impl TwoSnapshotFifo {
     const FIRST_WRITER_OPENING: usize = 1;
     const REPLACED: usize = 2;
     const SECOND_WRITER_OPENING: usize = 3;
+    const CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
     fn new() -> Self {
+        Self::new_with_writer_mode(WriterMode::Normal)
+    }
+
+    fn new_with_writer_mode(mode: WriterMode) -> Self {
         use std::io::Write;
         use std::sync::atomic::Ordering;
         use std::sync::{Arc, mpsc};
@@ -120,39 +140,52 @@ impl TwoSnapshotFifo {
         let phase = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let writer_phase = Arc::clone(&phase);
         let (second_opened, second_opened_receiver) = mpsc::channel();
+        let (writer_outcome, writer_outcome_receiver) = mpsc::channel();
         let writer = std::thread::spawn(move || {
-            writer_phase.store(Self::FIRST_WRITER_OPENING, Ordering::SeqCst);
-            let mut first = std::fs::OpenOptions::new()
-                .write(true)
-                .open(&writer_fifo)
-                .expect("open first FIFO for invalid source");
-            first
-                .write_all(invalid.as_bytes())
-                .expect("write invalid source");
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                writer_phase.store(Self::FIRST_WRITER_OPENING, Ordering::SeqCst);
+                let mut first = std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&writer_fifo)
+                    .expect("open first FIFO for invalid source");
+                first
+                    .write_all(invalid.as_bytes())
+                    .expect("write invalid source");
+                if matches!(mode, WriterMode::PanicBeforeRename) {
+                    panic!("intentional FIFO writer panic before rename");
+                }
 
-            // `rename` replaces the directory entry, while `first` remains
-            // connected to the old FIFO inode until this explicit drop.
-            std::fs::rename(&replacement, &writer_fifo).expect("replace FIFO path");
-            writer_phase.store(Self::REPLACED, Ordering::SeqCst);
-            drop(first);
+                // `rename` replaces the directory entry, while `first` remains
+                // connected to the old FIFO inode until this explicit drop.
+                std::fs::rename(&replacement, &writer_fifo).expect("replace FIFO path");
+                writer_phase.store(Self::REPLACED, Ordering::SeqCst);
+                drop(first);
 
-            writer_phase.store(Self::SECOND_WRITER_OPENING, Ordering::SeqCst);
-            let mut second = std::fs::OpenOptions::new()
-                .write(true)
-                .open(&writer_fifo)
-                .expect("open replacement FIFO for valid source");
-            second_opened
-                .send(())
-                .expect("test must retain second-open receiver");
-            second
-                .write_all(valid.as_bytes())
-                .expect("write valid source");
+                writer_phase.store(Self::SECOND_WRITER_OPENING, Ordering::SeqCst);
+                let mut second = std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&writer_fifo)
+                    .expect("open replacement FIFO for valid source");
+                second_opened
+                    .send(())
+                    .expect("test must retain second-open receiver");
+                second
+                    .write_all(valid.as_bytes())
+                    .expect("write valid source");
+            }));
+            let outcome = if result.is_ok() {
+                WriterOutcome::Finished
+            } else {
+                WriterOutcome::Panicked
+            };
+            let _ = writer_outcome.send(outcome);
         });
 
         Self {
             directory,
             fifo,
             second_opened: second_opened_receiver,
+            writer_outcome: writer_outcome_receiver,
             phase,
             writer: Some(writer),
             second_writer_opened: false,
@@ -174,46 +207,86 @@ impl TwoSnapshotFifo {
         }
     }
 
-    fn drain_current_fifo(&self) -> std::io::Result<()> {
-        use std::io::Read;
+    fn open_nonblocking_control_fifo(&self) -> std::io::Result<std::fs::File> {
+        use std::os::unix::fs::OpenOptionsExt;
 
-        let mut reader = std::fs::OpenOptions::new().read(true).open(&self.fifo)?;
-        let mut source = String::new();
-        reader.read_to_string(&mut source)?;
-        Ok(())
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&self.fifo)
     }
 
-    fn release_writer(&mut self) {
-        use std::sync::atomic::Ordering;
+    fn drain_nonblocking_control_fifo(control: &mut std::fs::File) -> std::io::Result<()> {
+        use std::io::Read;
 
-        let Some(writer) = self.writer.take() else {
-            return;
-        };
-
-        if !self.second_writer_opened {
-            // A timed-out multi-read mutant may already have consumed and
-            // closed the replacement source. Do not open a FIFO reader with
-            // no writer in that case.
-            if self.second_opened.try_recv().is_ok() {
-                self.second_writer_opened = true;
-            }
-            // This only releases test-owned blocked writers after the child
-            // exits. It does not contribute evidence about the child's reads.
-            if !self.second_writer_opened && self.phase.load(Ordering::SeqCst) < Self::REPLACED {
-                self.drain_current_fifo()
-                    .expect("drain first FIFO during cleanup");
-                if self.second_opened.try_recv().is_ok() {
-                    self.second_writer_opened = true;
-                }
-            }
-            if !self.second_writer_opened {
-                self.drain_current_fifo()
-                    .expect("drain replacement FIFO during cleanup");
-                self.second_writer_opened = true;
+        let mut bytes = [0; 4096];
+        loop {
+            match control.read(&mut bytes) {
+                Ok(0) => return Ok(()),
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+                Err(error) => return Err(error),
             }
         }
+    }
 
-        writer.join().expect("join FIFO writer");
+    fn release_writer(&mut self) -> WriterOutcome {
+        use std::sync::atomic::Ordering;
+        use std::sync::mpsc::TryRecvError;
+
+        let Some(writer) = self.writer.take() else {
+            return WriterOutcome::Finished;
+        };
+
+        // These retained, nonblocking descriptors release only test-owned FIFO
+        // writers. They cannot hang if the writer panicked before rename: the
+        // outcome channel closes/completes, and the bounded wait below joins
+        // only after `is_finished()` proves the thread has terminated.
+        let mut controls = vec![
+            self.open_nonblocking_control_fifo()
+                .expect("open nonblocking FIFO cleanup control"),
+        ];
+        let mut replacement_control_opened = self.phase.load(Ordering::SeqCst) >= Self::REPLACED;
+        let deadline = std::time::Instant::now() + Self::CLEANUP_TIMEOUT;
+        let mut outcome = None;
+
+        loop {
+            if !replacement_control_opened && self.phase.load(Ordering::SeqCst) >= Self::REPLACED {
+                controls.push(
+                    self.open_nonblocking_control_fifo()
+                        .expect("open replacement FIFO cleanup control"),
+                );
+                replacement_control_opened = true;
+            }
+
+            for control in &mut controls {
+                Self::drain_nonblocking_control_fifo(control)
+                    .expect("drain nonblocking FIFO cleanup control");
+            }
+
+            if outcome.is_none() {
+                match self.writer_outcome.try_recv() {
+                    Ok(received) => outcome = Some(received),
+                    Err(TryRecvError::Empty) => {}
+                    Err(TryRecvError::Disconnected) => {
+                        panic!("FIFO writer exited without reporting an outcome");
+                    }
+                }
+            }
+
+            if writer.is_finished() {
+                let outcome = outcome.expect("finished FIFO writer must report an outcome");
+                writer.join().expect("join finished FIFO writer");
+                return outcome;
+            }
+
+            assert!(
+                std::time::Instant::now() < deadline,
+                "FIFO writer cleanup exceeded {:?}",
+                Self::CLEANUP_TIMEOUT
+            );
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
     }
 }
 
@@ -224,7 +297,7 @@ impl Drop for TwoSnapshotFifo {
         // leave FIFOs behind merely because a check failed.
         if self.writer.is_some() {
             let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                self.release_writer();
+                let _ = self.release_writer();
             }));
         }
         let _ = std::fs::remove_file(&self.fifo);
@@ -233,8 +306,92 @@ impl Drop for TwoSnapshotFifo {
 }
 
 #[cfg(unix)]
+struct ReapedChild {
+    child: std::process::Child,
+    reaped: bool,
+}
+
+#[cfg(unix)]
+impl ReapedChild {
+    fn new(child: std::process::Child) -> Self {
+        Self {
+            child,
+            reaped: false,
+        }
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        let status = self.child.try_wait()?;
+        if status.is_some() {
+            self.reaped = true;
+        }
+        Ok(status)
+    }
+
+    fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        let status = self.child.wait()?;
+        self.reaped = true;
+        Ok(status)
+    }
+
+    fn terminate_and_reap_with<F>(
+        &mut self,
+        terminate: F,
+    ) -> (
+        Option<std::io::Error>,
+        std::io::Result<std::process::ExitStatus>,
+    )
+    where
+        F: FnOnce(&mut std::process::Child) -> std::io::Result<()>,
+    {
+        // `wait` is deliberately unconditional: a process can exit between a
+        // timeout poll and kill, making kill return ESRCH while still leaving
+        // a child for this parent to reap.
+        let terminate_error = terminate(&mut self.child).err();
+        let status = self.wait();
+        (terminate_error, status)
+    }
+
+    fn capture_output(&mut self, status: std::process::ExitStatus) -> std::process::Output {
+        use std::io::Read;
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        self.child
+            .stdout
+            .take()
+            .expect("capture FIFO child stdout")
+            .read_to_end(&mut stdout)
+            .expect("read FIFO child stdout");
+        self.child
+            .stderr
+            .take()
+            .expect("capture FIFO child stderr")
+            .read_to_end(&mut stderr)
+            .expect("read FIFO child stderr");
+        std::process::Output {
+            status,
+            stdout,
+            stderr,
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ReapedChild {
+    fn drop(&mut self) {
+        if !self.reaped {
+            // Ignore errors during unwinding, but never let a failed kill skip
+            // the reap attempt.
+            let _ = self.child.kill();
+            let _ = self.wait();
+        }
+    }
+}
+
+#[cfg(unix)]
 fn wait_for_output_with_timeout(
-    child: &mut std::process::Child,
+    child: &mut ReapedChild,
     timeout: std::time::Duration,
 ) -> std::process::Output {
     use std::io::Read;
@@ -245,24 +402,28 @@ fn wait_for_output_with_timeout(
             break status;
         }
         if std::time::Instant::now() >= deadline {
-            child.kill().expect("kill timed-out FIFO child");
-            let status = child.wait().expect("reap timed-out FIFO child");
+            let (kill_error, status) = child.terminate_and_reap_with(std::process::Child::kill);
+            let status = status.unwrap_or_else(|wait_error| {
+                panic!("reap timed-out FIFO child after kill result {kill_error:?}: {wait_error}")
+            });
             let mut stdout = Vec::new();
             let mut stderr = Vec::new();
             child
+                .child
                 .stdout
                 .take()
                 .expect("capture FIFO child stdout")
                 .read_to_end(&mut stdout)
                 .expect("read timed-out FIFO child stdout");
             child
+                .child
                 .stderr
                 .take()
                 .expect("capture FIFO child stderr")
                 .read_to_end(&mut stderr)
                 .expect("read timed-out FIFO child stderr");
             panic!(
-                "fslc against FIFO timed out after {timeout:?}; status={status}; stdout={}; stderr={}",
+                "fslc against FIFO timed out after {timeout:?}; kill_error={kill_error:?}; status={status}; stdout={}; stderr={}",
                 String::from_utf8_lossy(&stdout),
                 String::from_utf8_lossy(&stderr)
             );
@@ -270,25 +431,7 @@ fn wait_for_output_with_timeout(
         std::thread::sleep(std::time::Duration::from_millis(10));
     };
 
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    child
-        .stdout
-        .take()
-        .expect("capture FIFO child stdout")
-        .read_to_end(&mut stdout)
-        .expect("read FIFO child stdout");
-    child
-        .stderr
-        .take()
-        .expect("capture FIFO child stderr")
-        .read_to_end(&mut stderr)
-        .expect("read FIFO child stderr");
-    std::process::Output {
-        status,
-        stdout,
-        stderr,
-    }
+    child.capture_output(status)
 }
 
 /// Runs a command against a rejecting FIFO inode, then makes a valid source
@@ -299,24 +442,76 @@ fn run_against_two_snapshot_fifo(command: &str) -> (String, i32) {
 
     let mut fixture = TwoSnapshotFifo::new();
     let fifo_argument = fixture.fifo.to_string_lossy().into_owned();
-    let mut child = Command::new(env!("CARGO_BIN_EXE_fslc"))
-        .args(["domain", command, &fifo_argument])
-        .current_dir(root())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn native fslc against FIFO");
+    let mut child = ReapedChild::new(
+        Command::new(env!("CARGO_BIN_EXE_fslc"))
+            .args(["domain", command, &fifo_argument])
+            .current_dir(root())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn native fslc against FIFO"),
+    );
     let output = wait_for_output_with_timeout(&mut child, std::time::Duration::from_secs(5));
 
     // This assertion occurs before fixture cleanup opens the replacement FIFO.
     // Receiving here is therefore proof that the CLI itself opened it.
     fixture.assert_no_second_open();
-    fixture.release_writer();
+    assert_eq!(fixture.release_writer(), WriterOutcome::Finished);
 
     (
         String::from_utf8(output.stdout).expect("UTF-8 stdout"),
         output.status.code().expect("exit status"),
     )
+}
+
+/// The pre-rename panic is the cleanup failure mode that used to leave the
+/// second blocking FIFO open waiting forever. The writer outcome and retained
+/// nonblocking control FD make completion independent of that missing writer.
+#[cfg(unix)]
+#[test]
+fn fifo_cleanup_finishes_when_writer_panics_before_rename() {
+    let mut fixture = TwoSnapshotFifo::new_with_writer_mode(WriterMode::PanicBeforeRename);
+
+    assert_eq!(fixture.release_writer(), WriterOutcome::Panicked);
+}
+
+/// A deterministic ESRCH control for the timeout guard. Reading the pipe to
+/// EOF proves the child has exited without reaping it; injecting its possible
+/// kill result verifies that the guard still calls `wait` and completes.
+#[cfg(unix)]
+#[test]
+fn child_guard_reaps_after_esrch_kill_error() {
+    use std::io::Read;
+    use std::process::Stdio;
+
+    let mut child = ReapedChild::new(
+        Command::new("sh")
+            .args(["-c", "exit 0"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn already-exiting child"),
+    );
+    let mut stdout = Vec::new();
+    child
+        .child
+        .stdout
+        .as_mut()
+        .expect("capture child stdout")
+        .read_to_end(&mut stdout)
+        .expect("wait for child stdout EOF");
+    let (kill_error, status) =
+        child.terminate_and_reap_with(|_| Err(std::io::Error::from_raw_os_error(libc::ESRCH)));
+
+    assert_eq!(
+        kill_error.and_then(|error| error.raw_os_error()),
+        Some(libc::ESRCH),
+        "the control must exercise the ESRCH kill result"
+    );
+    assert!(
+        status.expect("reap child after ESRCH").success(),
+        "already-exited child must reap successfully"
+    );
 }
 
 fn assert_rejected_like_check(fixture: &str) {
@@ -380,9 +575,10 @@ fn domain_expand_rejection_does_not_write_output() {
 }
 
 /// #798 is the sibling generated-name case: direct lowering rejects authored
-/// use of a generated enum member, but the renderer formerly left that already
-/// qualified text in place, making a falsely valid Kernel. The shared lowering
-/// validation rejects it before either command emits a success envelope.
+/// use of a generated enum member, but the renderer still leaves that already
+/// qualified text unchanged. Before #796 the CLI emitted that falsely valid
+/// Kernel; shared lowering validation now rejects it before either command
+/// emits a success envelope.
 #[test]
 fn domain_analyze_and_expand_reject_generated_kernel_names_like_check() {
     assert_rejected_like_check(

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -317,14 +317,15 @@ findings, `fslc domain expand` to inspect the generated kernel, and
 real gateway behavior, queue delivery, wall-clock timeouts, or production
 exactly-once semantics.
 At command entry, `fslc domain analyze` and `fslc domain expand` both read one
-authored-source `String` and derive their `DomainSpec` summary or generated
-text and checked Kernel from that same snapshot through typed lowering. Atomic
-path replacement therefore cannot make either command validate a different
-source version before returning output. They reject unresolved identifiers with
-the original source location; neither command is a best-effort/raw-AST
-inspection path for semantically invalid domain input. `domain generate` uses
-the same typed lowering but does not yet have this single-snapshot contract;
-#808 tracks that separate TOCTOU follow-up.
+authored-source `String`, parse their `DomainSpec` with
+`parse_domain_document_from_source`, and pass that same string to
+`load_kernel_model_from_source` to construct the checked Kernel. Atomic path
+replacement therefore cannot make either command validate a different source
+version before returning output. They reject unresolved identifiers with the
+original source location; neither command is a best-effort/raw-AST inspection
+path for semantically invalid domain input. `domain generate` uses the same
+typed lowering but does not yet have this single-snapshot contract; #808 tracks
+that separate TOCTOU follow-up.
 The accepted #662 design keeps `event_*` flags one-hot/current-step and will add
 a dedicated `Map<Correlation,SagaPhase>` in a follow-up; do not make global
 event flags sticky or treat one effect's status map as a general saga history.

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -316,6 +316,11 @@ findings, `fslc domain expand` to inspect the generated kernel, and
 `DOMAIN-ASSUME-SAGA-OBSERVED-HISTORY`. The v0 implementation does not prove
 real gateway behavior, queue delivery, wall-clock timeouts, or production
 exactly-once semantics.
+`fslc domain analyze` and `fslc domain expand` both validate authored source
+through the same typed lowering path as `check`, `verify`, and `domain
+generate` before returning a summary or generated text. They reject unresolved
+identifiers with the original source location; neither command is a
+best-effort/raw-AST inspection path for semantically invalid domain input.
 The accepted #662 design keeps `event_*` flags one-hot/current-step and will add
 a dedicated `Map<Correlation,SagaPhase>` in a follow-up; do not make global
 event flags sticky or treat one effect's status map as a general saga history.

--- a/skills/fsl/reference.md
+++ b/skills/fsl/reference.md
@@ -316,11 +316,15 @@ findings, `fslc domain expand` to inspect the generated kernel, and
 `DOMAIN-ASSUME-SAGA-OBSERVED-HISTORY`. The v0 implementation does not prove
 real gateway behavior, queue delivery, wall-clock timeouts, or production
 exactly-once semantics.
-`fslc domain analyze` and `fslc domain expand` both validate authored source
-through the same typed lowering path as `check`, `verify`, and `domain
-generate` before returning a summary or generated text. They reject unresolved
-identifiers with the original source location; neither command is a
-best-effort/raw-AST inspection path for semantically invalid domain input.
+At command entry, `fslc domain analyze` and `fslc domain expand` both read one
+authored-source `String` and derive their `DomainSpec` summary or generated
+text and checked Kernel from that same snapshot through typed lowering. Atomic
+path replacement therefore cannot make either command validate a different
+source version before returning output. They reject unresolved identifiers with
+the original source location; neither command is a best-effort/raw-AST
+inspection path for semantically invalid domain input. `domain generate` uses
+the same typed lowering but does not yet have this single-snapshot contract;
+#808 tracks that separate TOCTOU follow-up.
 The accepted #662 design keeps `event_*` flags one-hot/current-step and will add
 a dedicated `Map<Correlation,SagaPhase>` in a follow-up; do not make global
 event flags sticky or treat one effect's status map as a general saga history.


### PR DESCRIPTION
## Summary
- Preserve the product-side single-snapshot fix and two-inode FIFO proof for `domain analyze` / `domain expand`.
- Make exceptional test cleanup bounded: retained nonblocking FIFO controls, an explicit writer outcome, and a child RAII guard eliminate the previous blocking-open and unreaped-child paths.
- Correct the parser/checked-loader ownership documentation and distinguish the fixed CLI boundary from the still-pinned #798 renderer divergence.
- Closes #796. Refs #798 and #808.

## Changes
- Replace `Drop`'s blocking FIFO reads with retained `O_NONBLOCK` control descriptors. Cleanup drains them opportunistically, consumes the writer outcome, and calls `join` only after `JoinHandle::is_finished()`; the deadline bounds the wait.
- Add Unix abnormal-path controls for a writer panic after the first source write but before rename, and for an already-exited child with a deterministic injected `ESRCH` kill result. Both verify cleanup reaches `wait` and returns.
- Wrap the spawned CLI in `ReapedChild`, which always attempts `wait` after `kill`, including a failed `kill`.
- Document that `parse_domain_document_from_source` owns `DomainSpec` parsing and `load_kernel_model_from_source` owns checked-Kernel construction from the same `String`; regenerate language HTML.

## Verification
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` — pass
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings` — pass
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test issue_796_domain_command_validation --locked -- --nocapture` — 7 passed in 2.49s
- Measured writer-panic control — 1 passed in 0.63s (test time; 18.68s including a rebuild); the intentional pre-rename panic was caught and cleanup returned
- Measured already-exited/ESRCH control — 1 passed in 0.59s (test time; 2.19s wall time); injected ESRCH still reached `wait` and reaped the child
- Same focused test 20 consecutive times — 20/20 passed in 94.97s
- Two-read mutation (`load_kernel_model(path)`) — expected failure, exit 101; `the CLI opened the replacement FIFO, proving a second path read` (6 passed, 1 failed)
- Three-read mutation — expected failure, exit 101; 5s timeout, `SIGKILL`, reap, and test-process exit (6 passed, 1 failed in 5.64s)
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test error_envelope_parity --locked` — 15 passed in 51.74s
- `cargo test --manifest-path rust/Cargo.toml --workspace --locked` — pass, exit 0 (3h 3m 25s)
- `./tools/aggregate_changelog.sh check` — pass

## Risk / Review Notes
- No frozen Python, FSL specs, CLI shape, JSON envelope, or product-side snapshot/two-inode logic changed in this round.
- The 20-run result is regression evidence, not the determinism proof: inode identity plus rename-before-close structurally separates the first reader from any later path open.
- The ESRCH control injects the kernel-reported error after stdout EOF proves the child exited, avoiding a timing-dependent PID race while exercising the required kill-error/reap branch.
- #798 remains a renderer divergence; #796 now rejects its generated-name misuse at the CLI boundary rather than claiming to fix the renderer.