### PR TITLE
fix(ci): pin CLI fixture line endings on every runner

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,16 @@
 *.fsl text eol=lf
+
+# Every checked-in fixture under this directory is compared byte-for-byte
+# against a CLI envelope, so a platform-dependent checkout changes what the
+# fixture means. `error_envelope_document.md` reached `main` without a rule,
+# was checked out CRLF on `windows-latest`, and its leading `---` stopped
+# parsing as document frontmatter: three `error_envelope_parity` cells failed
+# on that runner alone (run 31759050211). Cover the directory rather than each
+# new file, because the per-file rules below did not extend to fixtures added
+# later.
+rust/fslc/tests/fixtures/** text eol=lf
+rust/fslc/tests/fixtures/**/.z3-trace binary
+
 rust/fslc/tests/fixtures/conformance_coverage.v1.md text eol=lf
 rust/fslc/tests/fixtures/typestate_order.v1.json text eol=lf
 rust/fslc/tests/fixtures/typestate_order.v1.ts text eol=lf

--- a/changelog.d/804-windows-fixture-line-endings.fixed.md
+++ b/changelog.d/804-windows-fixture-line-endings.fixed.md
@@ -1,0 +1,9 @@
+Fixed: CLI test fixtures now check out with line-feed endings on every runner.
+`.gitattributes` pinned `*.fsl` and four named files, so the `.md` and `.json`
+fixtures added with the error-envelope parity matrix were checked out CRLF on
+`windows-latest`. `error_envelope_document.md`'s leading `---` then stopped
+parsing as document frontmatter and three parity cells failed on that runner
+alone while Linux and macOS stayed green (run `31759050211`). The directory now
+carries the rule, `.z3-trace` stays binary, and
+`rust/fslc/tests/fixture_line_endings.rs` fails with the offending path if a
+fixture escapes it again.

--- a/rust/fslc/tests/fixture_line_endings.rs
+++ b/rust/fslc/tests/fixture_line_endings.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Rejecting control for the checkout form of every CLI test fixture.
+//!
+//! `error_envelope_parity` compares CLI envelopes byte-for-byte against these
+//! fixtures, so a fixture whose checkout depends on the platform does not mean
+//! the same thing on every runner. `.gitattributes` covered `*.fsl` and four
+//! named files, but not the `.md`/`.json` fixtures added later: on
+//! `windows-latest` those were checked out CRLF, `error_envelope_document.md`'s
+//! leading `---` stopped parsing as document frontmatter, and three parity
+//! cells failed on that runner alone while Linux and macOS stayed green
+//! (run 31759050211).
+//!
+//! The `.gitattributes` rule fixes the checkout. This test is the control that
+//! notices when a new fixture escapes it: it reads the working tree, so on a
+//! runner that would reintroduce CRLF it fails with the offending path instead
+//! of surfacing as an unrelated envelope mismatch.
+
+use std::path::{Path, PathBuf};
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("repository root above rust/fslc")
+        .to_path_buf()
+}
+
+/// Files that are deliberately not text and are excluded from the check by
+/// `.gitattributes`' `binary` rule.
+fn is_excluded_binary(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == ".z3-trace")
+}
+
+fn collect_files(directory: &Path, files: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(directory).expect("readable fixture directory") {
+        let path = entry.expect("readable fixture entry").path();
+        if path.is_dir() {
+            collect_files(&path, files);
+        } else if !is_excluded_binary(&path) {
+            files.push(path);
+        }
+    }
+}
+
+#[test]
+fn every_cli_fixture_is_checked_out_with_line_feed_endings() {
+    let root = repository_root();
+    let fixtures = root.join("rust/fslc/tests/fixtures");
+
+    let mut files = Vec::new();
+    collect_files(&fixtures, &mut files);
+    files.sort();
+    assert!(
+        !files.is_empty(),
+        "no fixtures found under {}",
+        fixtures.display()
+    );
+
+    let offenders = files
+        .iter()
+        .filter(|path| {
+            std::fs::read(path)
+                .expect("readable fixture")
+                .windows(2)
+                .any(|pair| pair == b"\r\n")
+        })
+        .map(|path| {
+            path.strip_prefix(&root)
+                .unwrap_or(path)
+                .display()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        offenders.is_empty(),
+        "fixtures checked out with CRLF endings; add them to `.gitattributes` \
+         (`rust/fslc/tests/fixtures/** text eol=lf`) so every runner sees the \
+         same bytes: {}",
+        offenders.join(", ")
+    );
+}


### PR DESCRIPTION
## Problem

`main`'s product gate is red: `native Z3 4.16 (windows-latest)` fails on runs
`31759050211` and `31760345735`, while Linux and macOS stay green.

```
error_envelope_parity: 12 passed; 3 failed   (windows-latest only)

Parse/Guard/Name × "document check" all mismatched:
  {"result":"error","kind":"document",
   "message":"document has no frontmatter (expected a leading '---' block)",
   "code":"FSL-DOC-SCHEMA-UNSUPPORTED"}
```

`.gitattributes` pinned `*.fsl text eol=lf` plus four named files. The `.md` and
`.json` fixtures that arrived with the error-envelope parity matrix (#799) matched
none of those rules:

```
$ git check-attr eol -- <fixtures added by #799>
lf           error_envelope_*.fsl                       (13 files)
unspecified  error_envelope_document.md
unspecified  error_envelope_empty_records.json
unspecified  error_envelope_literate_ai_component.md
unspecified  error_envelope_literate_ai_project.md
```

Without a rule, the Windows runner's checkout applies CRLF. `error_envelope_document.md`'s
leading `---` then no longer parses as document frontmatter, so `document check` returns a
schema error instead of the parse/guard/name envelope the matrix compares against.

`native Z3 4.16` is a promotion-only lane that is skipped on pull requests, so the matrix
was never exercised on Windows until #799 reached `main`.

## Changes

- `.gitattributes` covers the fixture directory instead of individual files:
  `rust/fslc/tests/fixtures/** text eol=lf`. The per-file rules that predate this are kept
  for the fixtures they pin outside it.
- `rust/fslc/tests/fixtures/**/.z3-trace binary` keeps the three checked-in Z3 traces out of
  text normalization.
- New rejecting control `rust/fslc/tests/fixture_line_endings.rs` reads the working tree and
  fails with the offending path if any fixture is checked out with CRLF. It reports the cause
  directly rather than letting it surface as an unrelated envelope mismatch on one runner.

No fixture content changes: `git add --renormalize .` produces no diff beyond `.gitattributes`
itself, so the index was already LF and only the checkout was platform-dependent.

## Verification

- `cargo test -p fslc-rust --test fixture_line_endings --locked` — 1 passed.
- Negative control: rewriting `error_envelope_document.md` with CRLF makes it fail with
  ``fixtures checked out with CRLF endings; add them to `.gitattributes` … :
  rust/fslc/tests/fixtures/error_envelope_document.md`` — restored afterwards.
- `git check-attr text eol` after the change: `.md`/`.json` fixtures report `text=set eol=lf`;
  `.z3-trace` reports `text=unset`.

## Scope / Review Notes

- This restores `main`'s product gate. The Windows failure is a checkout artifact, not a
  defect in the parity matrix itself.
- The structural gap it exposes — a promotion-only lane means cross-platform behaviour is
  first exercised after merge — is not addressed here.
