### PR TITLE
fix(verify): bind verification to one captured root-spec snapshot

### DIFF
--- a/changelog.d/808-run-verify-single-snapshot.fixed.md
+++ b/changelog.d/808-run-verify-single-snapshot.fixed.md
@@ -1,0 +1,2 @@
+Fixed (#808): native `fslc` verification now binds validation, lowering,
+requirements metadata, and engine execution to one captured root-spec snapshot.

--- a/docs/DESIGN-rust-integration.md
+++ b/docs/DESIGN-rust-integration.md
@@ -43,6 +43,21 @@ six Rust-only causal commands, and the native test fixes that leaf count plus th
 `causal verify` path. `tools/export_cli_contract.py` exports only the frozen Python compatibility
 subset and refuses to overwrite the authoritative native file.
 
+## Root-source snapshot integrity
+
+`run_verify` and the native `verify` CLI capture their root specification once and derive
+specialized-document validation, Kernel/model lowering, requirements trace and implements metadata,
+strict-tag warnings, and every selected native verification engine from that same source string
+(#808). A concurrent atomic replacement of the root path therefore cannot make a successful
+verification report results derived from two versions of that document. The path-taking wrappers
+remain available to command entries that have not yet adopted this contract.
+
+This boundary applies only to the root document. `FsResolver` continues to read compose, import,
+and implements dependencies at their referenced paths; making the whole dependency graph
+transactional is a separate contract. Re-parsing the captured root source in individual helpers is
+allowed: it is the source identity, rather than sharing an AST or model, that establishes the
+snapshot guarantee.
+
 The #442 local-optimum audit found that retaining the old Python exporter as an apparent complete
 source was locally convenient when the Rust CLI still matched it, but became a `mixed`
 externalization/time-delayed defect once causal evolved only in Rust: documentation and 39 causal

--- a/docs/DESIGN-rust-integration.md
+++ b/docs/DESIGN-rust-integration.md
@@ -47,10 +47,11 @@ subset and refuses to overwrite the authoritative native file.
 
 `run_verify` and the native `verify` CLI capture their root specification once and derive
 specialized-document validation, Kernel/model lowering, requirements trace and implements metadata,
-strict-tag warnings, and every selected native verification engine from that same source string
-(#808). A concurrent atomic replacement of the root path therefore cannot make a successful
-verification report results derived from two versions of that document. The path-taking wrappers
-remain available to command entries that have not yet adopted this contract.
+strict-tag warnings, every selected native verification engine (BMC and induction, across every
+supported `--edition`), and the edition post-processing stage from that same source string (#808). A
+concurrent atomic replacement of the root path therefore cannot make a successful verification
+report results derived from two versions of that document. The path-taking wrappers remain
+available to command entries that have not yet adopted this contract.
 
 This boundary applies only to the root document. `FsResolver` continues to read compose, import,
 and implements dependencies at their referenced paths; making the whole dependency graph

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -16469,6 +16469,20 @@ spec InitTraceability {
                 output["leads_to"]["Served"]["checked_to_depth"], 4,
                 "{engine}/{edition} must execute source A's leadsTo check: {output:#}"
             );
+            // `checked_to_depth` alone only echoes `--depth`; it would match
+            // for any model that merely declares a `Served` leadsTo property.
+            // The `vacuous_leadsto` warning instead depends on the engine
+            // having actually evaluated source A's `pending ~> done` trigger
+            // reachability, so it is fixture-content evidence that the
+            // liveness check ran against A rather than a stray default.
+            assert!(
+                output["warnings"].as_array().is_some_and(|warnings| {
+                    warnings.iter().any(|warning| {
+                        warning["kind"] == "vacuous_leadsto" && warning["name"] == "Served"
+                    })
+                }),
+                "{engine}/{edition} must report source A's vacuous leadsTo trigger: {output:#}"
+            );
             if edition == "next" {
                 assert_eq!(
                     output["edition"], "next",

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -16416,7 +16416,7 @@ spec InitTraceability {
         let (_kernel, model) =
             load_kernel_model_from_source(&fixture.path, &captured).expect("lower source A");
         assert!(
-            model.state.contains_key("pending"),
+            model.state.iter().any(|(name, _)| name == "pending"),
             "kernel model must retain source A's state"
         );
         assert_eq!(
@@ -16437,8 +16437,16 @@ spec InitTraceability {
             "source A must retain its liveness property"
         );
 
-        for engine in ["bmc", "induction"] {
-            let (output, status) = run_verify_from_source(
+        // The in-process control covers every public engine × edition
+        // combination. `edition=next` additionally proves that the
+        // post-processing stage retains the already captured source.
+        for (engine, edition, expected_result) in [
+            ("bmc", "current", "verified"),
+            ("bmc", "next", "verified"),
+            ("induction", "current", "proved"),
+            ("induction", "next", "proved"),
+        ] {
+            let result = run_verify_from_source(
                 &fixture.path,
                 &captured,
                 4,
@@ -16447,11 +16455,26 @@ spec InitTraceability {
                 DEFAULT_EXPLICIT_BUDGET,
                 1,
             );
-            assert_eq!(status, 0, "{engine} must verify source A: {output:#}");
-            assert_ne!(
-                output["result"], "error",
-                "{engine} must not observe replacement source B: {output:#}"
+            let (output, status) =
+                apply_domain_edition_from_source(result, &captured, &fixture.path, edition);
+            assert_eq!(
+                status, 0,
+                "{engine}/{edition} must verify source A: {output:#}"
             );
+            assert_eq!(
+                output["result"], expected_result,
+                "{engine}/{edition} must retain source A's verdict: {output:#}"
+            );
+            assert_eq!(
+                output["leads_to"]["Served"]["checked_to_depth"], 4,
+                "{engine}/{edition} must execute source A's leadsTo check: {output:#}"
+            );
+            if edition == "next" {
+                assert_eq!(
+                    output["edition"], "next",
+                    "{engine}/{edition} post-processing must use source A: {output:#}"
+                );
+            }
         }
     }
 

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -29,7 +29,7 @@ use causal::{causal_command, run_causal_check};
 use verification::{
     BmcRequest, DeadlockMode, ExplicitRequest, InductionRequest, ModelSelection,
     VerificationEngine, run_auto_filtered, run_bmc_filtered, run_explicit_filtered,
-    run_induction_filtered, run_verify_cli,
+    run_induction_filtered, run_verify_cli, run_verify_cli_from_source,
 };
 
 const CLI_CONTRACT: &str = include_str!("../cli-contract.json");
@@ -1761,10 +1761,14 @@ fn command() -> Result<(Value, i32), String> {
                 .map_or(&display_path, |state| &state.path);
             let options = parse_verify_options(&mut args)?;
             Ok(if command == "verify" {
-                let result = run_verify_cli(path, &display_path, &options);
-                with_version_metadata(apply_domain_edition(
+                let source = match read_spec_source(path) {
+                    Ok(source) => source,
+                    Err(error) => return Ok((spec_load_error_output(&error), 2)),
+                };
+                let result = run_verify_cli_from_source(path, &display_path, &source, &options);
+                with_version_metadata(apply_domain_edition_from_source(
                     result,
-                    path,
+                    &source,
                     &display_path,
                     &options.edition,
                 ))
@@ -5853,7 +5857,7 @@ fn run_check_with_tags(
 /// names the document the caller passed on the command line, never the
 /// transient materialization.
 fn apply_domain_edition(
-    (mut output, status): (Value, i32),
+    (output, status): (Value, i32),
     path: &Path,
     display_path: &Path,
     edition: &str,
@@ -5861,13 +5865,22 @@ fn apply_domain_edition(
     let Ok(source) = std::fs::read_to_string(path) else {
         return (output, status);
     };
+    apply_domain_edition_from_source((output, status), &source, display_path, edition)
+}
+
+fn apply_domain_edition_from_source(
+    (mut output, status): (Value, i32),
+    source: &str,
+    display_path: &Path,
+    edition: &str,
+) -> (Value, i32) {
     let migration_edition = if edition == "next" {
         fslc_rust::migration::Edition::Next
     } else {
         fslc_rust::migration::Edition::Current
     };
     let Ok(plan) = fslc_rust::migration::plan_migration(
-        &source,
+        source,
         &display_path.to_string_lossy(),
         migration_edition,
     ) else {
@@ -5881,7 +5894,7 @@ fn apply_domain_edition(
         .collect::<Vec<_>>();
     if edition != "next" {
         additions.extend(fslc_rust::frontend_output::implicit_initial_value_warnings(
-            &source,
+            source,
             &display_path.to_string_lossy(),
         ));
     }
@@ -5971,8 +5984,8 @@ fn load_surface_document_from_source(
         .map_err(|error| SpecLoadError::Parse(Box::new(error)))
 }
 
-fn validate_specialized_document(path: &Path) -> Result<(), String> {
-    match parse_surface_document(path)? {
+fn validate_specialized_document_from_source(path: &Path, source: &str) -> Result<(), String> {
+    match parse_surface_document_from_source(path, source)? {
         fsl_syntax::SurfaceDocument::Db(system) => {
             fsl_tools::validate_db(&system).map_err(|error| error.to_string())
         }
@@ -6004,6 +6017,11 @@ fn validate_specialized_document(path: &Path) -> Result<(), String> {
         }
         _ => Ok(()),
     }
+}
+
+fn validate_specialized_document(path: &Path) -> Result<(), String> {
+    let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    validate_specialized_document_from_source(path, &source)
 }
 
 fn run_db_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Value, i32) {
@@ -14549,7 +14567,15 @@ fn validate_requirement_traces(
     model: &KernelModel,
 ) -> Result<(Option<Value>, bool), String> {
     let source = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
-    validate_requirement_trace_source(&source, model)
+    validate_requirement_traces_from_source(path, &source, model)
+}
+
+fn validate_requirement_traces_from_source(
+    _path: &Path,
+    source: &str,
+    model: &KernelModel,
+) -> Result<(Option<Value>, bool), String> {
+    validate_requirement_trace_source(source, model)
 }
 
 fn requirement_step_match(
@@ -14610,8 +14636,17 @@ fn implements_result(
             span: None,
         }
     })?;
+    implements_result_from_source(path, &source, model, depth)
+}
+
+fn implements_result_from_source(
+    path: &Path,
+    source: &str,
+    model: &KernelModel,
+    depth: usize,
+) -> Result<Option<Value>, fslc_rust::verification_output::RequirementsImplementsError> {
     let resolver = fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
-    fslc_rust::verification_output::requirements_implements_output(&source, &resolver, model, depth)
+    fslc_rust::verification_output::requirements_implements_output(source, &resolver, model, depth)
 }
 
 fn implements_error_output(
@@ -15195,16 +15230,42 @@ fn run_verify(
         Ok(source) => source,
         Err(error) => return (spec_load_error_output(&error), 2),
     };
+    run_verify_from_source(
+        path,
+        &source,
+        depth,
+        deadlock_mode,
+        engine,
+        explicit_budget,
+        k_ind,
+    )
+}
+
+/// Verify one caller-owned root-source snapshot.
+///
+/// The specialized validation, Kernel/model lowering, requirements metadata,
+/// and selected verification engine all derive from `source`. Dependency files
+/// loaded by `FsResolver` deliberately retain their independent read semantics.
+#[allow(clippy::too_many_lines)]
+fn run_verify_from_source(
+    path: &Path,
+    source: &str,
+    depth: usize,
+    deadlock_mode: &str,
+    engine: &str,
+    explicit_budget: usize,
+    k_ind: usize,
+) -> (Value, i32) {
     // Causal sources deliberately sit outside `parse_document`'s dialect
     // registry.  Classify their syntax failure with their own parser before
     // the generic dispatcher would report the unrelated unknown-dialect
     // diagnostic.  A valid causal source keeps the existing verify behavior.
-    if fsl_syntax::is_causal_source(&source)
-        && let Err(error) = fsl_syntax::parse_causal(&source)
+    if fsl_syntax::is_causal_source(source)
+        && let Err(error) = fsl_syntax::parse_causal(source)
     {
         return causal::causal_parse_error_output(&error, false);
     }
-    match fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&source)) {
+    match fsl_syntax::parse_document(fsl_syntax::SourceFile::new(source)) {
         Err(error) => return (surface_parse_error_output(&error), 2),
         Ok(fsl_syntax::ParsedDocument {
             surface: fsl_syntax::SurfaceDocument::Agent(_),
@@ -15220,31 +15281,49 @@ fn run_verify(
         }
         Ok(_) => {}
     }
-    if let Err(error) = validate_specialized_document(path) {
+    if let Err(error) = validate_specialized_document_from_source(path, source) {
         return (semantic_error_output(&error), 2);
     }
-    let mut has_trace_contract = false;
-    let mut implements = None;
-    let mut compose_warnings = Vec::new();
-    if let Ok((_, kernel, model)) = load_kernel_model(path) {
-        match validate_requirement_traces(path, &model) {
-            Ok((Some(failure), _)) => return (failure, 2),
-            Ok((None, has_contract)) => has_trace_contract = has_contract,
-            Err(error) => return (semantic_error_output(&error), 2),
+    // Preserve the established precedence of usage diagnostics over a Kernel
+    // load failure: the former path-based implementation reached engine
+    // selection before its engine loaded the model. Keep the error deferred,
+    // but never re-read `path` to obtain it.
+    let loaded_model = load_kernel_model_from_source(path, source);
+    let (has_trace_contract, implements, compose_warnings) = match &loaded_model {
+        Ok((kernel, model)) => {
+            let has_trace_contract =
+                match validate_requirement_traces_from_source(path, source, model) {
+                    Ok((Some(failure), _)) => return (failure, 2),
+                    Ok((None, has_contract)) => has_contract,
+                    Err(error) => return (semantic_error_output(&error), 2),
+                };
+            let implements = match implements_result_from_source(path, source, model, depth) {
+                Ok(implements) => implements,
+                Err(error) => return (implements_error_output(&error), 2),
+            };
+            (
+                has_trace_contract,
+                implements,
+                kernel.diagnostics().to_vec(),
+            )
         }
-        implements = match implements_result(path, &model, depth) {
-            Ok(implements) => implements,
-            Err(error) => return (implements_error_output(&error), 2),
-        };
-        compose_warnings = kernel.diagnostics().to_vec();
-    }
+        Err(_) => (false, None, Vec::new()),
+    };
     let deadlock = match DeadlockMode::parse(deadlock_mode) {
         Ok(mode) => mode,
         Err(error) => return (error_output("usage", &error), 2),
     };
+    let engine = match VerificationEngine::parse(engine) {
+        Ok(engine) => engine,
+        Err(error) => return (error_output("usage", &error), 2),
+    };
+    let (_, model) = match loaded_model {
+        Ok(model) => model,
+        Err(error) => return (spec_load_error_output(&error), 2),
+    };
     let selection = ModelSelection {
         path,
-        model: None,
+        model: Some(&model),
         scope: None,
         property: None,
         excluded: &[],
@@ -15254,15 +15333,15 @@ fn run_verify(
     // `BmcOutputOptions::skip_vacuity_probe` (issue #729), it must always
     // compute the reachability probe.
     let skip_vacuity_probe = false;
-    let (mut output, status) = match VerificationEngine::parse(engine) {
-        Ok(VerificationEngine::Bmc) => run_bmc_filtered(BmcRequest {
+    let (mut output, status) = match engine {
+        VerificationEngine::Bmc => run_bmc_filtered(BmcRequest {
             selection,
             depth,
             deadlock,
             initial_state: None,
             skip_vacuity_probe,
         }),
-        Ok(VerificationEngine::Induction) => run_induction_filtered(InductionRequest {
+        VerificationEngine::Induction => run_induction_filtered(InductionRequest {
             selection,
             depth,
             deadlock,
@@ -15270,21 +15349,20 @@ fn run_verify(
             auxiliary: &[],
             skip_vacuity_probe,
         }),
-        Ok(VerificationEngine::Explicit) => run_explicit_filtered(ExplicitRequest {
+        VerificationEngine::Explicit => run_explicit_filtered(ExplicitRequest {
             selection,
             depth,
             deadlock,
             budget: explicit_budget,
             skip_vacuity_probe,
         }),
-        Ok(VerificationEngine::Auto) => run_auto_filtered(ExplicitRequest {
+        VerificationEngine::Auto => run_auto_filtered(ExplicitRequest {
             selection,
             depth,
             deadlock,
             budget: explicit_budget,
             skip_vacuity_probe,
         }),
-        Err(error) => return (error_output("usage", &error), 2),
     };
     if let Value::Object(envelope) = &mut output
         && envelope.get("result").and_then(Value::as_str) != Some("error")
@@ -15668,17 +15746,22 @@ fn load_model(path: &Path) -> Result<KernelModel, SpecLoadError> {
     load_kernel_model(path).map(|(_, _, model)| model)
 }
 
+fn load_model_from_source(path: &Path, source: &str) -> Result<KernelModel, SpecLoadError> {
+    load_kernel_model_from_source(path, source).map(|(_, model)| model)
+}
+
 fn load_kernel_model(path: &Path) -> Result<(String, KernelSpec, KernelModel), SpecLoadError> {
     let source = read_spec_source(path)?;
     let (kernel, model) = load_kernel_model_from_source(path, &source)?;
     Ok((source, kernel, model))
 }
 
-/// Build a checked Kernel/model from a caller-owned source snapshot.
+/// Build a checked Kernel/model from a caller-owned root-source snapshot.
 ///
 /// `load_kernel_model` remains the path-reading compatibility entry point;
-/// callers that also need a specialized surface projection must use this
-/// variant to avoid a second filesystem read.
+/// callers that already captured their source — whether to avoid a second
+/// root-path read or because they also need a specialized surface projection
+/// — use this variant. The resolver can still read imported dependencies.
 fn load_kernel_model_from_source(
     path: &Path,
     source: &str,
@@ -15930,8 +16013,16 @@ fn load_snapshot_value_object(
 
 fn load_model_scoped(path: &Path, scope: &ScopeBounds) -> Result<KernelModel, SpecLoadError> {
     let source = read_spec_source(path)?;
+    load_model_scoped_from_source(path, &source, scope)
+}
+
+fn load_model_scoped_from_source(
+    _path: &Path,
+    source: &str,
+    scope: &ScopeBounds,
+) -> Result<KernelModel, SpecLoadError> {
     let kernel =
-        match fsl_core::parse_kernel_source_with_bounds(&source, &scope.instances, &scope.values) {
+        match fsl_core::parse_kernel_source_with_bounds(source, &scope.instances, &scope.values) {
             Ok(kernel) => kernel,
             // A rejected `--instances`/`--values` bound is a CLI argument
             // defect, not a construct in the spec, so it owns no location.
@@ -15940,7 +16031,7 @@ fn load_model_scoped(path: &Path, scope: &ScopeBounds) -> Result<KernelModel, Sp
                     error.message,
                 )));
             }
-            Err(error) => return Err(kernel_load_error(&source, &error)),
+            Err(error) => return Err(kernel_load_error(source, &error)),
         };
     fsl_core::build_model(kernel)
         .map_err(|error| SpecLoadError::Semantic(SemanticDiagnostic::from_model_error(&error)))
@@ -16277,5 +16368,112 @@ spec InitTraceability {
         );
 
         std::fs::remove_dir_all(&directory).expect("remove temporary fixture directory");
+    }
+
+    struct SnapshotFixture {
+        directory: std::path::PathBuf,
+        path: std::path::PathBuf,
+    }
+
+    impl SnapshotFixture {
+        fn new(name: &str, source: &str) -> Self {
+            let directory = std::env::temp_dir().join(format!(
+                "fslc-issue-808-{name}-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("system clock after Unix epoch")
+                    .as_nanos(),
+            ));
+            std::fs::create_dir(&directory).expect("create source snapshot directory");
+            let path = directory.join("input.fsl");
+            std::fs::write(&path, source).expect("write source A");
+            Self { directory, path }
+        }
+    }
+
+    impl Drop for SnapshotFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.directory);
+        }
+    }
+
+    /// Platform-neutral #808 control. Capturing source A from a regular file
+    /// before replacing it with malformed source B must leave every
+    /// `*_from_source` helper bound to A. No scheduling, thread, rename, or
+    /// platform-specific filesystem primitive is involved.
+    #[test]
+    fn source_helpers_use_the_captured_root_snapshot() {
+        let source_a = include_str!("../tests/fixtures/vacuous_leadsto.fsl");
+        let fixture = SnapshotFixture::new("helpers", source_a);
+        let captured = read_spec_source(&fixture.path).expect("capture source A");
+        std::fs::write(&fixture.path, "not valid FSL source").expect("replace with source B");
+
+        assert!(
+            validate_specialized_document_from_source(&fixture.path, &captured).is_ok(),
+            "specialized validation must use source A"
+        );
+        let (_kernel, model) =
+            load_kernel_model_from_source(&fixture.path, &captured).expect("lower source A");
+        assert!(
+            model.state.contains_key("pending"),
+            "kernel model must retain source A's state"
+        );
+        assert_eq!(
+            validate_requirement_traces_from_source(&fixture.path, &captured, &model)
+                .expect("validate source A requirement traces"),
+            (None, false)
+        );
+        assert_eq!(
+            implements_result_from_source(&fixture.path, &captured, &model, 4)
+                .expect("derive source A implements metadata"),
+            None
+        );
+        assert!(
+            model
+                .leadstos
+                .iter()
+                .any(|property| display(&property.name) == "Served"),
+            "source A must retain its liveness property"
+        );
+
+        for engine in ["bmc", "induction"] {
+            let (output, status) = run_verify_from_source(
+                &fixture.path,
+                &captured,
+                4,
+                "warn",
+                engine,
+                DEFAULT_EXPLICIT_BUDGET,
+                1,
+            );
+            assert_eq!(status, 0, "{engine} must verify source A: {output:#}");
+            assert_ne!(
+                output["result"], "error",
+                "{engine} must not observe replacement source B: {output:#}"
+            );
+        }
+    }
+
+    /// The requirements `implements` path invokes the native refinement
+    /// engine. Its root document must use the captured requirements source
+    /// even after that path is replaced; its referenced business document is
+    /// intentionally still read through `FsResolver` and is not part of #808.
+    #[test]
+    fn implements_refinement_uses_the_captured_root_snapshot() {
+        let requirements = include_str!("../../../tests/fixtures/chain/requirements.fsl");
+        let business = include_str!("../../../tests/fixtures/chain/business.fsl");
+        let fixture = SnapshotFixture::new("implements", requirements);
+        std::fs::write(fixture.directory.join("business.fsl"), business)
+            .expect("write implements dependency");
+        let captured = read_spec_source(&fixture.path).expect("capture requirements source A");
+        std::fs::write(&fixture.path, "not valid FSL source").expect("replace with source B");
+        let (_, model) =
+            load_kernel_model_from_source(&fixture.path, &captured).expect("lower requirements A");
+
+        let implements = implements_result_from_source(&fixture.path, &captured, &model, 4)
+            .expect("derive implements refinement from source A")
+            .expect("requirements source A declares implements");
+        assert_eq!(implements["result"], "refines", "{implements:#}");
     }
 }

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -9,11 +9,13 @@ use sha2::{Digest, Sha256};
 
 use super::{
     CliVerifyOptions, ScopeBounds, SpecLoadError, add_strict_tag_warnings, apply_vacuity_mode,
-    block_on_native, display, envelope, error_output, implements_error_output, implements_result,
-    invariant_names, load_kernel_model, load_model, load_model_scoped, load_snapshot_value_object,
-    load_state_snapshot, read_spec_source, select_properties, selected_implicit_bounds,
-    semantic_error_output, spec_load_error_output, surface_parse_error_output,
-    validate_requirement_traces, validate_specialized_document,
+    block_on_native, display, envelope, error_output, implements_error_output,
+    implements_result_from_source, invariant_names, load_kernel_model_from_source, load_model,
+    load_model_from_source, load_model_scoped, load_model_scoped_from_source,
+    load_snapshot_value_object, load_state_snapshot, read_spec_source, select_properties,
+    selected_implicit_bounds, semantic_error_output, spec_load_error_output,
+    surface_parse_error_output, validate_requirement_traces_from_source,
+    validate_specialized_document_from_source,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1809,6 +1811,19 @@ pub(super) fn run_verify_cli(
     cache_identity_path: &Path,
     options: &CliVerifyOptions,
 ) -> CommandResult {
+    let source = match read_spec_source(path) {
+        Ok(source) => source,
+        Err(error) => return (spec_load_error_output(&error), 2),
+    };
+    run_verify_cli_from_source(path, cache_identity_path, &source, options)
+}
+
+pub(super) fn run_verify_cli_from_source(
+    path: &Path,
+    cache_identity_path: &Path,
+    source: &str,
+    options: &CliVerifyOptions,
+) -> CommandResult {
     if !options.lemmas.is_empty() && options.engine != "induction" {
         return (
             error_output("usage", "--lemma requires --engine induction"),
@@ -1827,13 +1842,15 @@ pub(super) fn run_verify_cli(
     // Causal models are intentionally outside the kernel dialect dispatcher.
     // Check their syntax first so a malformed causal input retains its parser
     // diagnostic instead of being rewritten as an unknown kernel dialect.
-    if let Ok(source) = std::fs::read_to_string(path)
-        && fsl_syntax::is_causal_source(&source)
-        && let Err(error) = fsl_syntax::parse_causal(&source)
+    // Uses the already-captured `source` snapshot rather than re-reading
+    // `path`, so this check can never observe a different root source than
+    // the rest of this verification.
+    if fsl_syntax::is_causal_source(source)
+        && let Err(error) = fsl_syntax::parse_causal(source)
     {
         return super::causal::causal_parse_error_output(&error, false);
     }
-    let prepared = match prepare_cli_verification(path, options) {
+    let prepared = match prepare_cli_verification_from_source(path, source, options) {
         Ok(prepared) => prepared,
         Err(output) => return output,
     };
@@ -1860,7 +1877,7 @@ pub(super) fn run_verify_cli(
     {
         return output;
     }
-    let (output, status) = execute_cli_verification(path, options, &prepared);
+    let (output, status) = execute_cli_verification(path, source, options, &prepared);
     let (output, status) = finalize_cli_verification(
         path,
         options,
@@ -1875,24 +1892,24 @@ pub(super) fn run_verify_cli(
     (output, status)
 }
 
-fn prepare_cli_verification(
+fn prepare_cli_verification_from_source(
     path: &Path,
+    source: &str,
     options: &CliVerifyOptions,
 ) -> Result<PreparedCliVerification, CommandResult> {
-    let source = read_spec_source(path).map_err(|error| (spec_load_error_output(&error), 2))?;
-    let is_agent_document = match fsl_syntax::parse_surface_document(&source) {
+    let is_agent_document = match fsl_syntax::parse_surface_document(source) {
         Ok(fsl_syntax::SurfaceDocument::Agent(_)) => true,
         Ok(_) => false,
         Err(error) => return Err((surface_parse_error_output(&error), 2)),
     };
     let has_scope = !options.scope.instances.is_empty() || !options.scope.values.is_empty();
-    if let Err(error) = validate_specialized_document(path) {
+    if let Err(error) = validate_specialized_document_from_source(path, source) {
         return Err((semantic_error_output(&error), 2));
     }
     let snapshot_model = if has_scope {
-        load_model_scoped(path, &options.scope)
+        load_model_scoped_from_source(path, source, &options.scope)
     } else {
-        load_model(path)
+        load_model_from_source(path, source)
     };
     let initial_state = if let Some(snapshot_path) = options.from_state.as_deref() {
         let model = snapshot_model
@@ -1907,7 +1924,7 @@ fn prepare_cli_verification(
     };
     let mut has_trace_contract = false;
     if !has_scope && let Ok(model) = &snapshot_model {
-        match validate_requirement_traces(path, model) {
+        match validate_requirement_traces_from_source(path, source, model) {
             Ok((Some(failure), _)) => return Err((failure, 2)),
             Ok((None, has_contract)) => has_trace_contract = has_contract,
             Err(error) => return Err((semantic_error_output(&error), 2)),
@@ -1920,11 +1937,17 @@ fn prepare_cli_verification(
     let compose_warnings = if has_scope {
         Vec::new()
     } else {
-        load_kernel_model(path)
-            .map(|(_, kernel, _)| kernel.diagnostics().to_vec())
+        load_kernel_model_from_source(path, source)
+            .map(|(kernel, _)| kernel.diagnostics().to_vec())
             .unwrap_or_default()
     };
-    validate_cli_property_selection(path, options, has_scope, snapshot_model.as_ref().ok())?;
+    validate_cli_property_selection(
+        path,
+        source,
+        options,
+        has_scope,
+        snapshot_model.as_ref().ok(),
+    )?;
     Ok(PreparedCliVerification {
         has_scope,
         is_agent_document,
@@ -1937,6 +1960,7 @@ fn prepare_cli_verification(
 
 fn validate_cli_property_selection(
     path: &Path,
+    source: &str,
     options: &CliVerifyOptions,
     has_scope: bool,
     prepared_model: Option<&KernelModel>,
@@ -1946,8 +1970,8 @@ fn validate_cli_property_selection(
     }
     let mut model = match prepared_model {
         Some(model) => Ok(model.clone()),
-        None if has_scope => load_model_scoped(path, &options.scope),
-        None => load_model(path),
+        None if has_scope => load_model_scoped_from_source(path, source, &options.scope),
+        None => load_model_from_source(path, source),
     }
     .map_err(|error| (spec_load_error_output(&error), 2))?;
     if options.engine == "induction"
@@ -2167,6 +2191,7 @@ fn store_auto_verification(
 
 fn execute_cli_verification(
     path: &Path,
+    source: &str,
     options: &CliVerifyOptions,
     prepared: &PreparedCliVerification,
 ) -> CommandResult {
@@ -2194,7 +2219,7 @@ fn execute_cli_verification(
     let implements = if filtered {
         None
     } else {
-        match implements_result(path, model, options.depth) {
+        match implements_result_from_source(path, source, model, options.depth) {
             Ok(implements) => implements,
             Err(error) => return (implements_error_output(&error), 2),
         }
@@ -2323,8 +2348,15 @@ fn finalize_cli_verification(
     }
     if status == 0
         && options.strict_tags
-        && let Err(output) =
-            add_cli_strict_tag_warnings(path, options, prepared.has_scope, &mut output)
+        && let Err(output) = add_cli_strict_tag_warnings(
+            path,
+            options,
+            prepared
+                .model
+                .as_ref()
+                .expect("successful verification has a prepared model"),
+            &mut output,
+        )
     {
         return output;
     }
@@ -2382,16 +2414,10 @@ fn add_snapshot_metadata(output: &mut Value, options: &CliVerifyOptions) {
 fn add_cli_strict_tag_warnings(
     path: &Path,
     options: &CliVerifyOptions,
-    has_scope: bool,
+    model: &KernelModel,
     output: &mut Value,
 ) -> Result<(), CommandResult> {
-    let model = if has_scope {
-        load_model_scoped(path, &options.scope)
-    } else {
-        load_model(path)
-    }
-    .map_err(|error| (spec_load_error_output(&error), 2))?;
-    add_strict_tag_warnings(output, &model, path, true, options.requirements.as_deref())
+    add_strict_tag_warnings(output, model, path, true, options.requirements.as_deref())
         .map_err(|error| (error_output("io", &error), 2))
 }
 #[cfg(test)]

--- a/rust/fslc/tests/issue_808_run_verify_snapshot.rs
+++ b/rust/fslc/tests/issue_808_run_verify_snapshot.rs
@@ -256,6 +256,19 @@ fn verify_reads_one_fifo_snapshot_for_bmc_induction_and_liveness() {
             output["leads_to"]["Served"]["checked_to_depth"], 4,
             "{engine} must execute source A's leadsTo check: {output:#}"
         );
+        // `checked_to_depth` alone only echoes `--depth`; it says nothing
+        // about the model that was actually loaded. The `vacuous_leadsto`
+        // warning instead depends on the engine having evaluated source A's
+        // `pending ~> done` trigger reachability, so it is content-bound
+        // evidence that the liveness check ran against A, not against B.
+        assert!(
+            output["warnings"].as_array().is_some_and(|warnings| {
+                warnings
+                    .iter()
+                    .any(|warning| warning["kind"] == "vacuous_leadsto" && warning["name"] == "Served")
+            }),
+            "{engine} must report source A's vacuous leadsTo trigger: {output:#}"
+        );
     }
 }
 

--- a/rust/fslc/tests/issue_808_run_verify_snapshot.rs
+++ b/rust/fslc/tests/issue_808_run_verify_snapshot.rs
@@ -263,9 +263,9 @@ fn verify_reads_one_fifo_snapshot_for_bmc_induction_and_liveness() {
         // evidence that the liveness check ran against A, not against B.
         assert!(
             output["warnings"].as_array().is_some_and(|warnings| {
-                warnings
-                    .iter()
-                    .any(|warning| warning["kind"] == "vacuous_leadsto" && warning["name"] == "Served")
+                warnings.iter().any(|warning| {
+                    warning["kind"] == "vacuous_leadsto" && warning["name"] == "Served"
+                })
             }),
             "{engine} must report source A's vacuous leadsTo trigger: {output:#}"
         );

--- a/rust/fslc/tests/issue_808_run_verify_snapshot.rs
+++ b/rust/fslc/tests/issue_808_run_verify_snapshot.rs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Deterministic CLI read-count control for #808's `run_verify` foundation.
+
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::Command;
+
+#[cfg(unix)]
+use serde_json::Value;
+
+#[cfg(unix)]
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned()
+}
+
+#[cfg(unix)]
+fn fixture_directory() -> PathBuf {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static NEXT_FIFO: AtomicUsize = AtomicUsize::new(0);
+    let directory = std::env::temp_dir().join(format!(
+        "fslc-issue-808-fifo-{}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after Unix epoch")
+            .as_nanos(),
+        NEXT_FIFO.fetch_add(1, Ordering::Relaxed),
+    ));
+    std::fs::create_dir(&directory).expect("create FIFO fixture directory");
+    directory
+}
+
+#[cfg(unix)]
+fn create_fifo(path: &Path) {
+    let status = Command::new("mkfifo")
+        .arg(path)
+        .status()
+        .expect("run mkfifo");
+    assert!(status.success(), "mkfifo failed with {status}");
+}
+
+/// The first writer remains attached to the first inode while the pathname is
+/// atomically replaced with the second FIFO. Thus source A cannot be
+/// concatenated with source B: only a second open of the pathname reaches B.
+#[cfg(unix)]
+struct TwoSnapshotFifo {
+    directory: PathBuf,
+    fifo: PathBuf,
+    second_opened: std::sync::mpsc::Receiver<()>,
+    writer: Option<std::thread::JoinHandle<()>>,
+    second_writer_opened: bool,
+}
+
+#[cfg(unix)]
+impl TwoSnapshotFifo {
+    fn new() -> Self {
+        use std::io::Write;
+        use std::sync::mpsc;
+
+        let directory = fixture_directory();
+        let fifo = directory.join("verify.fsl");
+        let replacement = directory.join("verify-replacement.fsl");
+        create_fifo(&fifo);
+        create_fifo(&replacement);
+
+        let source_a = include_str!("fixtures/vacuous_leadsto.fsl").to_owned();
+        let source_b = "not valid FSL source".to_owned();
+        let writer_fifo = fifo.clone();
+        let (second_opened, receiver) = mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            let mut first = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&writer_fifo)
+                .expect("open first FIFO for valid source A");
+            first
+                .write_all(source_a.as_bytes())
+                .expect("write valid source A");
+            std::fs::rename(&replacement, &writer_fifo).expect("replace FIFO path");
+            drop(first);
+
+            let mut second = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&writer_fifo)
+                .expect("open replacement FIFO for invalid source B");
+            second_opened
+                .send(())
+                .expect("test must retain second-open receiver");
+            second
+                .write_all(source_b.as_bytes())
+                .expect("write invalid source B");
+        });
+
+        Self {
+            directory,
+            fifo,
+            second_opened: receiver,
+            writer: Some(writer),
+            second_writer_opened: false,
+        }
+    }
+
+    fn assert_no_second_open(&mut self) {
+        use std::sync::mpsc::TryRecvError;
+
+        match self.second_opened.try_recv() {
+            Err(TryRecvError::Empty) => {}
+            Ok(()) => {
+                self.second_writer_opened = true;
+                panic!("the CLI opened source B, proving a second root-path read");
+            }
+            Err(TryRecvError::Disconnected) => {
+                panic!("FIFO writer stopped before opening the replacement source")
+            }
+        }
+    }
+
+    fn release_writer(&mut self) {
+        use std::io::Read;
+
+        let Some(writer) = self.writer.take() else {
+            return;
+        };
+        if !self.second_writer_opened {
+            self.second_writer_opened = self.second_opened.try_recv().is_ok();
+        }
+        if !self.second_writer_opened {
+            let mut reader = std::fs::OpenOptions::new()
+                .read(true)
+                .open(&self.fifo)
+                .expect("open replacement FIFO during cleanup");
+            let mut source = String::new();
+            reader
+                .read_to_string(&mut source)
+                .expect("drain replacement FIFO during cleanup");
+        }
+        writer.join().expect("join FIFO writer");
+    }
+}
+
+#[cfg(unix)]
+impl Drop for TwoSnapshotFifo {
+    fn drop(&mut self) {
+        if self.writer.is_some() {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                self.release_writer();
+            }));
+        }
+        let _ = std::fs::remove_file(&self.fifo);
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_output(child: &mut std::process::Child) -> std::process::Output {
+    use std::io::Read;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("poll FIFO child") {
+            break status;
+        }
+        if std::time::Instant::now() >= deadline {
+            child.kill().expect("kill timed-out FIFO child");
+            let status = child.wait().expect("reap timed-out FIFO child");
+            panic!("fslc against FIFO timed out after 5s; status={status}");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    };
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    child
+        .stdout
+        .take()
+        .expect("capture FIFO child stdout")
+        .read_to_end(&mut stdout)
+        .expect("read FIFO child stdout");
+    child
+        .stderr
+        .take()
+        .expect("capture FIFO child stderr")
+        .read_to_end(&mut stderr)
+        .expect("read FIFO child stderr");
+    std::process::Output {
+        status,
+        stdout,
+        stderr,
+    }
+}
+
+#[cfg(unix)]
+fn verify_against_two_snapshot_fifo(engine: &str, edition: &str) -> (Value, i32) {
+    use std::process::Stdio;
+
+    let mut fixture = TwoSnapshotFifo::new();
+    let path = fixture.fifo.to_string_lossy().into_owned();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "verify",
+            &path,
+            "--depth",
+            "4",
+            "--engine",
+            engine,
+            "--edition",
+            edition,
+            "--no-cache",
+        ])
+        .current_dir(root())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn native fslc against FIFO");
+    let output = wait_for_output(&mut child);
+
+    // This is the correctness oracle. Cleanup opens B only after this point.
+    fixture.assert_no_second_open();
+    fixture.release_writer();
+
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; engine={engine}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+/// The BMC control also exercises source A's `leadsTo` property. Induction is
+/// separately pinned because it has its own base/step and liveness paths.
+///
+/// This is intentionally Unix-only: Windows lacks the FIFO read-count oracle.
+/// The non-Unix marker below makes a green Windows result explicitly not claim
+/// that this CLI-level control ran there (#806).
+#[cfg(unix)]
+#[test]
+fn verify_reads_one_fifo_snapshot_for_bmc_induction_and_liveness() {
+    for (engine, edition) in [("bmc", "current"), ("induction", "next")] {
+        let (output, status) = verify_against_two_snapshot_fifo(engine, edition);
+        assert_eq!(status, 0, "{engine}: {output:#}");
+        assert_ne!(
+            output["result"], "error",
+            "{engine} must verify valid source A, not invalid source B: {output:#}"
+        );
+    }
+}
+
+/// Windows does not implement the FIFO read-count control above. This marker
+/// prevents a passing non-Unix test run from being mistaken for its evidence.
+#[cfg(not(unix))]
+#[test]
+fn fifo_source_snapshot_control_is_unavailable_on_non_unix() {
+    assert!(cfg!(not(unix)));
+}

--- a/rust/fslc/tests/issue_808_run_verify_snapshot.rs
+++ b/rust/fslc/tests/issue_808_run_verify_snapshot.rs
@@ -242,12 +242,19 @@ fn verify_against_two_snapshot_fifo(engine: &str, edition: &str) -> (Value, i32)
 #[cfg(unix)]
 #[test]
 fn verify_reads_one_fifo_snapshot_for_bmc_induction_and_liveness() {
-    for (engine, edition) in [("bmc", "current"), ("induction", "next")] {
+    for (engine, edition, expected_result) in [
+        ("bmc", "current", "verified"),
+        ("induction", "next", "proved"),
+    ] {
         let (output, status) = verify_against_two_snapshot_fifo(engine, edition);
         assert_eq!(status, 0, "{engine}: {output:#}");
-        assert_ne!(
-            output["result"], "error",
-            "{engine} must verify valid source A, not invalid source B: {output:#}"
+        assert_eq!(
+            output["result"], expected_result,
+            "{engine} must verify source A, not invalid source B: {output:#}"
+        );
+        assert_eq!(
+            output["leads_to"]["Served"]["checked_to_depth"], 4,
+            "{engine} must execute source A's leadsTo check: {output:#}"
         );
     }
 }


### PR DESCRIPTION
## Problem

`fslc` read its input path more than once per command, so the snapshot it *verified* and the
snapshot it *reported on* could differ. An atomic replacement between two reads makes the
command validate one document and emit a verdict describing another (#808).

Two separate paths were affected:

| Path | Callers |
|---|---|
| `main.rs::run_verify` | scenarios (`:5109`), html report (`:6009`, `:6188`), domain (`:6823`), `run_mutate_legacy` (`:9334`), `run_mutate` (`:10205`), `run_testgen` (`:10754`), `:3813`, `:11381` |
| `verification.rs::run_verify_cli_from_source` | the `verify` subcommand (`main.rs:1768`) |

The `verify` subcommand does **not** go through `main.rs::run_verify`, so both paths needed
fixing. `run_verify` normally read six times, seven with induction/auto fallback.

## Contract change

Verification captures its root specification once and derives specialized-document
validation, Kernel/model lowering, requirements trace and `implements` metadata, every
selected engine, and the edition post-processing stage from that same `String`. Recorded in
`docs/DESIGN-rust-integration.md`.

Eleven `*_from_source` helpers were split out; every existing path-taking function remains as
a delegate, so no caller signature changed. Only the **root** path stops being re-read — the
resolver still reads `compose`/`import`/`implements` dependencies, which is separate work
tracked on the issue.

`--engine` accepts only `bmc | induction`. Refinement is reached through `implements` and
liveness through `bounded_liveness` inside BMC, so engine coverage cannot be read off
`VerificationEngine`.

## Controls

Two layers, both required.

**Layer A — platform-neutral, in-process** (`main.rs`, `#[cfg(test)]`). Captures source A from
a regular file, overwrites the path with source B, then asserts every `*_from_source` helper
stays bound to A. Covers all four `engine × edition` combinations (`bmc`/`induction` ×
`current`/`next`) plus the refinement path through `implements`.

Liveness is asserted with content-bound evidence rather than a self-satisfying field:
`checked_to_depth` alone only echoes `--depth`, so the control also requires source A's
`vacuous_leadsto` warning for `Served`, which depends on the engine having evaluated A's
`pending ~> done` trigger reachability.

**Layer B — Unix CLI-level** (`tests/issue_808_run_verify_snapshot.rs`). Two-inode FIFO: the
first writer holds the original inode while the pathname is atomically replaced, so a second
`open` of the path is the only way to reach source B. `assert_no_second_open()` is the oracle.

Windows has no FIFO read-count oracle, so layer B is `#[cfg(unix)]` and a
`#[cfg(not(unix))]` marker keeps a green non-Unix run from being mistaken for its evidence
(#806).

## Mutation evidence

Every control was verified to fail when the fix is reverted.

| Mutation | Result |
|---|---|
| `load_kernel_model_from_source` re-reads the path | `source_helpers_use_the_captured_root_snapshot` FAILED — `lower source A: Parse(… FSL-DIALECT-UNKNOWN)`; `implements_refinement_uses_the_captured_root_snapshot` also FAILED |
| `prepare_cli_verification_from_source`'s `snapshot_model` re-reads the path | `verify_reads_one_fifo_snapshot_for_bmc_induction_and_liveness` FAILED — `the CLI opened source B, proving a second root-path read` (1.86s, no hang) |
| `apply_domain_edition_from_source` re-reads the path | `source_helpers_use_the_captured_root_snapshot` FAILED — `left: Null / right: "next"`; `plan_migration` fails on B and early-returns before the `edition` insert |

## Test evidence

Rebased onto `6ee8948` (#803). Its TOCTOU control
(`domain_projection_validation_uses_the_original_source_snapshot`) and this PR's controls now
share a module and both pass.

```
cargo fmt --check                              clean
cargo clippy --workspace --all-targets -D warnings   no warnings
cargo test -p fslc-rust --locked               883 passed; 0 failed
cargo test --workspace --locked                1485 passed; 0 failed  (pre-rebase tree)
./tools/aggregate_changelog.sh check           PASS
```

## Out of scope

`mutate` (PR 2), generic `testgen`/scenarios (PR 3), the resolver's dependency graph, and the
`domain`/AI dialect commands — the last because those surfaces have no users yet.

Refs #808.

## Rebase onto #807

Rebased onto `1291a72` after #807 landed. Three conflicts, all resolved so that both fixes
survive:

- `main.rs` — kept #807's `load_surface_document`/`load_surface_document_from_source`
  alongside this PR's `validate_specialized_document_from_source`. The `.md` literate branch
  that preserves the pre-#780 unlocated `semantics` classification is intact.
- `main.rs` — #807's causal classification moved **into** `run_verify_from_source`, not the
  thin `run_verify` wrapper. `run_mutate`, `run_testgen`, scenarios and the html report call
  `run_verify_from_source` directly, so leaving it in the wrapper would have dropped #807's
  fix on every one of those paths.
- `verification.rs` — #807's causal check called `std::fs::read_to_string(path)`, which was
  itself the second read this PR removes. It now classifies the already-captured `source`, so
  both properties hold on one read. Read failures no longer skip the check silently; they are
  already classified by `read_spec_source`'s io path before this point.

`cargo test -p fslc-rust --locked` → **885 passed; 0 failed** (883 before the rebase, +2 from
#807's new tests). fmt, clippy `-D warnings`, `cargo build --workspace` and the changelog check
all pass.

Both mutation controls still fire after the rebase, and #796's TOCTOU control plus the
literate-classification control pass alongside this PR's.

## Coverage gap found while rebasing

Removing the causal guard from `main.rs::run_verify_from_source` leaves `error_envelope_parity`
(17 passed) and `causal_cli` (41 passed) green, while the same removal in `verification.rs`
fails the parity gate. The contract is only guarded on the `verify` path. Filed as #812; not
fixed here, since adding that control is #812's scope rather than this PR's.
