### PR TITLE
fix(cli): preserve dialect parse error envelopes

### DIFF
--- a/changelog.d/780-dialect-parse-envelope.fixed.md
+++ b/changelog.d/780-dialect-parse-envelope.fixed.md
@@ -1,2 +1,2 @@
-Fixed (#780): dialect CLI commands now preserve parse error kind, location, and
-`FSL-PARSE` diagnostic code through their specialized spec-loading boundaries.
+Partially fixed (#780): domain, DB, AI-component, AI-project evidence, approval,
+and causal command boundaries preserve parse error kind, location, and `FSL-PARSE`.

--- a/changelog.d/780-dialect-parse-envelope.fixed.md
+++ b/changelog.d/780-dialect-parse-envelope.fixed.md
@@ -1,0 +1,2 @@
+Fixed (#780): dialect CLI commands now preserve parse error kind, location, and
+`FSL-PARSE` diagnostic code through their specialized spec-loading boundaries.

--- a/changelog.d/780-dialect-parse-envelope.fixed.md
+++ b/changelog.d/780-dialect-parse-envelope.fixed.md
@@ -1,2 +1,2 @@
-Partially fixed (#780): domain, DB, AI-component, AI-project evidence, approval,
-and causal command boundaries preserve parse error kind, location, and `FSL-PARSE`.
+Partially fixed (#780): domain, DB, AI-component, AI-project check/evidence,
+approval, and causal command boundaries preserve parse kind, location, and `FSL-PARSE`.

--- a/rust/fsl-syntax/src/ai_project.rs
+++ b/rust/fsl-syntax/src/ai_project.rs
@@ -13,7 +13,7 @@
 //! `src/fslc/ai_project.py`: a small typed metadata model built with a
 //! brace-matching block scanner, not a strict grammar.
 
-use crate::ai::{AiComponent, parse_ai_component};
+use crate::{AiComponent, ParseError, SourcePos, Span, parse_ai_component};
 
 /// Top-level declaration kinds this parser recognizes as fsl-ai project
 /// blocks. A block whose kind is not in this set is ignored (mirrors the
@@ -318,13 +318,21 @@ impl AiProject {
 ///
 /// # Errors
 ///
-/// Returns a message when no recognized top-level block is found, a block is
-/// unterminated, or a `statistical_property`/`observed_property`/
-/// `ai_migration` name is declared more than once.
-pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, String> {
-    let blocks = top_blocks(source, 0)?;
+/// Returns a typed parser diagnostic when no recognized top-level block is
+/// found, a block is unterminated, or a `statistical_property`/
+/// `observed_property`/`ai_migration` name is declared more than once.
+///
+/// The fsl-ai project's brace scanner owns its own syntax. Its failures must
+/// therefore retain their source span here rather than being reinterpreted by
+/// the generic surface parser at a command boundary.
+pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, ParseError> {
+    let blocks = top_blocks(source, 0, source)?;
     if blocks.is_empty() {
-        return Err("expected fsl-ai project declarations".to_owned());
+        return Err(parse_error_at(
+            source,
+            0,
+            "expected fsl-ai project declarations",
+        ));
     }
     let mut project = AiProject {
         name: name.to_owned(),
@@ -333,9 +341,10 @@ pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, String> {
     for block in &blocks {
         match block.kind.as_str() {
             "ai_component" => {
-                project
-                    .components
-                    .push(parse_ai_component(&block.text).map_err(|error| error.to_string())?);
+                project.components.push(
+                    parse_ai_component(&block.text)
+                        .map_err(|error| relocate_parse_error(source, block, error))?,
+                );
             }
             "dataset" => project.datasets.push(parse_dataset(block)),
             // Descended only far enough to record the name: these are tracked
@@ -350,7 +359,7 @@ pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, String> {
             "observed_property" => project
                 .observed_properties
                 .push(parse_observed_property(block, source)?),
-            "ai_migration" => project.migrations.push(parse_migration(block)?),
+            "ai_migration" => project.migrations.push(parse_migration(block, source)?),
             kind if RAW_BLOCKS.contains(&kind) => project.raw_blocks.push(AiRawBlock {
                 kind: block.kind.clone(),
                 name: block.name.clone(),
@@ -363,31 +372,27 @@ pub fn parse_ai_project(source: &str, name: &str) -> Result<AiProject, String> {
     // until issue 571: a `dataset X` reference resolves by name, so two
     // declarations sharing one made the resolution depend on declaration order,
     // and `datasets` echoed the name twice.
-    reject_duplicates(project.datasets.iter().map(|d| d.name.as_str()), "dataset")?;
-    reject_duplicates(project.evaluators.iter().map(String::as_str), "evaluator")?;
-    reject_duplicates(
-        project
-            .statistical_properties
-            .iter()
-            .map(|p| p.name.as_str()),
-        "statistical_property",
-    )?;
-    reject_duplicates(
-        project.observed_properties.iter().map(|p| p.name.as_str()),
-        "observed_property",
-    )?;
-    reject_duplicates(
-        project.migrations.iter().map(|p| p.name.as_str()),
-        "ai_migration",
-    )?;
+    reject_duplicate_blocks(&blocks, "dataset", source)?;
+    reject_duplicate_blocks(&blocks, "evaluator", source)?;
+    reject_duplicate_blocks(&blocks, "statistical_property", source)?;
+    reject_duplicate_blocks(&blocks, "observed_property", source)?;
+    reject_duplicate_blocks(&blocks, "ai_migration", source)?;
     Ok(project)
 }
 
-fn reject_duplicates<'a>(names: impl Iterator<Item = &'a str>, label: &str) -> Result<(), String> {
+fn reject_duplicate_blocks(
+    blocks: &[RawBlock],
+    label: &str,
+    source: &str,
+) -> Result<(), ParseError> {
     let mut seen = std::collections::BTreeSet::new();
-    for name in names {
-        if !seen.insert(name) {
-            return Err(format!("duplicate {label} '{name}'"));
+    for block in blocks.iter().filter(|block| block.kind == label) {
+        if !seen.insert(block.name.as_str()) {
+            return Err(parse_error_at(
+                source,
+                block.start,
+                format!("duplicate {label} '{}'", block.name),
+            ));
         }
     }
     Ok(())
@@ -398,6 +403,9 @@ fn reject_duplicates<'a>(names: impl Iterator<Item = &'a str>, label: &str) -> R
 struct RawBlock {
     kind: String,
     name: String,
+    /// Char offset of the declaration's first character in the whole project
+    /// source. Duplicate declarations report this declaration, not a sibling.
+    start: usize,
     /// Char offset of `body`'s first character within the whole project
     /// source, so a clause inside it can report its own `loc` (#562).
     body_offset: usize,
@@ -539,7 +547,11 @@ fn brace_depth(chars: &[char]) -> i32 {
     depth
 }
 
-fn top_blocks(source: &str, base: usize) -> Result<Vec<RawBlock>, String> {
+fn top_blocks(
+    source: &str,
+    base: usize,
+    project_source: &str,
+) -> Result<Vec<RawBlock>, ParseError> {
     let chars: Vec<char> = source.chars().collect();
     let mut blocks = Vec::new();
     let mut i = 0usize;
@@ -555,13 +567,15 @@ fn top_blocks(source: &str, base: usize) -> Result<Vec<RawBlock>, String> {
             continue;
         }
         let Some(end) = matching_brace(&chars, header.brace) else {
-            return Err(format!(
-                "unterminated {} '{}' block",
-                header.kind, header.name
+            return Err(parse_error_at(
+                project_source,
+                base + header.brace,
+                format!("unterminated {} '{}' block", header.kind, header.name),
             ));
         };
         if brace_depth(&chars[..header.start]) == 0 {
             blocks.push(RawBlock {
+                start: base + header.start,
                 text: chars[header.start..=end].iter().collect(),
                 body: chars[header.brace + 1..end].iter().collect(),
                 body_offset: base + header.brace + 1,
@@ -572,6 +586,50 @@ fn top_blocks(source: &str, base: usize) -> Result<Vec<RawBlock>, String> {
         i = end + 1;
     }
     Ok(blocks)
+}
+
+fn source_pos(source: &str, char_offset: usize) -> SourcePos {
+    let mut offset = 0;
+    let mut line = 1;
+    let mut column = 1;
+    for character in source.chars().take(char_offset) {
+        offset += character.len_utf8();
+        if character == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+    SourcePos {
+        offset,
+        line,
+        column,
+    }
+}
+
+fn parse_error_at(source: &str, char_offset: usize, message: impl Into<String>) -> ParseError {
+    let position = source_pos(source, char_offset);
+    ParseError::new(
+        message,
+        Span {
+            start: position,
+            end: position,
+        },
+    )
+}
+
+fn relocate_parse_error(source: &str, block: &RawBlock, error: ParseError) -> ParseError {
+    let start = block.start + block.text[..error.span.start.offset].chars().count();
+    let end = block.start + block.text[..error.span.end.offset].chars().count();
+    ParseError::coded(
+        error.code(),
+        error.message,
+        Span {
+            start: source_pos(source, start),
+            end: source_pos(source, end),
+        },
+    )
 }
 
 fn strip_comment(line: &str) -> &str {
@@ -807,7 +865,7 @@ fn parse_metric_requirement(
 fn parse_statistical_property(
     block: &RawBlock,
     source: &str,
-) -> Result<AiStatisticalProperty, String> {
+) -> Result<AiStatisticalProperty, ParseError> {
     let mut target = None;
     let mut dataset = None;
     let mut evaluator = None;
@@ -823,9 +881,13 @@ fn parse_statistical_property(
             evaluator = Some(atom(rest));
         } else if let Some(rest) = line.strip_prefix("confidence ") {
             confidence = atom(rest).parse().map_err(|_| {
-                format!(
-                    "statistical_property '{}' has a non-numeric confidence",
-                    block.name
+                parse_error_at(
+                    source,
+                    entry.offset,
+                    format!(
+                        "statistical_property '{}' has a non-numeric confidence",
+                        block.name
+                    ),
                 )
             })?;
         } else if let Some(rest) = line.strip_prefix("require ") {
@@ -836,7 +898,7 @@ fn parse_statistical_property(
             ));
         }
     }
-    for child in top_blocks(&block.body, block.body_offset)? {
+    for child in top_blocks(&block.body, block.body_offset, source)? {
         if child.kind != "slice" {
             continue;
         }
@@ -926,7 +988,7 @@ fn parse_observed_requirement(
 fn parse_observed_property(
     block: &RawBlock,
     project_source: &str,
-) -> Result<AiObservedProperty, String> {
+) -> Result<AiObservedProperty, ParseError> {
     let mut target = None;
     let mut source = None;
     let mut window = None;
@@ -947,7 +1009,7 @@ fn parse_observed_property(
             ));
         }
     }
-    for child in top_blocks(&block.body, block.body_offset)? {
+    for child in top_blocks(&block.body, block.body_offset, project_source)? {
         if child.kind != "slice" {
             continue;
         }
@@ -998,13 +1060,13 @@ fn parse_regression_requirement(
     })
 }
 
-fn parse_migration(block: &RawBlock) -> Result<AiMigration, String> {
+fn parse_migration(block: &RawBlock, source: &str) -> Result<AiMigration, ParseError> {
     let mut regression_requirements = Vec::new();
-    for child in top_blocks(&block.body, block.body_offset)? {
+    for child in top_blocks(&block.body, block.body_offset, source)? {
         if child.kind != "preserve" {
             continue;
         }
-        for grandchild in top_blocks(&child.body, child.body_offset)? {
+        for grandchild in top_blocks(&child.body, child.body_offset, source)? {
             if grandchild.kind != "no_regression" {
                 continue;
             }
@@ -1014,8 +1076,10 @@ fn parse_migration(block: &RawBlock) -> Result<AiMigration, String> {
                 if let Some(rest) = line.strip_prefix("dataset ") {
                     dataset = Some(atom(rest));
                 } else if line.starts_with("metric ") {
-                    regression_requirements
-                        .push(parse_regression_requirement(line, dataset.clone())?);
+                    regression_requirements.push(
+                        parse_regression_requirement(line, dataset.clone())
+                            .map_err(|error| parse_error_at(source, entry.offset, error))?,
+                    );
                 }
             }
         }
@@ -1115,7 +1179,11 @@ observed_property SupportAgentOperationalQuality {
     #[test]
     fn rejects_source_with_no_recognized_block() {
         let error = parse_ai_project("domain D {}", "P").unwrap_err();
-        assert!(error.contains("expected fsl-ai project declarations"));
+        assert!(
+            error
+                .message
+                .contains("expected fsl-ai project declarations")
+        );
     }
 
     #[test]

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -632,6 +632,25 @@ mod tests {
     }
 
     #[test]
+    fn check_preserves_ai_project_parser_location_and_code() {
+        let request = Request {
+            cmd: "check".to_owned(),
+            source: include_str!("../../fslc/tests/fixtures/error_envelope_broken_ai_project.fsl")
+                .to_owned(),
+            source_file: "broken_ai_project.fsl".to_owned(),
+            files: BTreeMap::new(),
+            options: Options::default(),
+        };
+
+        let error = block_on(check(&request, TEST_SOLVER_VERSION));
+
+        assert_eq!(error["result"], json!("error"));
+        assert_eq!(error["kind"], json!("parse"));
+        assert_eq!(error["diagnostic_code"], json!("FSL-PARSE"));
+        assert_eq!(error["loc"], json!({"line": 9, "column": 3}));
+    }
+
+    #[test]
     fn check_rejects_an_incomplete_governance_contract() {
         let request = Request {
             cmd: "check".to_owned(),

--- a/rust/fslc/src/approval.rs
+++ b/rust/fslc/src/approval.rs
@@ -469,6 +469,14 @@ pub fn spec_digest(path: &Path) -> Result<String, String> {
     let resolver = fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
     let kernel =
         fsl_core::parse_kernel_source(&source, &resolver).map_err(|error| error.to_string())?;
+    spec_digest_kernel(&kernel)
+}
+
+/// Hash an already-lowered kernel AST while ignoring source locations.
+///
+/// This lets callers that own a public spec-loading envelope preserve a
+/// typed parse failure through loading before calculating the approval digest.
+pub fn spec_digest_kernel(kernel: &fsl_core::KernelSpec) -> Result<String, String> {
     let ast = normalized_ast(&kernel.kernel_ast_v1())
         .ok_or_else(|| "normalized kernel AST is empty".to_owned())?;
     let encoded = serde_json::to_vec(&ast).map_err(|error| error.to_string())?;

--- a/rust/fslc/src/causal.rs
+++ b/rust/fslc/src/causal.rs
@@ -255,13 +255,47 @@ pub(super) fn causal_command(
     }
 }
 
-fn causal_error_output(error: &fsl_tools::CausalError) -> (Value, i32) {
-    let kind = if error.kind == "parse" {
-        "parse"
-    } else {
-        "semantics"
-    };
-    let mut output = error_output(kind, &error.message);
+pub(super) fn causal_parse_error_output(
+    error: &fsl_syntax::ParseError,
+    legacy_literate: bool,
+) -> (Value, i32) {
+    let mut output = error_output("parse", &error.to_string());
+    if let Some(object) = output.as_object_mut() {
+        if legacy_literate {
+            object.insert("diagnostic".to_owned(), json!("parse"));
+        } else {
+            object.insert("diagnostic_code".to_owned(), json!("FSL-PARSE"));
+        }
+        object.insert("loc".to_owned(), error.span.python_loc());
+    }
+    (output, 2)
+}
+
+fn causal_unadorned_parse_error_output(error: &fsl_syntax::ParseError) -> (Value, i32) {
+    let mut output = error_output("parse", &error.to_string());
+    if let Some(object) = output.as_object_mut() {
+        object.insert("loc".to_owned(), error.span.python_loc());
+    }
+    (output, 2)
+}
+
+fn causal_error_output(error: &fsl_tools::CausalError, legacy_literate: bool) -> (Value, i32) {
+    if error.kind == "parse" {
+        let mut output = error_output("parse", &error.message);
+        if let Some(object) = output.as_object_mut() {
+            if legacy_literate {
+                object.insert("diagnostic".to_owned(), json!("parse"));
+            } else {
+                object.insert("diagnostic_code".to_owned(), json!("FSL-PARSE"));
+            }
+            object.insert(
+                "loc".to_owned(),
+                json!({"line": error.line, "column": error.column}),
+            );
+        }
+        return (output, 2);
+    }
+    let mut output = error_output("semantics", &error.message);
     if let Some(object) = output.as_object_mut() {
         object.insert("diagnostic".to_owned(), json!(error.kind));
         object.insert(
@@ -285,7 +319,9 @@ fn load_causal_model(
         .parent()
         .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
     let resolver = fsl_core::FsResolver::new(base);
-    fsl_tools::build_causal_model(&source, &resolver).map_err(|error| causal_error_output(&error))
+    let legacy_literate = path.extension().and_then(std::ffi::OsStr::to_str) == Some("md");
+    fsl_tools::build_causal_model(&source, &resolver)
+        .map_err(|error| causal_error_output(&error, legacy_literate))
 }
 
 fn merge_causal_envelope(value: Value) -> (Value, i32) {
@@ -499,11 +535,11 @@ fn run_causal_verify_expectations(path: &Path, depth: usize) -> (Value, i32) {
     let surface = match fsl_syntax::parse_causal(&source) {
         Ok(surface) => surface,
         Err(error) => {
-            let mut output = error_output("parse", &error.to_string());
-            if let Some(object) = output.as_object_mut() {
-                object.insert("loc".to_owned(), error.span.python_loc());
-            }
-            return (output, 2);
+            return if path.extension().and_then(std::ffi::OsStr::to_str) == Some("md") {
+                causal_unadorned_parse_error_output(&error)
+            } else {
+                causal_parse_error_output(&error, false)
+            };
         }
     };
     let (model, _) = match load_causal_model(path) {
@@ -516,7 +552,7 @@ fn run_causal_verify_expectations(path: &Path, depth: usize) -> (Value, i32) {
     let resolver = fsl_core::FsResolver::new(base);
     let compiled = match fsl_tools::compile_expectations(&surface, &model, &resolver) {
         Ok(compiled) => compiled,
-        Err(error) => return causal_error_output(&error),
+        Err(error) => return causal_error_output(&error, false),
     };
     let mut expectations = Vec::new();
     for expectation in &compiled {
@@ -636,11 +672,11 @@ fn run_causal_observe_expectations(
     let surface = match fsl_syntax::parse_causal(&source) {
         Ok(surface) => surface,
         Err(error) => {
-            let mut output = error_output("parse", &error.to_string());
-            if let Some(object) = output.as_object_mut() {
-                object.insert("loc".to_owned(), error.span.python_loc());
-            }
-            return (output, 2);
+            return if path.extension().and_then(std::ffi::OsStr::to_str) == Some("md") {
+                causal_unadorned_parse_error_output(&error)
+            } else {
+                causal_parse_error_output(&error, false)
+            };
         }
     };
     let (model, _) = match load_causal_model(path) {
@@ -653,7 +689,7 @@ fn run_causal_observe_expectations(
     let resolver = fsl_core::FsResolver::new(base);
     let compiled = match fsl_tools::compile_expectations(&surface, &model, &resolver) {
         Ok(compiled) => compiled,
-        Err(error) => return causal_error_output(&error),
+        Err(error) => return causal_error_output(&error, false),
     };
     if compiled.is_empty() {
         return (

--- a/rust/fslc/src/frontend_output.rs
+++ b/rust/fslc/src/frontend_output.rs
@@ -58,7 +58,6 @@ pub fn parse_checked_ai_project(
             message: error.to_string(),
             position: Some((error.span.start.line, error.span.start.column)),
             diagnostic_code: Some(error.code()),
-            generic_loc: false,
         })?;
     let unparsed = project.unparsed_clauses();
     if unparsed.is_empty() {
@@ -84,7 +83,6 @@ pub fn parse_checked_ai_project(
         ),
         position: Some((first.line, first.column)),
         diagnostic_code: Some("FSL-PARSE"),
-        generic_loc: true,
     })
 }
 
@@ -95,10 +93,6 @@ pub struct AiProjectParseError {
     pub message: String,
     pub position: Option<(u32, u32)>,
     pub diagnostic_code: Option<&'static str>,
-    /// Generic `check` has a legacy parser-envelope pin for project scanner
-    /// failures, but its independently validated unexecutable-clause path
-    /// already promises this location (#562).
-    pub generic_loc: bool,
 }
 
 /// Render the multi-declaration AI project check result when applicable,
@@ -117,10 +111,11 @@ pub fn ai_project_check_output(
         output.insert("result".to_owned(), json!("error"));
         output.insert("kind".to_owned(), json!("parse"));
         output.insert("message".to_owned(), json!(error.message));
-        if error.generic_loc
-            && let Some((line, column)) = error.position
-        {
+        if let Some((line, column)) = error.position {
             output.insert("loc".to_owned(), json!({"line": line, "column": column}));
+        }
+        if let Some(code) = error.diagnostic_code {
+            output.insert("diagnostic_code".to_owned(), json!(code));
         }
         return Some((Value::Object(output), 2));
     }

--- a/rust/fslc/src/frontend_output.rs
+++ b/rust/fslc/src/frontend_output.rs
@@ -54,9 +54,11 @@ pub fn parse_checked_ai_project(
     name: &str,
 ) -> Result<fsl_syntax::AiProject, AiProjectParseError> {
     let project =
-        fsl_syntax::parse_ai_project(source, name).map_err(|message| AiProjectParseError {
-            message,
-            position: None,
+        fsl_syntax::parse_ai_project(source, name).map_err(|error| AiProjectParseError {
+            message: error.to_string(),
+            position: Some((error.span.start.line, error.span.start.column)),
+            diagnostic_code: Some(error.code()),
+            generic_loc: false,
         })?;
     let unparsed = project.unparsed_clauses();
     if unparsed.is_empty() {
@@ -81,6 +83,8 @@ pub fn parse_checked_ai_project(
              (min_samples, ci_lower, ci_upper, a point estimate, observed, or drift): {detail}"
         ),
         position: Some((first.line, first.column)),
+        diagnostic_code: Some("FSL-PARSE"),
+        generic_loc: true,
     })
 }
 
@@ -90,6 +94,11 @@ pub fn parse_checked_ai_project(
 pub struct AiProjectParseError {
     pub message: String,
     pub position: Option<(u32, u32)>,
+    pub diagnostic_code: Option<&'static str>,
+    /// Generic `check` has a legacy parser-envelope pin for project scanner
+    /// failures, but its independently validated unexecutable-clause path
+    /// already promises this location (#562).
+    pub generic_loc: bool,
 }
 
 /// Render the multi-declaration AI project check result when applicable,
@@ -108,7 +117,9 @@ pub fn ai_project_check_output(
         output.insert("result".to_owned(), json!("error"));
         output.insert("kind".to_owned(), json!("parse"));
         output.insert("message".to_owned(), json!(error.message));
-        if let Some((line, column)) = error.position {
+        if error.generic_loc
+            && let Some((line, column)) = error.position
+        {
             output.insert("loc".to_owned(), json!({"line": line, "column": column}));
         }
         return Some((Value::Object(output), 2));

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5946,7 +5946,11 @@ fn load_surface_document(path: &Path) -> Result<fsl_syntax::SurfaceDocument, Spe
     if path.extension().and_then(std::ffi::OsStr::to_str) == Some("md") {
         return parse_surface_document(path).map_err(SpecLoadError::unlocated_semantic);
     }
-    let source = read_spec_source(path)?;
+    // This loader's caller contract predates the typed `io` envelope. Keep a
+    // read failure distinct from a parse failure without widening #780 beyond
+    // its declared parse-only surface.
+    let source = std::fs::read_to_string(path)
+        .map_err(|error| SpecLoadError::unlocated_semantic(error.to_string()))?;
     load_surface_document_from_source(&source)
 }
 
@@ -6390,10 +6394,13 @@ fn run_ai_project_check(source: &str, path: &Path) -> (Value, i32) {
         Ok(project) => project,
         Err(error) => {
             let mut output = error_output("parse", &error.message);
-            if let Some((line, column)) = error.position
-                && let Some(object) = output.as_object_mut()
-            {
-                object.insert("loc".to_owned(), json!({"line": line, "column": column}));
+            if let Some(object) = output.as_object_mut() {
+                if let Some((line, column)) = error.position {
+                    object.insert("loc".to_owned(), json!({"line": line, "column": column}));
+                }
+                if let Some(code) = error.diagnostic_code {
+                    object.insert("diagnostic_code".to_owned(), json!(code));
+                }
             }
             return (output, 2);
         }
@@ -6488,14 +6495,11 @@ fn load_ai_project(path: &Path) -> Result<fsl_syntax::AiProject, (Value, i32)> {
         .map_err(|error| (error_output("io", &error.to_string()), 2))?;
     if path.extension().and_then(std::ffi::OsStr::to_str) == Some("md") {
         return fsl_syntax::parse_ai_project(&source, &ai_project_name(path))
-            .map_err(|error| (semantic_error_output(&error), 2));
+            .map_err(|error| (semantic_error_output(&error.message), 2));
     }
     match fsl_syntax::parse_ai_project(&source, &ai_project_name(path)) {
         Ok(project) => Ok(project),
-        Err(message) => surface_parse_failure(&source).map_or_else(
-            || Err((semantic_error_output(&message), 2)),
-            |error| Err((surface_parse_error_output(&error), 2)),
-        ),
+        Err(error) => Err((surface_parse_error_output(&error), 2)),
     }
 }
 
@@ -6652,7 +6656,7 @@ fn run_ai_compat(path: &Path, environment: Option<&str>) -> (Value, i32) {
         if fslc_rust::frontend_output::is_ai_project(&source) {
             match fsl_syntax::parse_ai_project(&source, &ai_project_name(path)) {
                 Ok(project) => project.components,
-                Err(error) => return (semantic_error_output(&error), 2),
+                Err(error) => return (semantic_error_output(&error.message), 2),
             }
         } else {
             match load_surface_document(path) {
@@ -6809,7 +6813,11 @@ fn parse_domain_document_from_source(
 fn read_domain_command_input(
     path: &Path,
 ) -> Result<(String, fsl_syntax::DomainSpec), SpecLoadError> {
-    let source = read_spec_source(path)?;
+    // This command's caller contract predates the typed `io` envelope, same as
+    // `load_surface_document` above. Keep a read failure classified as
+    // `semantics` without widening #780 beyond its declared parse-only scope.
+    let source = std::fs::read_to_string(path)
+        .map_err(|error| SpecLoadError::unlocated_semantic(error.to_string()))?;
     let domain = parse_domain_document_from_source(&source)?;
     Ok((source, domain))
 }

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5938,6 +5938,29 @@ fn parse_surface_document(path: &Path) -> Result<fsl_syntax::SurfaceDocument, St
     parse_surface_document_from_source(path, &source)
 }
 
+/// Load a dialect surface document without flattening a parser diagnostic at
+/// the command boundary.  The legacy string-returning helper above is kept
+/// for callers that deliberately own a non-envelope result; spec-input
+/// commands must retain the parser's class and span through this path.
+fn load_surface_document(path: &Path) -> Result<fsl_syntax::SurfaceDocument, SpecLoadError> {
+    if path.extension().and_then(std::ffi::OsStr::to_str) == Some("md") {
+        return parse_surface_document(path).map_err(SpecLoadError::unlocated_semantic);
+    }
+    let source = read_spec_source(path)?;
+    load_surface_document_from_source(&source)
+}
+
+/// Load a dialect surface document from an already-captured source string.
+///
+/// Domain-projection commands (#796) must validate and project from the same
+/// snapshot they read, so they call this instead of re-reading `path` through
+/// [`load_surface_document`].
+fn load_surface_document_from_source(
+    source: &str,
+) -> Result<fsl_syntax::SurfaceDocument, SpecLoadError> {
+    fsl_syntax::parse_surface_document(source).map_err(|error| SpecLoadError::Parse(Box::new(error)))
+}
+
 fn validate_specialized_document(path: &Path) -> Result<(), String> {
     match parse_surface_document(path)? {
         fsl_syntax::SurfaceDocument::Db(system) => {
@@ -5974,10 +5997,10 @@ fn validate_specialized_document(path: &Path) -> Result<(), String> {
 }
 
 fn run_db_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Value, i32) {
-    let system = match parse_surface_document(path) {
+    let system = match load_surface_document(path) {
         Ok(fsl_syntax::SurfaceDocument::Db(system)) => system,
         Ok(_) => return (semantic_error_output("expected a dbsystem document"), 2),
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let mut result = match fsl_tools::check_db(&system) {
         Ok(Value::Object(result)) => result,
@@ -6017,10 +6040,10 @@ fn run_db_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
 }
 
 fn run_db_observe(path: &Path, trace: &Path) -> (Value, i32) {
-    let system = match parse_surface_document(path) {
+    let system = match load_surface_document(path) {
         Ok(fsl_syntax::SurfaceDocument::Db(system)) => system,
         Ok(_) => return (semantic_error_output("expected a dbsystem document"), 2),
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let payload = match std::fs::read_to_string(trace)
         .map_err(|error| error.to_string())
@@ -6164,7 +6187,7 @@ fn run_ai_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
     if fslc_rust::frontend_output::is_ai_project(&source) {
         return run_ai_project_check(&source, path);
     }
-    match parse_surface_document(path) {
+    match load_surface_document(path) {
         Ok(fsl_syntax::SurfaceDocument::AiComponent(component)) => {
             let (kernel, status) =
                 run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
@@ -6188,7 +6211,7 @@ fn run_ai_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Val
             semantic_error_output("expected an ai_component or agent document"),
             2,
         ),
-        Err(error) => (semantic_error_output(&error), 2),
+        Err(error) => (spec_load_error_output(&error), 2),
     }
 }
 
@@ -6266,7 +6289,7 @@ fn run_ai_replay(path: &Path, logs: &Path, selected_component: Option<&str>) -> 
             json!({"result":if findings.is_empty(){"replay_conformant"}else{"replay_nonconformant"},"dialect":"fsl-ai-hard.v0","finding_schema_version":"fsl-ai-finding.v0","event_schema_version":"fsl-ai-event.v0","ai_component":summary.component,"events_checked":events.len(),"formal_result":"not_run","evidence":{"kind":"runtime_replay","formal_proof":false},"assumptions":[],"findings":findings}),
         );
     }
-    let component = match parse_surface_document(path) {
+    let component = match load_surface_document(path) {
         Ok(fsl_syntax::SurfaceDocument::AiComponent(component)) => component,
         Ok(_) => {
             return (
@@ -6274,7 +6297,7 @@ fn run_ai_replay(path: &Path, logs: &Path, selected_component: Option<&str>) -> 
                 2,
             );
         }
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     if selected_component.is_some_and(|selected| selected != component.name) {
         return (
@@ -6463,8 +6486,17 @@ fn ai_project_name(path: &Path) -> String {
 fn load_ai_project(path: &Path) -> Result<fsl_syntax::AiProject, (Value, i32)> {
     let source = std::fs::read_to_string(path)
         .map_err(|error| (error_output("io", &error.to_string()), 2))?;
-    fsl_syntax::parse_ai_project(&source, &ai_project_name(path))
-        .map_err(|error| (semantic_error_output(&error), 2))
+    if path.extension().and_then(std::ffi::OsStr::to_str) == Some("md") {
+        return fsl_syntax::parse_ai_project(&source, &ai_project_name(path))
+            .map_err(|error| (semantic_error_output(&error), 2));
+    }
+    match fsl_syntax::parse_ai_project(&source, &ai_project_name(path)) {
+        Ok(project) => Ok(project),
+        Err(message) => surface_parse_failure(&source).map_or_else(
+            || Err((semantic_error_output(&message), 2)),
+            |error| Err((surface_parse_error_output(&error), 2)),
+        ),
+    }
 }
 
 /// `fslc ai eval`: check a selected `statistical_property`'s declared
@@ -6623,7 +6655,7 @@ fn run_ai_compat(path: &Path, environment: Option<&str>) -> (Value, i32) {
                 Err(error) => return (semantic_error_output(&error), 2),
             }
         } else {
-            match parse_surface_document(path) {
+            match load_surface_document(path) {
                 Ok(fsl_syntax::SurfaceDocument::AiComponent(component)) => vec![component],
                 Ok(_) => {
                     return (
@@ -6633,7 +6665,7 @@ fn run_ai_compat(path: &Path, environment: Option<&str>) -> (Value, i32) {
                         2,
                     );
                 }
-                Err(error) => return (semantic_error_output(&error), 2),
+                Err(error) => return (spec_load_error_output(&error), 2),
             }
         };
     if components.is_empty() {
@@ -6746,18 +6778,26 @@ fn ai_compat_profile_block(profile: &Value) -> String {
     format!("artifact {artifact} {{\n{requires_line}{provides_line}}}\n")
 }
 
-fn parse_domain_document(path: &Path) -> Result<fsl_syntax::DomainSpec, String> {
-    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
-    parse_domain_document_from_source(path, &source)
+fn parse_domain_document(path: &Path) -> Result<fsl_syntax::DomainSpec, SpecLoadError> {
+    match load_surface_document(path)? {
+        fsl_syntax::SurfaceDocument::Domain(domain) => Ok(domain),
+        _ => Err(SpecLoadError::unlocated_semantic(
+            "expected a domain document",
+        )),
+    }
 }
 
+/// Same as [`parse_domain_document`], but from an already-captured source
+/// string so a caller that must validate and project the identical snapshot
+/// (#796) does not re-read `path`.
 fn parse_domain_document_from_source(
-    path: &Path,
     source: &str,
-) -> Result<fsl_syntax::DomainSpec, String> {
-    match parse_surface_document_from_source(path, source)? {
+) -> Result<fsl_syntax::DomainSpec, SpecLoadError> {
+    match load_surface_document_from_source(source)? {
         fsl_syntax::SurfaceDocument::Domain(domain) => Ok(domain),
-        _ => Err("expected a domain document".to_owned()),
+        _ => Err(SpecLoadError::unlocated_semantic(
+            "expected a domain document",
+        )),
     }
 }
 
@@ -6766,9 +6806,11 @@ fn parse_domain_document_from_source(
 /// The AST projected by `domain analyze` / `domain expand` and the checked
 /// Kernel validation must originate from this same string. Re-reading `path`
 /// after parsing would permit an atomic save to validate different content.
-fn read_domain_command_input(path: &Path) -> Result<(String, fsl_syntax::DomainSpec), String> {
-    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
-    let domain = parse_domain_document_from_source(path, &source)?;
+fn read_domain_command_input(
+    path: &Path,
+) -> Result<(String, fsl_syntax::DomainSpec), SpecLoadError> {
+    let source = read_spec_source(path)?;
+    let domain = parse_domain_document_from_source(&source)?;
     Ok((source, domain))
 }
 
@@ -6830,7 +6872,7 @@ fn run_domain_check(
     let domain = match parse_domain_document(path) {
         Ok(domain) => domain,
         Err(error) => {
-            return apply_domain_edition((semantic_error_output(&error), 2), path, path, edition);
+            return apply_domain_edition((spec_load_error_output(&error), 2), path, path, edition);
         }
     };
     let (kernel, status) = run_verify(path, depth, deadlock, engine, DEFAULT_EXPLICIT_BUDGET, 1);
@@ -6860,14 +6902,14 @@ fn run_domain_analyze(path: &Path) -> (Value, i32) {
             },
             Err(error) => (core_error_output(&error), 2),
         },
-        Err(error) => (semantic_error_output(&error), 2),
+        Err(error) => (spec_load_error_output(&error), 2),
     }
 }
 
 fn run_domain_expand(path: &Path, output_path: Option<&Path>) -> (Value, i32) {
     let (input_source, domain) = match read_domain_command_input(path) {
         Ok(input) => input,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let source = match fsl_tools::domain_kernel_source(&domain) {
         Ok(source) => source,
@@ -6899,7 +6941,7 @@ fn run_domain_generate(
 ) -> (Value, i32) {
     let domain = match parse_domain_document(path) {
         Ok(domain) => domain,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     if profile != "functional-ddd" {
         return (
@@ -7067,7 +7109,7 @@ fn domain_replay_step(
 fn run_domain_replay(path: &Path, logs: &Path) -> (Value, i32) {
     let domain = match parse_domain_document(path) {
         Ok(domain) => domain,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let events = match read_json_events(logs) {
         Ok(events) => events,
@@ -7346,7 +7388,7 @@ fn run_domain_testgen(
 ) -> (Value, i32) {
     let domain = match parse_domain_document(path) {
         Ok(domain) => domain,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let (generic, generic_status) = run_testgen(path, depth, target, deadlock_mode, strict, None);
     if generic_status != 0 {
@@ -10977,6 +11019,24 @@ fn approval_artifact(
     Ok((bytes, None))
 }
 
+fn approval_spec_digest(path: &Path) -> Result<String, SpecLoadError> {
+    if path.extension().and_then(std::ffi::OsStr::to_str) == Some("md") {
+        return approval::spec_digest(path).map_err(SpecLoadError::unlocated_semantic);
+    }
+    let source = read_spec_source(path)?;
+    if fsl_syntax::extract_literate_fsl(&source).is_some() {
+        return approval::spec_digest(path).map_err(SpecLoadError::unlocated_semantic);
+    }
+    let resolver = fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
+    let kernel = fsl_core::parse_kernel_source(&source, &resolver).map_err(|error| {
+        surface_parse_failure(&source).map_or_else(
+            || SpecLoadError::unlocated_semantic(error.to_string()),
+            |error| SpecLoadError::Parse(Box::new(error)),
+        )
+    })?;
+    approval::spec_digest_kernel(&kernel).map_err(SpecLoadError::unlocated_semantic)
+}
+
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn run_approval_create(
     path: &Path,
@@ -11252,7 +11312,7 @@ fn approval_evaluation(
     approval::verify_git_baseline(&repo, &relative_path, &record.spec.git_commit)
         .map_err(|error| error_output("io", &error))?;
     let current_spec_digest =
-        approval::spec_digest(path).map_err(|error| semantic_error_output(&error))?;
+        approval_spec_digest(path).map_err(|error| spec_load_error_output(&error))?;
     let (artifact, current_claim_set_digest) =
         approval_artifact(path, &record.target.kind, &record.target.inputs)?;
     let normalized_artifact = approval::normalized_artifact(&record.target.kind, &artifact)
@@ -15120,6 +15180,15 @@ fn run_verify(
         Ok(source) => source,
         Err(error) => return (spec_load_error_output(&error), 2),
     };
+    // Causal sources deliberately sit outside `parse_document`'s dialect
+    // registry.  Classify their syntax failure with their own parser before
+    // the generic dispatcher would report the unrelated unknown-dialect
+    // diagnostic.  A valid causal source keeps the existing verify behavior.
+    if fsl_syntax::is_causal_source(&source)
+        && let Err(error) = fsl_syntax::parse_causal(&source)
+    {
+        return causal::causal_parse_error_output(&error, false);
+    }
     match fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&source)) {
         Err(error) => return (surface_parse_error_output(&error), 2),
         Ok(fsl_syntax::ParsedDocument {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5962,7 +5962,8 @@ fn load_surface_document(path: &Path) -> Result<fsl_syntax::SurfaceDocument, Spe
 fn load_surface_document_from_source(
     source: &str,
 ) -> Result<fsl_syntax::SurfaceDocument, SpecLoadError> {
-    fsl_syntax::parse_surface_document(source).map_err(|error| SpecLoadError::Parse(Box::new(error)))
+    fsl_syntax::parse_surface_document(source)
+        .map_err(|error| SpecLoadError::Parse(Box::new(error)))
 }
 
 fn validate_specialized_document(path: &Path) -> Result<(), String> {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5943,25 +5943,30 @@ fn parse_surface_document(path: &Path) -> Result<fsl_syntax::SurfaceDocument, St
 /// for callers that deliberately own a non-envelope result; spec-input
 /// commands must retain the parser's class and span through this path.
 fn load_surface_document(path: &Path) -> Result<fsl_syntax::SurfaceDocument, SpecLoadError> {
-    if path.extension().and_then(std::ffi::OsStr::to_str) == Some("md") {
-        return parse_surface_document(path).map_err(SpecLoadError::unlocated_semantic);
-    }
     // This loader's caller contract predates the typed `io` envelope. Keep a
     // read failure distinct from a parse failure without widening #780 beyond
     // its declared parse-only surface.
     let source = std::fs::read_to_string(path)
         .map_err(|error| SpecLoadError::unlocated_semantic(error.to_string()))?;
-    load_surface_document_from_source(&source)
+    load_surface_document_from_source(path, &source)
 }
 
 /// Load a dialect surface document from an already-captured source string.
 ///
 /// Domain-projection commands (#796) must validate and project from the same
 /// snapshot they read, so they call this instead of re-reading `path` through
-/// [`load_surface_document`].
+/// [`load_surface_document`]. `path` is still needed here (not just for
+/// diagnostics): a literate (`.md`) document keeps the pre-#780 unlocated
+/// `semantics` classification instead of a located `parse` envelope, and that
+/// dispatch is keyed on the extension, not the content.
 fn load_surface_document_from_source(
+    path: &Path,
     source: &str,
 ) -> Result<fsl_syntax::SurfaceDocument, SpecLoadError> {
+    if path.extension().and_then(std::ffi::OsStr::to_str) == Some("md") {
+        return parse_surface_document_from_source(path, source)
+            .map_err(SpecLoadError::unlocated_semantic);
+    }
     fsl_syntax::parse_surface_document(source)
         .map_err(|error| SpecLoadError::Parse(Box::new(error)))
 }
@@ -6796,9 +6801,10 @@ fn parse_domain_document(path: &Path) -> Result<fsl_syntax::DomainSpec, SpecLoad
 /// string so a caller that must validate and project the identical snapshot
 /// (#796) does not re-read `path`.
 fn parse_domain_document_from_source(
+    path: &Path,
     source: &str,
 ) -> Result<fsl_syntax::DomainSpec, SpecLoadError> {
-    match load_surface_document_from_source(source)? {
+    match load_surface_document_from_source(path, source)? {
         fsl_syntax::SurfaceDocument::Domain(domain) => Ok(domain),
         _ => Err(SpecLoadError::unlocated_semantic(
             "expected a domain document",
@@ -6819,7 +6825,7 @@ fn read_domain_command_input(
     // `semantics` without widening #780 beyond its declared parse-only scope.
     let source = std::fs::read_to_string(path)
         .map_err(|error| SpecLoadError::unlocated_semantic(error.to_string()))?;
-    let domain = parse_domain_document_from_source(&source)?;
+    let domain = parse_domain_document_from_source(path, &source)?;
     Ok((source, domain))
 }
 

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -1824,6 +1824,15 @@ pub(super) fn run_verify_cli(
             2,
         );
     }
+    // Causal models are intentionally outside the kernel dialect dispatcher.
+    // Check their syntax first so a malformed causal input retains its parser
+    // diagnostic instead of being rewritten as an unknown kernel dialect.
+    if let Ok(source) = std::fs::read_to_string(path)
+        && fsl_syntax::is_causal_source(&source)
+        && let Err(error) = fsl_syntax::parse_causal(&source)
+    {
+        return super::causal::causal_parse_error_output(&error, false);
+    }
     let prepared = match prepare_cli_verification(path, options) {
         Ok(prepared) => prepared,
         Err(output) => return output,

--- a/rust/fslc/tests/error_envelope_parity.rs
+++ b/rust/fslc/tests/error_envelope_parity.rs
@@ -769,11 +769,6 @@ const PARSE_WITH_DIAGNOSTIC_ALIAS: Expectation = Expectation::Json(JsonExpectati
     diagnostic: Diagnostic::Alias("parse"),
     ..PARSE_JSON
 });
-const PARSE_WITHOUT_LOCATION_OR_DIAGNOSTIC: Expectation = Expectation::Json(JsonExpectation {
-    location: LocationShape::Absent,
-    diagnostic: Diagnostic::None,
-    ..PARSE_JSON
-});
 const LITERATE_UNIFORM: Expectation = Expectation::Json(JsonExpectation {
     result: ExpectedField::Exact("error"),
     kind: ExpectedField::Exact("usage"),
@@ -1294,18 +1289,6 @@ const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
     // #800 tracks these product parse-path false negatives and envelope
     // differences. They are not accepted behavior: replay reports success
     // for a malformed project while its siblings reject it inconsistently.
-    // #780 tracks nonuniform product Parse envelopes. #801 separately tracks
-    // deriving the hand-authored input-shape population from an independent
-    // owner; resolving that structural task alone would not make these cells
-    // uniform.
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Parse,
-        "check",
-        PARSE_AI_PROJECT_FIXTURE,
-        PARSE_WITHOUT_LOCATION_OR_DIAGNOSTIC,
-        "#780"
-    ),
     pin!(
         shape: InputShape::Project;
         FailureClass::Parse,

--- a/rust/fslc/tests/error_envelope_parity.rs
+++ b/rust/fslc/tests/error_envelope_parity.rs
@@ -30,6 +30,8 @@ const PARSE_DB_FIXTURE: &str = "rust/fslc/tests/fixtures/error_envelope_broken_d
 const PARSE_AI_FIXTURE: &str = "rust/fslc/tests/fixtures/error_envelope_broken_ai_component.fsl";
 const PARSE_AI_PROJECT_FIXTURE: &str =
     "rust/fslc/tests/fixtures/error_envelope_broken_ai_project.fsl";
+const PARSE_AI_PROJECT_DUPLICATE_FIXTURE: &str =
+    "rust/fslc/tests/fixtures/error_envelope_duplicate_ai_project.fsl";
 const PARSE_CAUSAL_FIXTURE: &str = "rust/fslc/tests/fixtures/error_envelope_broken_causal.fsl";
 const PARSE_APPROVAL_REQUIREMENTS_DOCUMENT_FIXTURE: &str =
     "rust/fslc/tests/fixtures/error_envelope_broken_approval_requirements_document.fsl";
@@ -1216,7 +1218,7 @@ const CAUSAL_COVERAGE: &[FailureCoverage] = &[
     FailureCoverage {
         class: FailureClass::Name,
         fixture: CAUSAL_NAME_FIXTURE,
-        uniform: SEMANTIC_WITHOUT_INPUT_PATH,
+        uniform: CAUSAL_NAME_WITH_DIAGNOSTIC,
     },
 ];
 const DOMAIN_COVERAGE: &[FailureCoverage] = &[
@@ -1292,14 +1294,6 @@ const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
     // #800 tracks these product parse-path false negatives and envelope
     // differences. They are not accepted behavior: replay reports success
     // for a malformed project while its siblings reject it inconsistently.
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Parse,
-        "ai check",
-        PARSE_AI_PROJECT_FIXTURE,
-        PARSE_WITHOUT_LOCATION_OR_DIAGNOSTIC,
-        "#800"
-    ),
     // #780 tracks nonuniform product Parse envelopes. #801 separately tracks
     // deriving the hand-authored input-shape population from an independent
     // owner; resolving that structural task alone would not make these cells
@@ -1310,48 +1304,6 @@ const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
         "check",
         PARSE_AI_PROJECT_FIXTURE,
         PARSE_WITHOUT_LOCATION_OR_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal analyze",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal check",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal diff",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal ledger",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal observe-expectations",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal verify-expectations",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
         "#780"
     ),
     pin!(
@@ -1970,7 +1922,7 @@ fn has_literate_not_applicable(entry: &CommandRegistration) -> bool {
 fn coverage_input_shape(command: &str, fixture: &str) -> InputShape {
     if matches!(command, "check" | "verify") {
         return match fixture {
-            PARSE_AI_PROJECT_FIXTURE => InputShape::Project,
+            PARSE_AI_PROJECT_FIXTURE | PARSE_AI_PROJECT_DUPLICATE_FIXTURE => InputShape::Project,
             PARSE_CAUSAL_FIXTURE => InputShape::Causal,
             _ => InputShape::Source,
         };
@@ -1980,6 +1932,7 @@ fn coverage_input_shape(command: &str, fixture: &str) -> InputShape {
     }
     if command.starts_with("ai ") {
         if fixture == PARSE_AI_PROJECT_FIXTURE
+            || fixture == PARSE_AI_PROJECT_DUPLICATE_FIXTURE
             || fixture == AI_PROJECT_GUARD_FIXTURE
             || fixture == AI_PROJECT_NAME_FIXTURE
         {
@@ -2610,6 +2563,64 @@ fn parse_errors_are_uniform_or_pinned_across_frontend_siblings() {
     for cell in cells(FailureClass::Parse) {
         assert_cell(cell);
     }
+}
+
+#[test]
+fn ai_project_parser_failures_keep_their_own_spans_across_evidence_commands() {
+    for fixture in [PARSE_AI_PROJECT_FIXTURE, PARSE_AI_PROJECT_DUPLICATE_FIXTURE] {
+        let outputs = ["ai check", "ai drift", "ai eval", "ai regress"]
+            .into_iter()
+            .map(|command| {
+                let actual = run(command, fixture);
+                assert_expectation(
+                    &actual,
+                    PARSE_UNIFORM,
+                    fixture,
+                    FailureClass::Parse,
+                    command,
+                );
+                actual.json.expect("parse error JSON envelope")
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            outputs.windows(2).all(|pair| pair[0] == pair[1]),
+            "{fixture} must retain one parser-owned envelope: {outputs:?}"
+        );
+        if fixture == PARSE_AI_PROJECT_DUPLICATE_FIXTURE {
+            assert_eq!(
+                outputs[0]["loc"],
+                serde_json::json!({"line": 13, "column": 1}),
+                "the duplicate declaration, not a preceding sibling, owns the diagnostic"
+            );
+            assert_eq!(
+                outputs[0]["message"],
+                "duplicate statistical_property 'DuplicateQuality' at 13:1"
+            );
+        }
+    }
+}
+
+#[test]
+fn surface_loader_read_failures_keep_the_legacy_semantic_envelope() {
+    let missing = "rust/fslc/tests/fixtures/error_envelope_missing_surface_input.fsl";
+    assert!(
+        !workspace_root().join(missing).exists(),
+        "{missing} is reserved as a missing-input calibration path"
+    );
+    let actual = run_from(
+        "domain analyze",
+        PARSE_DOMAIN_FIXTURE,
+        missing,
+        None,
+        &workspace_root(),
+    );
+    assert_eq!(actual.exit, 2, "{}", actual.stdout);
+    let output = actual.json.expect("missing input JSON envelope");
+    assert_eq!(output["result"], "error", "{output}");
+    assert_eq!(output["kind"], "semantics", "{output}");
+    assert!(output.get("loc").is_none(), "{output}");
+    assert!(output.get("diagnostic").is_none(), "{output}");
+    assert!(output.get("diagnostic_code").is_none(), "{output}");
 }
 
 #[test]

--- a/rust/fslc/tests/error_envelope_parity.rs
+++ b/rust/fslc/tests/error_envelope_parity.rs
@@ -772,11 +772,6 @@ const PARSE_WITHOUT_LOCATION_OR_DIAGNOSTIC: Expectation = Expectation::Json(Json
     diagnostic: Diagnostic::None,
     ..PARSE_JSON
 });
-const PARSE_WITH_DIALECT_UNKNOWN_DIAGNOSTIC: Expectation = Expectation::Json(JsonExpectation {
-    diagnostic: Diagnostic::Code("FSL-DIALECT-UNKNOWN"),
-    ..PARSE_JSON
-});
-
 const LITERATE_UNIFORM: Expectation = Expectation::Json(JsonExpectation {
     result: ExpectedField::Exact("error"),
     kind: ExpectedField::Exact("usage"),
@@ -1294,110 +1289,6 @@ macro_rules! pin {
 }
 
 const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
-    pin!(
-        FailureClass::Parse,
-        "domain check",
-        PARSE_DOMAIN_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "domain analyze",
-        PARSE_DOMAIN_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "domain expand",
-        PARSE_DOMAIN_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "domain generate",
-        PARSE_DOMAIN_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "domain replay",
-        PARSE_DOMAIN_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "domain testgen",
-        PARSE_DOMAIN_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "db check",
-        PARSE_DB_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "db observe",
-        PARSE_DB_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        shape: InputShape::Component;
-        FailureClass::Parse,
-        "ai check",
-        PARSE_AI_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        shape: InputShape::Component;
-        FailureClass::Parse,
-        "ai compat",
-        PARSE_AI_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        shape: InputShape::Component;
-        FailureClass::Parse,
-        "ai drift",
-        PARSE_AI_FIXTURE,
-        SEMANTIC_WITHOUT_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        shape: InputShape::Component;
-        FailureClass::Parse,
-        "ai eval",
-        PARSE_AI_FIXTURE,
-        SEMANTIC_WITHOUT_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        shape: InputShape::Component;
-        FailureClass::Parse,
-        "ai regress",
-        PARSE_AI_FIXTURE,
-        SEMANTIC_WITHOUT_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        shape: InputShape::Component;
-        FailureClass::Parse,
-        "ai replay",
-        PARSE_AI_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
     // #800 tracks these product parse-path false negatives and envelope
     // differences. They are not accepted behavior: replay reports success
     // for a malformed project while its siblings reject it inconsistently.
@@ -1422,19 +1313,45 @@ const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
         "#780"
     ),
     pin!(
-        shape: InputShape::Causal;
-        FailureClass::Parse,
-        "check",
-        PARSE_CAUSAL_FIXTURE,
-        PARSE_WITH_DIAGNOSTIC_ALIAS,
+        FailureClass::Name,
+        "causal analyze",
+        CAUSAL_NAME_FIXTURE,
+        CAUSAL_NAME_WITH_DIAGNOSTIC,
         "#780"
     ),
     pin!(
-        shape: InputShape::Causal;
-        FailureClass::Parse,
-        "verify",
-        PARSE_CAUSAL_FIXTURE,
-        PARSE_WITH_DIALECT_UNKNOWN_DIAGNOSTIC,
+        FailureClass::Name,
+        "causal check",
+        CAUSAL_NAME_FIXTURE,
+        CAUSAL_NAME_WITH_DIAGNOSTIC,
+        "#780"
+    ),
+    pin!(
+        FailureClass::Name,
+        "causal diff",
+        CAUSAL_NAME_FIXTURE,
+        CAUSAL_NAME_WITH_DIAGNOSTIC,
+        "#780"
+    ),
+    pin!(
+        FailureClass::Name,
+        "causal ledger",
+        CAUSAL_NAME_FIXTURE,
+        CAUSAL_NAME_WITH_DIAGNOSTIC,
+        "#780"
+    ),
+    pin!(
+        FailureClass::Name,
+        "causal observe-expectations",
+        CAUSAL_NAME_FIXTURE,
+        CAUSAL_NAME_WITH_DIAGNOSTIC,
+        "#780"
+    ),
+    pin!(
+        FailureClass::Name,
+        "causal verify-expectations",
+        CAUSAL_NAME_FIXTURE,
+        CAUSAL_NAME_WITH_DIAGNOSTIC,
         "#780"
     ),
     pin!(
@@ -1448,132 +1365,10 @@ const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
     pin!(
         shape: InputShape::Project;
         FailureClass::Parse,
-        "ai drift",
-        PARSE_AI_PROJECT_FIXTURE,
-        SEMANTIC_WITHOUT_INPUT_PATH_WITHOUT_LOCATION,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Parse,
-        "ai eval",
-        PARSE_AI_PROJECT_FIXTURE,
-        SEMANTIC_WITHOUT_INPUT_PATH_WITHOUT_LOCATION,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Parse,
-        "ai regress",
-        PARSE_AI_PROJECT_FIXTURE,
-        SEMANTIC_WITHOUT_INPUT_PATH_WITHOUT_LOCATION,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Parse,
         "ai replay",
         PARSE_AI_PROJECT_FIXTURE,
         AI_REPLAY_FALSE_GREEN,
         "#800"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "compat check",
-        PARSE_KERNEL_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "causal check",
-        PARSE_CAUSAL_FIXTURE,
-        PARSE_WITH_DIAGNOSTIC_ALIAS,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "causal verify-expectations",
-        PARSE_CAUSAL_FIXTURE,
-        CAUSAL_PARSE_WITHOUT_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "causal analyze",
-        PARSE_CAUSAL_FIXTURE,
-        PARSE_WITH_DIAGNOSTIC_ALIAS,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "causal diff",
-        PARSE_CAUSAL_FIXTURE,
-        PARSE_WITH_DIAGNOSTIC_ALIAS,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "causal ledger",
-        PARSE_CAUSAL_FIXTURE,
-        PARSE_WITH_DIAGNOSTIC_ALIAS,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "causal observe-expectations",
-        PARSE_CAUSAL_FIXTURE,
-        CAUSAL_PARSE_WITHOUT_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal analyze",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal check",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal diff",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal ledger",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal observe-expectations",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "causal verify-expectations",
-        CAUSAL_NAME_FIXTURE,
-        CAUSAL_NAME_WITH_DIAGNOSTIC,
-        "#780"
-    ),
-    pin!(
-        FailureClass::Parse,
-        "approval check",
-        PARSE_KERNEL_FIXTURE,
-        SEMANTIC_WITHOUT_INPUT_PATH_WITHOUT_LOCATION,
-        "#780"
     ),
     // #800 tracks these product false negatives. They are not accepted
     // behavior: the affected command/input-shape pairs report success

--- a/rust/fslc/tests/fixtures/error_envelope_duplicate_ai_project.fsl
+++ b/rust/fslc/tests/fixtures/error_envelope_duplicate_ai_project.fsl
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+dataset DuplicateRecords {
+  source "records.jsonl"
+}
+
+statistical_property DuplicateQuality {
+  target SupportAnswerAgent
+  dataset DuplicateRecords
+  require min_samples >= 0
+}
+
+statistical_property DuplicateQuality {
+  target SupportAnswerAgent
+  dataset DuplicateRecords
+  require min_samples >= 0
+}


### PR DESCRIPTION
## Summary
- Preserve typed surface-parser envelopes through the domain, DB, AI-component, approval, and causal loading boundaries.
- Make the fsl-ai project parser return its own typed `ParseError`; generic `check`, `ai check`, `ai drift`, `ai eval`, and `ai regress` now retain the parser-owned `FSL-PARSE` span.
- Keep read failures at the affected surface loaders on their legacy `kind:"semantics"` envelope; #780 is scoped to parse failures.
- Move causal Name cells to their established `causal_unknown_reference` diagnostic expectation rather than pinning them as #780 debt.

## Cause and contract
`parse_ai_project` detected duplicate declarations but returned only a string. The dialect commands then ran the generic parser on an AI project, which could report a sibling declaration rather than the actual duplicate. `parse_ai_project` now returns a typed `ParseError` with an original-source span, and all native/Worker AI-project check renderers preserve that exact error.

The shared surface loader had also changed read failures to `kind:"io"` incidentally. This PR deliberately preserves the base public envelope for those failures; the regression test asserts only stable fields, not OS-dependent errno/path text.

## Evidence
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test error_envelope_parity --locked`
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test causal_cli --locked`
- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --locked`
- `cargo test --manifest-path rust/Cargo.toml --workspace --locked`
- `./tools/aggregate_changelog.sh check`
- The nested-component and duplicate-declaration negative controls run across `ai check`, `ai drift`, `ai eval`, and `ai regress`. The duplicate control reports `kind:"parse"`, `diagnostic_code:"FSL-PARSE"`, and `{line:13,column:1}` in all four commands.
- Native generic `check` and the browser Worker now have explicit malformed-AI-project coverage for the same location and code.
- Base (`2259def`) and this head both report a missing `domain analyze` input as exit 2, `result:"error"`, `kind:"semantics"`, and no `loc`/diagnostic fields. The test does not inspect platform-specific message text.

## Remaining pins
14 `#780` pins remain, all unrelated Guard/Name asymmetries outside the specialized parse-load boundary. `#800` is partially resolved; 18 pins remain for its separate AI-project validation gaps.

## Risk / Review Notes
Public JSON changes are limited to declared parse-failure boundaries plus native/Worker AI-project checks and evidence commands. `ai compat × AI project` and `ai replay × AI project` retain their existing behavior. No frozen Python files, FSL specs, CLI flags, or `cli-contract.json` changed.

Refs #780