### PR TITLE
fix(tests): unify and harden the FIFO read-count oracle so it fails instead of hanging

### DIFF
--- a/changelog.d/819-unify-fifo-snapshot-oracle-hardening.unified.md
+++ b/changelog.d/819-unify-fifo-snapshot-oracle-hardening.unified.md
@@ -1,0 +1,13 @@
+Unified (#819): the two-inode FIFO read-count oracle used by all six #796/#808
+CLI-level snapshot controls now lives once, in
+`rust/fslc/tests/support/fifo_snapshot.rs`, carrying the cleanup hardening
+`issue_796_domain_command_validation.rs`'s independent copy grew during its
+own review: nonblocking cleanup reader descriptors, a
+`WriterOutcome`/`WriterMode`-driven writer thread, and a `ReapedChild` guard
+that reaps unconditionally even when `kill` itself fails. The previously
+unhardened shared copy could hang instead of fail when the CLI under test
+exited before ever opening the FIFO path -- the exact incident during #813's
+development that cancelled a CI job after 30 minutes and hung a local run for
+1h33m. A new negative control in `fifo_snapshot_hardening.rs`,
+`release_writer_completes_when_cli_never_opens_the_path`, reproduces that
+scenario directly and proves cleanup now terminates instead of hanging.

--- a/rust/fslc/tests/fifo_snapshot_hardening.rs
+++ b/rust/fslc/tests/fifo_snapshot_hardening.rs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Controls on `support/fifo_snapshot.rs`'s own cleanup hardening, not on any
+//! particular CLI command. #819 ported these from
+//! `issue_796_domain_command_validation.rs`'s independently-hardened copy
+//! into the shared module every #808 snapshot control now uses, and this
+//! file is where they now belong: they exercise `TwoSnapshotFifo` and
+//! `ReapedChild` directly rather than a specific `fslc` subcommand's
+//! behavior.
+//!
+//! `fifo_cleanup_finishes_when_writer_panics_before_rename` and
+//! `child_guard_reaps_after_esrch_kill_error` were raised as a major finding
+//! during #803's round-4 review: a blocking cleanup `open` inside a
+//! `catch_unwind`-guarded `Drop` cannot be interrupted by an assertion
+//! failure, so the failure itself is silently swallowed by an indefinite
+//! hang instead of being reported. `release_writer_completes_when_cli_never_
+//! opens_the_path` is #819's own closing control: the exact #813-development
+//! scenario (a CLI argument the parser rejects, so the process exits before
+//! ever opening the FIFO path at all) reproduced directly, proving cleanup
+//! still terminates.
+
+#[cfg(unix)]
+#[path = "support/fifo_snapshot.rs"]
+mod fifo_snapshot;
+
+#[cfg(unix)]
+use std::process::Command;
+
+#[cfg(unix)]
+use fifo_snapshot::{ReapedChild, TwoSnapshotFifo, WriterMode, WriterOutcome};
+#[cfg(unix)]
+use serde_json::Value;
+
+/// The pre-rename panic is the cleanup failure mode that used to leave the
+/// second blocking FIFO open waiting forever. The writer outcome and
+/// nonblocking control descriptors make completion independent of that
+/// missing second writer.
+#[cfg(unix)]
+#[test]
+fn fifo_cleanup_finishes_when_writer_panics_before_rename() {
+    let mut fixture = TwoSnapshotFifo::new_with_writer_mode(
+        "writer-panics-before-rename",
+        "source A: never fully consumed",
+        "source B: never reached",
+        WriterMode::PanicBeforeRename,
+    );
+
+    assert_eq!(fixture.release_writer(), WriterOutcome::Panicked);
+}
+
+/// A deterministic ESRCH control for the timeout guard. Reading the pipe to
+/// EOF proves the child has exited without reaping it; injecting its
+/// possible kill result verifies that the guard still calls `wait` and
+/// completes.
+#[cfg(unix)]
+#[test]
+fn child_guard_reaps_after_esrch_kill_error() {
+    use std::io::Read;
+    use std::process::Stdio;
+
+    let mut child = ReapedChild::new(
+        Command::new("sh")
+            .args(["-c", "exit 0"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn already-exiting child"),
+    );
+    let mut stdout = Vec::new();
+    child
+        .child
+        .stdout
+        .as_mut()
+        .expect("capture child stdout")
+        .read_to_end(&mut stdout)
+        .expect("wait for child stdout EOF");
+    let (kill_error, status) =
+        child.terminate_and_reap_with(|_| Err(std::io::Error::from_raw_os_error(libc::ESRCH)));
+
+    assert_eq!(
+        kill_error.and_then(|error| error.raw_os_error()),
+        Some(libc::ESRCH),
+        "the control must exercise the ESRCH kill result"
+    );
+    assert!(
+        status.expect("reap child after ESRCH").success(),
+        "already-exited child must reap successfully"
+    );
+}
+
+/// #819's closing negative control, reproducing #813's development incident
+/// directly: `mutate` rejects an option its parser does not know before it
+/// ever opens the spec path (see `main.rs`'s `"explain" | "mutate" |
+/// "typestate"` arm, which returns `Err(format!("unknown {command} option
+/// '{option}'"))` from argument parsing -- before `run_mutate` is ever
+/// called, so nothing opens `path`). The FIFO writer thread is consequently
+/// left blocked forever in its first `open`, since no reader ever attaches
+/// to the pathname.
+///
+/// Before #819, `release_writer`'s cleanup itself performed a *blocking*
+/// `open` gated on `self.second_writer_opened` (false here, since the writer
+/// never even reaches its first successful open/write/rename), and
+/// `writer.join()` afterward waited unconditionally -- so this exact
+/// scenario is the one that hung CI for 30 minutes and a local run for 1h33m
+/// during #813's development (the wrong-argument product bug was already
+/// fixed; the hang was purely this cleanup defect). This test's oracle is
+/// *termination*, not a particular writer outcome, so a straightforward
+/// `assert_eq!(fixture.release_writer(), ...)` on the test thread would not
+/// be faithful: were the hang regression to reappear, that call would block
+/// the test thread forever and the whole run would need Ctrl-C or a harness
+/// timeout to end -- exactly the failure mode #819 exists to convert into an
+/// ordinary failing assertion. Running `release_writer` on a helper thread
+/// and bounding the *test's own* wait with `recv_timeout` performs that
+/// inversion faithfully: a regression now surfaces as a timed-out `recv`
+/// (still inside this process, no external timeout needed) rather than a
+/// hang, while the fixed implementation is expected to return quickly with a
+/// determinate outcome -- draining the writer to completion through
+/// nonblocking reader descriptors on both the original and (once reachable)
+/// replacement FIFO paths is exactly what lets the writer's own blocking
+/// opens succeed even though no CLI process ever attached as a reader, so
+/// green here is `WriterOutcome::Finished`, not merely "did not panic".
+/// A version of this test that skipped the helper thread and asserted
+/// `WriterOutcome::Finished` directly on the test thread would have a green
+/// result compatible with a hang (it simply would never reach the
+/// assertion); the `recv_timeout` bound is what makes a hang observable as
+/// red instead of silence.
+#[cfg(unix)]
+#[test]
+fn release_writer_completes_when_cli_never_opens_the_path() {
+    let mut fixture = TwoSnapshotFifo::new(
+        "cli-exits-before-open",
+        "source A: the CLI never opens the path at all",
+        "source B: never reached either",
+    );
+    let path = fixture.fifo.to_string_lossy().into_owned();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(["mutate", &path, "--this-option-does-not-exist"])
+        .current_dir(fifo_snapshot::root())
+        .output()
+        .expect("run native fslc with a rejected option");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(
+        value["kind"], "usage",
+        "the CLI must reject the unsupported option before opening the path: {value:#}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "usage rejection must exit 2: {value:#}"
+    );
+
+    // Nothing has opened `fixture.fifo`: the CLI's argument parser rejected
+    // the command before `run_mutate` (and therefore before any file open)
+    // ever ran. `assert_no_second_open` is consequently vacuous here (it
+    // would also pass under the old hanging cleanup, which never returned
+    // control at all) -- the real oracle is the bounded `recv_timeout` below.
+    fixture.assert_no_second_open();
+
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let outcome = fixture.release_writer();
+        let _ = sender.send(outcome);
+        // `fixture` drops here, on the helper thread, after `release_writer`
+        // already joined the writer thread -- `Drop` finds `writer: None`
+        // and does not attempt a second release.
+    });
+
+    let outcome = receiver
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .unwrap_or_else(|_| {
+            panic!(
+                "release_writer did not return within 10s after the CLI exited \
+                 without ever opening the FIFO path -- this is the exact #813/#819 \
+                 hang this control exists to catch"
+            )
+        });
+
+    assert_eq!(
+        outcome,
+        WriterOutcome::Finished,
+        "the hardened cleanup must drain the writer to completion via nonblocking \
+         reader descriptors even though no CLI process ever opened the path"
+    );
+
+    handle
+        .join()
+        .expect("join release_writer helper thread after it reported an outcome");
+}
+
+/// Windows does not implement the FIFO read-count control above. This
+/// passing marker makes the platform exclusion visible in filtered test
+/// output; it does not claim the Unix TOCTOU control ran on this target.
+#[cfg(not(unix))]
+#[test]
+fn fifo_snapshot_hardening_control_is_unavailable_on_non_unix() {
+    assert!(cfg!(not(unix)));
+}

--- a/rust/fslc/tests/issue_796_domain_command_validation.rs
+++ b/rust/fslc/tests/issue_796_domain_command_validation.rs
@@ -15,6 +15,13 @@ use std::process::Command;
 
 use serde_json::Value;
 
+#[cfg(unix)]
+#[path = "support/fifo_snapshot.rs"]
+mod fifo_snapshot;
+
+#[cfg(unix)]
+use fifo_snapshot::{ReapedChild, TwoSnapshotFifo, WriterOutcome, wait_for_output};
+
 fn root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -50,394 +57,21 @@ fn run_text(args: &[&str]) -> (String, i32) {
     )
 }
 
-#[cfg(unix)]
-fn fifo_fixture_directory() -> PathBuf {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    static NEXT_FIFO: AtomicUsize = AtomicUsize::new(0);
-
-    let directory = std::env::temp_dir().join(format!(
-        "fslc-issue-796-fifo-{}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system clock after Unix epoch")
-            .as_nanos(),
-        NEXT_FIFO.fetch_add(1, Ordering::Relaxed),
-    ));
-    std::fs::create_dir(&directory).expect("create FIFO fixture directory");
-    directory
-}
-
-#[cfg(unix)]
-fn create_fifo(path: &Path) {
-    let status = Command::new("mkfifo")
-        .arg(path)
-        .status()
-        .expect("run mkfifo");
-    assert!(status.success(), "mkfifo failed with {status}");
-}
-
-/// A two-inode FIFO fixture that proves a command's source-read count.
-///
-/// The writer atomically replaces the path with a second FIFO *before* closing
-/// the writer on the first FIFO. The command's initial reader is consequently
-/// still connected to the old inode and must observe its EOF. Only a later
-/// path open can reach the replacement FIFO, so the two sources cannot be
-/// concatenated by scheduling.
-#[cfg(unix)]
-struct TwoSnapshotFifo {
-    directory: PathBuf,
-    fifo: PathBuf,
-    second_opened: std::sync::mpsc::Receiver<()>,
-    writer_outcome: std::sync::mpsc::Receiver<WriterOutcome>,
-    phase: std::sync::Arc<std::sync::atomic::AtomicUsize>,
-    writer: Option<std::thread::JoinHandle<()>>,
-}
-
-#[cfg(unix)]
-#[derive(Debug, Eq, PartialEq)]
-enum WriterOutcome {
-    Finished,
-    Panicked,
-}
-
-#[cfg(unix)]
-#[derive(Clone, Copy)]
-enum WriterMode {
-    Normal,
-    PanicBeforeRename,
-}
-
-#[cfg(unix)]
-impl TwoSnapshotFifo {
-    const FIRST_WRITER_OPENING: usize = 1;
-    const REPLACED: usize = 2;
-    const SECOND_WRITER_OPENING: usize = 3;
-    const CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-
-    fn new() -> Self {
-        Self::new_with_writer_mode(WriterMode::Normal)
-    }
-
-    fn new_with_writer_mode(mode: WriterMode) -> Self {
-        use std::io::Write;
-        use std::sync::atomic::Ordering;
-        use std::sync::{Arc, mpsc};
-
-        let directory = fifo_fixture_directory();
-        let fifo = directory.join("domain.fsl");
-        let replacement = directory.join("domain-replacement.fsl");
-        create_fifo(&fifo);
-        create_fifo(&replacement);
-
-        let invalid =
-            include_str!("fixtures/domain_characterization/invalid_unknown_name.fsl").to_owned();
-        let valid =
-            include_str!("fixtures/domain_characterization/expressions_valid.fsl").to_owned();
-        let writer_fifo = fifo.clone();
-        let phase = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let writer_phase = Arc::clone(&phase);
-        let (second_opened, second_opened_receiver) = mpsc::channel();
-        let (writer_outcome, writer_outcome_receiver) = mpsc::channel();
-        let writer = std::thread::spawn(move || {
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                writer_phase.store(Self::FIRST_WRITER_OPENING, Ordering::SeqCst);
-                let mut first = std::fs::OpenOptions::new()
-                    .write(true)
-                    .open(&writer_fifo)
-                    .expect("open first FIFO for invalid source");
-                first
-                    .write_all(invalid.as_bytes())
-                    .expect("write invalid source");
-                if matches!(mode, WriterMode::PanicBeforeRename) {
-                    panic!("intentional FIFO writer panic before rename");
-                }
-
-                // `rename` replaces the directory entry, while `first` remains
-                // connected to the old FIFO inode until this explicit drop.
-                std::fs::rename(&replacement, &writer_fifo).expect("replace FIFO path");
-                writer_phase.store(Self::REPLACED, Ordering::SeqCst);
-                drop(first);
-
-                writer_phase.store(Self::SECOND_WRITER_OPENING, Ordering::SeqCst);
-                let mut second = std::fs::OpenOptions::new()
-                    .write(true)
-                    .open(&writer_fifo)
-                    .expect("open replacement FIFO for valid source");
-                second_opened
-                    .send(())
-                    .expect("test must retain second-open receiver");
-                second
-                    .write_all(valid.as_bytes())
-                    .expect("write valid source");
-            }));
-            let outcome = if result.is_ok() {
-                WriterOutcome::Finished
-            } else {
-                WriterOutcome::Panicked
-            };
-            let _ = writer_outcome.send(outcome);
-        });
-
-        Self {
-            directory,
-            fifo,
-            second_opened: second_opened_receiver,
-            writer_outcome: writer_outcome_receiver,
-            phase,
-            writer: Some(writer),
-        }
-    }
-
-    fn assert_no_second_open(&mut self) {
-        use std::sync::mpsc::TryRecvError;
-
-        match self.second_opened.try_recv() {
-            Err(TryRecvError::Empty) => {}
-            Ok(()) => {
-                panic!("the CLI opened the replacement FIFO, proving a second path read");
-            }
-            Err(TryRecvError::Disconnected) => {
-                panic!("FIFO writer stopped before opening the replacement source");
-            }
-        }
-    }
-
-    fn open_nonblocking_control_fifo(&self) -> std::io::Result<std::fs::File> {
-        use std::os::unix::fs::OpenOptionsExt;
-
-        std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_NONBLOCK)
-            .open(&self.fifo)
-    }
-
-    fn drain_nonblocking_control_fifo(control: &mut std::fs::File) -> std::io::Result<()> {
-        use std::io::Read;
-
-        let mut bytes = [0; 4096];
-        loop {
-            match control.read(&mut bytes) {
-                Ok(0) => return Ok(()),
-                Ok(_) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
-                Err(error) => return Err(error),
-            }
-        }
-    }
-
-    fn release_writer(&mut self) -> WriterOutcome {
-        use std::sync::atomic::Ordering;
-        use std::sync::mpsc::TryRecvError;
-
-        let Some(writer) = self.writer.take() else {
-            return WriterOutcome::Finished;
-        };
-
-        // These retained, nonblocking descriptors release only test-owned FIFO
-        // writers. They cannot hang if the writer panicked before rename: the
-        // outcome channel closes/completes, and the bounded wait below joins
-        // only after `is_finished()` proves the thread has terminated.
-        let mut controls = vec![
-            self.open_nonblocking_control_fifo()
-                .expect("open nonblocking FIFO cleanup control"),
-        ];
-        let mut replacement_control_opened = self.phase.load(Ordering::SeqCst) >= Self::REPLACED;
-        let deadline = std::time::Instant::now() + Self::CLEANUP_TIMEOUT;
-        let mut outcome = None;
-
-        loop {
-            if !replacement_control_opened && self.phase.load(Ordering::SeqCst) >= Self::REPLACED {
-                controls.push(
-                    self.open_nonblocking_control_fifo()
-                        .expect("open replacement FIFO cleanup control"),
-                );
-                replacement_control_opened = true;
-            }
-
-            for control in &mut controls {
-                Self::drain_nonblocking_control_fifo(control)
-                    .expect("drain nonblocking FIFO cleanup control");
-            }
-
-            if outcome.is_none() {
-                match self.writer_outcome.try_recv() {
-                    Ok(received) => outcome = Some(received),
-                    Err(TryRecvError::Empty) => {}
-                    Err(TryRecvError::Disconnected) => {
-                        panic!("FIFO writer exited without reporting an outcome");
-                    }
-                }
-            }
-
-            if writer.is_finished() {
-                let outcome = outcome.expect("finished FIFO writer must report an outcome");
-                writer.join().expect("join finished FIFO writer");
-                return outcome;
-            }
-
-            assert!(
-                std::time::Instant::now() < deadline,
-                "FIFO writer cleanup exceeded {:?}",
-                Self::CLEANUP_TIMEOUT
-            );
-            std::thread::sleep(std::time::Duration::from_millis(1));
-        }
-    }
-}
-
-#[cfg(unix)]
-impl Drop for TwoSnapshotFifo {
-    fn drop(&mut self) {
-        // This runs during assertion unwinding as well, so the fixture cannot
-        // leave FIFOs behind merely because a check failed.
-        if self.writer.is_some() {
-            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                let _ = self.release_writer();
-            }));
-        }
-        let _ = std::fs::remove_file(&self.fifo);
-        let _ = std::fs::remove_dir_all(&self.directory);
-    }
-}
-
-#[cfg(unix)]
-struct ReapedChild {
-    child: std::process::Child,
-    reaped: bool,
-}
-
-#[cfg(unix)]
-impl ReapedChild {
-    fn new(child: std::process::Child) -> Self {
-        Self {
-            child,
-            reaped: false,
-        }
-    }
-
-    fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
-        let status = self.child.try_wait()?;
-        if status.is_some() {
-            self.reaped = true;
-        }
-        Ok(status)
-    }
-
-    fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
-        let status = self.child.wait()?;
-        self.reaped = true;
-        Ok(status)
-    }
-
-    fn terminate_and_reap_with<F>(
-        &mut self,
-        terminate: F,
-    ) -> (
-        Option<std::io::Error>,
-        std::io::Result<std::process::ExitStatus>,
-    )
-    where
-        F: FnOnce(&mut std::process::Child) -> std::io::Result<()>,
-    {
-        // `wait` is deliberately unconditional: a process can exit between a
-        // timeout poll and kill, making kill return ESRCH while still leaving
-        // a child for this parent to reap.
-        let terminate_error = terminate(&mut self.child).err();
-        let status = self.wait();
-        (terminate_error, status)
-    }
-
-    fn capture_output(&mut self, status: std::process::ExitStatus) -> std::process::Output {
-        use std::io::Read;
-
-        let mut stdout = Vec::new();
-        let mut stderr = Vec::new();
-        self.child
-            .stdout
-            .take()
-            .expect("capture FIFO child stdout")
-            .read_to_end(&mut stdout)
-            .expect("read FIFO child stdout");
-        self.child
-            .stderr
-            .take()
-            .expect("capture FIFO child stderr")
-            .read_to_end(&mut stderr)
-            .expect("read FIFO child stderr");
-        std::process::Output {
-            status,
-            stdout,
-            stderr,
-        }
-    }
-}
-
-#[cfg(unix)]
-impl Drop for ReapedChild {
-    fn drop(&mut self) {
-        if !self.reaped {
-            // Ignore errors during unwinding, but never let a failed kill skip
-            // the reap attempt.
-            let _ = self.child.kill();
-            let _ = self.wait();
-        }
-    }
-}
-
-#[cfg(unix)]
-fn wait_for_output_with_timeout(
-    child: &mut ReapedChild,
-    timeout: std::time::Duration,
-) -> std::process::Output {
-    use std::io::Read;
-
-    let deadline = std::time::Instant::now() + timeout;
-    let status = loop {
-        if let Some(status) = child.try_wait().expect("poll FIFO child") {
-            break status;
-        }
-        if std::time::Instant::now() >= deadline {
-            let (kill_error, status) = child.terminate_and_reap_with(std::process::Child::kill);
-            let status = status.unwrap_or_else(|wait_error| {
-                panic!("reap timed-out FIFO child after kill result {kill_error:?}: {wait_error}")
-            });
-            let mut stdout = Vec::new();
-            let mut stderr = Vec::new();
-            child
-                .child
-                .stdout
-                .take()
-                .expect("capture FIFO child stdout")
-                .read_to_end(&mut stdout)
-                .expect("read timed-out FIFO child stdout");
-            child
-                .child
-                .stderr
-                .take()
-                .expect("capture FIFO child stderr")
-                .read_to_end(&mut stderr)
-                .expect("read timed-out FIFO child stderr");
-            panic!(
-                "fslc against FIFO timed out after {timeout:?}; kill_error={kill_error:?}; status={status}; stdout={}; stderr={}",
-                String::from_utf8_lossy(&stdout),
-                String::from_utf8_lossy(&stderr)
-            );
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    };
-
-    child.capture_output(status)
-}
-
 /// Runs a command against a rejecting FIFO inode, then makes a valid source
 /// available only through a replacement inode for an illegal second path read.
+///
+/// Uses the shared, cleanup-hardened `TwoSnapshotFifo`/`ReapedChild` oracle
+/// from `support/fifo_snapshot.rs` (#819) instead of a local copy, so this
+/// file's abnormal-path controls (writer panic before rename, ESRCH during
+/// timeout kill) now live in `fifo_snapshot_hardening.rs`, which exercises
+/// the shared module directly rather than a `domain` subcommand.
 #[cfg(unix)]
 fn run_against_two_snapshot_fifo(command: &str) -> (String, i32) {
     use std::process::Stdio;
 
-    let mut fixture = TwoSnapshotFifo::new();
+    let invalid = include_str!("fixtures/domain_characterization/invalid_unknown_name.fsl");
+    let valid = include_str!("fixtures/domain_characterization/expressions_valid.fsl");
+    let mut fixture = TwoSnapshotFifo::new("domain", invalid, valid);
     let fifo_argument = fixture.fifo.to_string_lossy().into_owned();
     let mut child = ReapedChild::new(
         Command::new(env!("CARGO_BIN_EXE_fslc"))
@@ -448,7 +82,7 @@ fn run_against_two_snapshot_fifo(command: &str) -> (String, i32) {
             .spawn()
             .expect("spawn native fslc against FIFO"),
     );
-    let output = wait_for_output_with_timeout(&mut child, std::time::Duration::from_secs(5));
+    let output = wait_for_output(&mut child);
 
     // This assertion occurs before fixture cleanup opens the replacement FIFO.
     // Receiving here is therefore proof that the CLI itself opened it.
@@ -459,56 +93,6 @@ fn run_against_two_snapshot_fifo(command: &str) -> (String, i32) {
         String::from_utf8(output.stdout).expect("UTF-8 stdout"),
         output.status.code().expect("exit status"),
     )
-}
-
-/// The pre-rename panic is the cleanup failure mode that used to leave the
-/// second blocking FIFO open waiting forever. The writer outcome and retained
-/// nonblocking control FD make completion independent of that missing writer.
-#[cfg(unix)]
-#[test]
-fn fifo_cleanup_finishes_when_writer_panics_before_rename() {
-    let mut fixture = TwoSnapshotFifo::new_with_writer_mode(WriterMode::PanicBeforeRename);
-
-    assert_eq!(fixture.release_writer(), WriterOutcome::Panicked);
-}
-
-/// A deterministic ESRCH control for the timeout guard. Reading the pipe to
-/// EOF proves the child has exited without reaping it; injecting its possible
-/// kill result verifies that the guard still calls `wait` and completes.
-#[cfg(unix)]
-#[test]
-fn child_guard_reaps_after_esrch_kill_error() {
-    use std::io::Read;
-    use std::process::Stdio;
-
-    let mut child = ReapedChild::new(
-        Command::new("sh")
-            .args(["-c", "exit 0"])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("spawn already-exiting child"),
-    );
-    let mut stdout = Vec::new();
-    child
-        .child
-        .stdout
-        .as_mut()
-        .expect("capture child stdout")
-        .read_to_end(&mut stdout)
-        .expect("wait for child stdout EOF");
-    let (kill_error, status) =
-        child.terminate_and_reap_with(|_| Err(std::io::Error::from_raw_os_error(libc::ESRCH)));
-
-    assert_eq!(
-        kill_error.and_then(|error| error.raw_os_error()),
-        Some(libc::ESRCH),
-        "the control must exercise the ESRCH kill result"
-    );
-    assert!(
-        status.expect("reap child after ESRCH").success(),
-        "already-exited child must reap successfully"
-    );
 }
 
 fn assert_rejected_like_check(fixture: &str) {

--- a/rust/fslc/tests/issue_808_mutate_snapshot.rs
+++ b/rust/fslc/tests/issue_808_mutate_snapshot.rs
@@ -21,7 +21,7 @@ mod fifo_snapshot;
 use std::process::Command;
 
 #[cfg(unix)]
-use fifo_snapshot::{TwoSnapshotFifo, wait_for_output};
+use fifo_snapshot::{ReapedChild, TwoSnapshotFifo, WriterOutcome, wait_for_output};
 #[cfg(unix)]
 use serde_json::Value;
 
@@ -33,23 +33,29 @@ fn mutate_against_two_snapshot_fifo() -> (Value, i32) {
     let source_b = include_str!("fixtures/issue_808_mutate_snapshot_b.fsl");
     let mut fixture = TwoSnapshotFifo::new("mutate", source_a, source_b);
     let path = fixture.fifo.to_string_lossy().into_owned();
-    let mut child = Command::new(env!("CARGO_BIN_EXE_fslc"))
-        // `mutate` accepts only `--depth`, `--by-requirement`, `--max-mutants`
-        // and `--from`. Passing an unsupported option makes the CLI exit with
-        // `kind: usage` before it ever opens the path, which leaves the FIFO
-        // writer blocked in `open` and makes `assert_no_second_open` vacuously
-        // true — the control would prove nothing even if it terminated.
-        .args(["mutate", &path, "--depth", "4"])
-        .current_dir(fifo_snapshot::root())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn native fslc against FIFO");
+    let mut child = ReapedChild::new(
+        Command::new(env!("CARGO_BIN_EXE_fslc"))
+            // `mutate` accepts only `--depth`, `--by-requirement`,
+            // `--max-mutants` and `--from`. Passing an unsupported option
+            // makes the CLI exit with `kind: usage` before it ever opens the
+            // path, which used to leave the FIFO writer blocked forever in a
+            // blocking cleanup `open` (#819); the hardened
+            // `TwoSnapshotFifo::release_writer` now uses only nonblocking
+            // reads so this shape of mistake fails with an assertion instead
+            // of hanging (see `fifo_snapshot_hardening.rs` for a dedicated
+            // control on exactly this path).
+            .args(["mutate", &path, "--depth", "4"])
+            .current_dir(fifo_snapshot::root())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn native fslc against FIFO"),
+    );
     let output = wait_for_output(&mut child);
 
     // This is the correctness oracle. Cleanup opens B only after this point.
     fixture.assert_no_second_open();
-    fixture.release_writer();
+    assert_eq!(fixture.release_writer(), WriterOutcome::Finished, "mutate");
 
     let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
         panic!(

--- a/rust/fslc/tests/issue_808_run_verify_snapshot.rs
+++ b/rust/fslc/tests/issue_808_run_verify_snapshot.rs
@@ -11,7 +11,7 @@ mod fifo_snapshot;
 use std::process::Command;
 
 #[cfg(unix)]
-use fifo_snapshot::{TwoSnapshotFifo, wait_for_output};
+use fifo_snapshot::{ReapedChild, TwoSnapshotFifo, WriterOutcome, wait_for_output};
 #[cfg(unix)]
 use serde_json::Value;
 
@@ -23,28 +23,30 @@ fn verify_against_two_snapshot_fifo(engine: &str, edition: &str) -> (Value, i32)
     let source_b = "not valid FSL source";
     let mut fixture = TwoSnapshotFifo::new("verify", source_a, source_b);
     let path = fixture.fifo.to_string_lossy().into_owned();
-    let mut child = Command::new(env!("CARGO_BIN_EXE_fslc"))
-        .args([
-            "verify",
-            &path,
-            "--depth",
-            "4",
-            "--engine",
-            engine,
-            "--edition",
-            edition,
-            "--no-cache",
-        ])
-        .current_dir(fifo_snapshot::root())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn native fslc against FIFO");
+    let mut child = ReapedChild::new(
+        Command::new(env!("CARGO_BIN_EXE_fslc"))
+            .args([
+                "verify",
+                &path,
+                "--depth",
+                "4",
+                "--engine",
+                engine,
+                "--edition",
+                edition,
+                "--no-cache",
+            ])
+            .current_dir(fifo_snapshot::root())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn native fslc against FIFO"),
+    );
     let output = wait_for_output(&mut child);
 
     // This is the correctness oracle. Cleanup opens B only after this point.
     fixture.assert_no_second_open();
-    fixture.release_writer();
+    assert_eq!(fixture.release_writer(), WriterOutcome::Finished, "verify");
 
     let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
         panic!(

--- a/rust/fslc/tests/issue_808_testgen_scenarios_snapshot.rs
+++ b/rust/fslc/tests/issue_808_testgen_scenarios_snapshot.rs
@@ -21,7 +21,7 @@ mod fifo_snapshot;
 use std::process::Command;
 
 #[cfg(unix)]
-use fifo_snapshot::{TwoSnapshotFifo, wait_for_output};
+use fifo_snapshot::{ReapedChild, TwoSnapshotFifo, WriterOutcome, wait_for_output};
 #[cfg(unix)]
 use serde_json::Value;
 
@@ -105,18 +105,20 @@ fn spawn_against_two_snapshot_fifo(
     args.push(remaining.next().expect("command name"));
     args.push(&path);
     args.extend(remaining);
-    let mut child = Command::new(env!("CARGO_BIN_EXE_fslc"))
-        .args(&args)
-        .current_dir(fifo_snapshot::root())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn native fslc against FIFO");
+    let mut child = ReapedChild::new(
+        Command::new(env!("CARGO_BIN_EXE_fslc"))
+            .args(&args)
+            .current_dir(fifo_snapshot::root())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn native fslc against FIFO"),
+    );
     let output = wait_for_output(&mut child);
 
     // This is the correctness oracle. Cleanup opens B only after this point.
     fixture.assert_no_second_open();
-    fixture.release_writer();
+    assert_eq!(fixture.release_writer(), WriterOutcome::Finished, "{label}");
     (fixture, output)
 }
 

--- a/rust/fslc/tests/support/fifo_snapshot.rs
+++ b/rust/fslc/tests/support/fifo_snapshot.rs
@@ -1,22 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Ryoichi Izumita
 
-//! Shared Unix CLI-level #808 read-count oracle.
+//! Shared Unix CLI-level #808/#796 read-count oracle.
 //!
 //! `TwoSnapshotFifo` binds a first writer to a first-created FIFO inode
 //! while atomically replacing the pathname with a second FIFO, so the CLI
 //! process cannot see source A concatenated with source B: only a second
 //! `open` of the pathname would reach B. Extracted from
 //! `issue_808_run_verify_snapshot.rs` (PR 1, #811) so
-//! `issue_808_testgen_scenarios_snapshot.rs` (PR 3, #808) can reuse the same
-//! oracle instead of re-deriving it. Pulled in per-file with
+//! `issue_808_testgen_scenarios_snapshot.rs` (PR 3, #808) and
+//! `issue_808_mutate_snapshot.rs` can reuse the same oracle instead of
+//! re-deriving it. Pulled in per-file with
 //! `#[path = "support/fifo_snapshot.rs"] mod fifo_snapshot;`, matching the
 //! existing `support/self_conformance_mapping.rs` convention -- not through
 //! `support/mod.rs`, which is unrelated corpus-walk tooling.
 //!
-//! A future #808 PR touching `mutate` may want the same oracle; extracting
-//! it here risks a merge conflict with that PR if it adds its own copy or
-//! its own extraction concurrently.
+//! #819 ported the cleanup hardening `issue_796_domain_command_validation.rs`
+//! grew during its own review into this shared copy and deleted that file's
+//! duplicate implementation, so all six FIFO-oracle tests now share one
+//! hardened oracle instead of an unhardened one drifting from a hardened one.
+//! Three properties motivate every piece of the hardening below:
+//!
+//! 1. `release_writer`'s cleanup path must never perform a *blocking* `open`
+//!    of the FIFO. Opening a FIFO for reading blocks until a writer attaches;
+//!    if the writer thread never reached its second `open` (it panicked, or
+//!    the CLI under test exited before opening the path at all -- see #813's
+//!    development, where a rejected CLI argument caused exactly this), a
+//!    blocking cleanup `open` hangs forever.
+//! 2. `Drop` funnels into that same cleanup path via `catch_unwind`, which
+//!    cannot interrupt a blocking syscall. A blocking `open` in `Drop` turns
+//!    an assertion failure mid-test into a silent hang instead of a reported
+//!    failure.
+//! 3. A timed-out child must still be reaped even if `kill` itself fails
+//!    (e.g. `ESRCH` because the child exited between the timeout poll and the
+//!    kill): `ReapedChild::terminate_and_reap_with` calls `wait`
+//!    unconditionally, and `Drop for ReapedChild` is the backstop if the
+//!    caller never reaps explicitly.
 
 #![cfg(unix)]
 
@@ -59,6 +78,28 @@ fn create_fifo(path: &Path) {
     assert!(status.success(), "mkfifo failed with {status}");
 }
 
+/// Outcome of the FIFO writer thread, reported by `release_writer` and by
+/// `Drop`'s best-effort cleanup so callers can tell an orderly finish apart
+/// from a caught writer panic.
+#[allow(dead_code)]
+#[derive(Debug, Eq, PartialEq)]
+pub enum WriterOutcome {
+    Finished,
+    Panicked,
+}
+
+/// Selects whether the writer thread completes normally or panics after
+/// writing source A but before the atomic rename to the replacement FIFO.
+/// `PanicBeforeRename` drives the cleanup-hardening control that proves
+/// `release_writer` terminates even when the writer never reaches its second
+/// `open`.
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+pub enum WriterMode {
+    Normal,
+    PanicBeforeRename,
+}
+
 /// The first writer remains attached to the first inode while the pathname is
 /// atomically replaced with the second FIFO. Thus source A cannot be
 /// concatenated with source B: only a second open of the pathname reaches B.
@@ -67,12 +108,19 @@ pub struct TwoSnapshotFifo {
     directory: PathBuf,
     pub fifo: PathBuf,
     second_opened: std::sync::mpsc::Receiver<()>,
+    writer_outcome: std::sync::mpsc::Receiver<WriterOutcome>,
+    phase: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     writer: Option<std::thread::JoinHandle<()>>,
     second_writer_opened: bool,
 }
 
 #[allow(dead_code)]
 impl TwoSnapshotFifo {
+    const FIRST_WRITER_OPENING: usize = 1;
+    const REPLACED: usize = 2;
+    const SECOND_WRITER_OPENING: usize = 3;
+    const CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
     /// `label` distinguishes concurrent fixture directories across test
     /// binaries. `source_a` and `source_b` should normally be two *distinct
     /// valid* FSL documents (not merely valid vs. invalid): a caller wants to
@@ -80,8 +128,22 @@ impl TwoSnapshotFifo {
     /// and got a different-but-still-valid B would otherwise look identical
     /// to a correct run under a status/`result != "error"` check alone.
     pub fn new(label: &str, source_a: &str, source_b: &str) -> Self {
+        Self::new_with_writer_mode(label, source_a, source_b, WriterMode::Normal)
+    }
+
+    /// As `new`, but drives the writer thread through `mode`. Used by the
+    /// cleanup-hardening control to force a writer panic before the FIFO path
+    /// is ever replaced, so `release_writer` must terminate without a second
+    /// `open` ever becoming reachable.
+    pub fn new_with_writer_mode(
+        label: &str,
+        source_a: &str,
+        source_b: &str,
+        mode: WriterMode,
+    ) -> Self {
         use std::io::Write;
-        use std::sync::mpsc;
+        use std::sync::atomic::Ordering;
+        use std::sync::{Arc, mpsc};
 
         let directory = fixture_directory(label);
         let fifo = directory.join("input.fsl");
@@ -92,34 +154,56 @@ impl TwoSnapshotFifo {
         let source_a = source_a.to_owned();
         let source_b = source_b.to_owned();
         let writer_fifo = fifo.clone();
-        let (second_opened, receiver) = mpsc::channel();
+        let phase = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let writer_phase = Arc::clone(&phase);
+        let (second_opened, second_opened_receiver) = mpsc::channel();
+        let (writer_outcome, writer_outcome_receiver) = mpsc::channel();
         let writer = std::thread::spawn(move || {
-            let mut first = std::fs::OpenOptions::new()
-                .write(true)
-                .open(&writer_fifo)
-                .expect("open first FIFO for source A");
-            first
-                .write_all(source_a.as_bytes())
-                .expect("write source A");
-            std::fs::rename(&replacement, &writer_fifo).expect("replace FIFO path");
-            drop(first);
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                writer_phase.store(Self::FIRST_WRITER_OPENING, Ordering::SeqCst);
+                let mut first = std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&writer_fifo)
+                    .expect("open first FIFO for source A");
+                first
+                    .write_all(source_a.as_bytes())
+                    .expect("write source A");
+                if matches!(mode, WriterMode::PanicBeforeRename) {
+                    panic!("intentional FIFO writer panic before rename");
+                }
 
-            let mut second = std::fs::OpenOptions::new()
-                .write(true)
-                .open(&writer_fifo)
-                .expect("open replacement FIFO for source B");
-            second_opened
-                .send(())
-                .expect("test must retain second-open receiver");
-            second
-                .write_all(source_b.as_bytes())
-                .expect("write source B");
+                // `rename` replaces the directory entry, while `first` remains
+                // connected to the old FIFO inode until this explicit drop.
+                std::fs::rename(&replacement, &writer_fifo).expect("replace FIFO path");
+                writer_phase.store(Self::REPLACED, Ordering::SeqCst);
+                drop(first);
+
+                writer_phase.store(Self::SECOND_WRITER_OPENING, Ordering::SeqCst);
+                let mut second = std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&writer_fifo)
+                    .expect("open replacement FIFO for source B");
+                second_opened
+                    .send(())
+                    .expect("test must retain second-open receiver");
+                second
+                    .write_all(source_b.as_bytes())
+                    .expect("write source B");
+            }));
+            let outcome = if result.is_ok() {
+                WriterOutcome::Finished
+            } else {
+                WriterOutcome::Panicked
+            };
+            let _ = writer_outcome.send(outcome);
         });
 
         Self {
             directory,
             fifo,
-            second_opened: receiver,
+            second_opened: second_opened_receiver,
+            writer_outcome: writer_outcome_receiver,
+            phase,
             writer: Some(writer),
             second_writer_opened: false,
         }
@@ -143,35 +227,113 @@ impl TwoSnapshotFifo {
         }
     }
 
-    pub fn release_writer(&mut self) {
+    /// A nonblocking reader on the current FIFO path. `O_NONBLOCK` makes this
+    /// `open` return immediately (with `ENXIO`-free semantics on a FIFO that
+    /// already has a writer, or simply no data yet) instead of blocking until
+    /// a writer attaches -- the property a cleanup path must have, since a
+    /// writer may never attach at all (see the module doc's point 1).
+    fn open_nonblocking_control_fifo(&self) -> std::io::Result<std::fs::File> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&self.fifo)
+    }
+
+    fn drain_nonblocking_control_fifo(control: &mut std::fs::File) -> std::io::Result<()> {
         use std::io::Read;
 
+        let mut bytes = [0; 4096];
+        loop {
+            match control.read(&mut bytes) {
+                Ok(0) => return Ok(()),
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    /// Releases the writer thread without ever performing a blocking `open`.
+    /// Holds nonblocking reader descriptors on both the original and (once
+    /// reachable) the replacement FIFO path, draining them so the writer's
+    /// blocking `open`/`write_all` calls can complete, and bounds the wait by
+    /// `CLEANUP_TIMEOUT` instead of joining unconditionally. This cannot hang
+    /// even if the writer panics before ever reaching the rename: the
+    /// nonblocking descriptors do not depend on a second writer existing, and
+    /// the loop below only joins once `writer.is_finished()` is true.
+    pub fn release_writer(&mut self) -> WriterOutcome {
+        use std::sync::atomic::Ordering;
+        use std::sync::mpsc::TryRecvError;
+
         let Some(writer) = self.writer.take() else {
-            return;
+            return WriterOutcome::Finished;
         };
         if !self.second_writer_opened {
             self.second_writer_opened = self.second_opened.try_recv().is_ok();
         }
-        if !self.second_writer_opened {
-            let mut reader = std::fs::OpenOptions::new()
-                .read(true)
-                .open(&self.fifo)
-                .expect("open replacement FIFO during cleanup");
-            let mut source = String::new();
-            reader
-                .read_to_string(&mut source)
-                .expect("drain replacement FIFO during cleanup");
+
+        let mut controls = vec![
+            self.open_nonblocking_control_fifo()
+                .expect("open nonblocking FIFO cleanup control"),
+        ];
+        let mut replacement_control_opened = self.phase.load(Ordering::SeqCst) >= Self::REPLACED;
+        let deadline = std::time::Instant::now() + Self::CLEANUP_TIMEOUT;
+        let mut outcome = None;
+
+        loop {
+            if !replacement_control_opened && self.phase.load(Ordering::SeqCst) >= Self::REPLACED {
+                controls.push(
+                    self.open_nonblocking_control_fifo()
+                        .expect("open replacement FIFO cleanup control"),
+                );
+                replacement_control_opened = true;
+            }
+
+            for control in &mut controls {
+                Self::drain_nonblocking_control_fifo(control)
+                    .expect("drain nonblocking FIFO cleanup control");
+            }
+
+            if outcome.is_none() {
+                match self.writer_outcome.try_recv() {
+                    Ok(received) => outcome = Some(received),
+                    Err(TryRecvError::Empty) => {}
+                    Err(TryRecvError::Disconnected) => {
+                        panic!("FIFO writer exited without reporting an outcome");
+                    }
+                }
+            }
+
+            if writer.is_finished() {
+                let outcome = outcome.expect("finished FIFO writer must report an outcome");
+                writer.join().expect("join finished FIFO writer");
+                return outcome;
+            }
+
+            assert!(
+                std::time::Instant::now() < deadline,
+                "FIFO writer cleanup exceeded {:?}",
+                Self::CLEANUP_TIMEOUT
+            );
+            std::thread::sleep(std::time::Duration::from_millis(1));
         }
-        writer.join().expect("join FIFO writer");
     }
 }
 
 #[allow(dead_code)]
 impl Drop for TwoSnapshotFifo {
     fn drop(&mut self) {
+        // This runs during assertion unwinding as well, so the fixture cannot
+        // leave FIFOs (or a hung writer thread) behind merely because a check
+        // failed. `catch_unwind` only guards against `release_writer` itself
+        // panicking (e.g. its internal timeout assertion); it does not need
+        // to guard against a blocking syscall because `release_writer` no
+        // longer performs one.
         if self.writer.is_some() {
             let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                self.release_writer();
+                let _ = self.release_writer();
             }));
         }
         let _ = std::fs::remove_file(&self.fifo);
@@ -179,39 +341,115 @@ impl Drop for TwoSnapshotFifo {
     }
 }
 
+/// Wraps a spawned child so a reap is never skipped, including when `kill`
+/// itself fails (e.g. `ESRCH` because the child already exited) and including
+/// on drop if the caller never reaps explicitly.
 #[allow(dead_code)]
-pub fn wait_for_output(child: &mut std::process::Child) -> std::process::Output {
-    use std::io::Read;
+pub struct ReapedChild {
+    pub child: std::process::Child,
+    reaped: bool,
+}
 
+#[allow(dead_code)]
+impl ReapedChild {
+    pub fn new(child: std::process::Child) -> Self {
+        Self {
+            child,
+            reaped: false,
+        }
+    }
+
+    pub fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        let status = self.child.try_wait()?;
+        if status.is_some() {
+            self.reaped = true;
+        }
+        Ok(status)
+    }
+
+    pub fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        let status = self.child.wait()?;
+        self.reaped = true;
+        Ok(status)
+    }
+
+    /// `wait` is deliberately unconditional: a process can exit between a
+    /// timeout poll and kill, making kill return `ESRCH` while still leaving
+    /// a child for this parent to reap. Returning the terminate error
+    /// separately (rather than `.expect()`-ing it) is exactly what lets the
+    /// reap proceed regardless of whether termination itself succeeded.
+    pub fn terminate_and_reap_with<F>(
+        &mut self,
+        terminate: F,
+    ) -> (
+        Option<std::io::Error>,
+        std::io::Result<std::process::ExitStatus>,
+    )
+    where
+        F: FnOnce(&mut std::process::Child) -> std::io::Result<()>,
+    {
+        let terminate_error = terminate(&mut self.child).err();
+        let status = self.wait();
+        (terminate_error, status)
+    }
+
+    fn capture_output(&mut self, status: std::process::ExitStatus) -> std::process::Output {
+        use std::io::Read;
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        self.child
+            .stdout
+            .take()
+            .expect("capture FIFO child stdout")
+            .read_to_end(&mut stdout)
+            .expect("read FIFO child stdout");
+        self.child
+            .stderr
+            .take()
+            .expect("capture FIFO child stderr")
+            .read_to_end(&mut stderr)
+            .expect("read FIFO child stderr");
+        std::process::Output {
+            status,
+            stdout,
+            stderr,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl Drop for ReapedChild {
+    fn drop(&mut self) {
+        if !self.reaped {
+            // Ignore errors during unwinding, but never let a failed kill
+            // skip the reap attempt.
+            let _ = self.child.kill();
+            let _ = self.wait();
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn wait_for_output(child: &mut ReapedChild) -> std::process::Output {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     let status = loop {
         if let Some(status) = child.try_wait().expect("poll FIFO child") {
             break status;
         }
         if std::time::Instant::now() >= deadline {
-            child.kill().expect("kill timed-out FIFO child");
-            let status = child.wait().expect("reap timed-out FIFO child");
-            panic!("fslc against FIFO timed out after 5s; status={status}");
+            let (kill_error, status) = child.terminate_and_reap_with(std::process::Child::kill);
+            let status = status.unwrap_or_else(|wait_error| {
+                panic!("reap timed-out FIFO child after kill result {kill_error:?}: {wait_error}")
+            });
+            let output = child.capture_output(status);
+            panic!(
+                "fslc against FIFO timed out after 5s; kill_error={kill_error:?}; status={status}; stdout={}; stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
     };
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    child
-        .stdout
-        .take()
-        .expect("capture FIFO child stdout")
-        .read_to_end(&mut stdout)
-        .expect("read FIFO child stdout");
-    child
-        .stderr
-        .take()
-        .expect("capture FIFO child stderr")
-        .read_to_end(&mut stderr)
-        .expect("read FIFO child stderr");
-    std::process::Output {
-        status,
-        stdout,
-        stderr,
-    }
+    child.capture_output(status)
 }

--- a/rust/fslc/tests/support/fifo_snapshot.rs
+++ b/rust/fslc/tests/support/fifo_snapshot.rs
@@ -111,7 +111,6 @@ pub struct TwoSnapshotFifo {
     writer_outcome: std::sync::mpsc::Receiver<WriterOutcome>,
     phase: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     writer: Option<std::thread::JoinHandle<()>>,
-    second_writer_opened: bool,
 }
 
 #[allow(dead_code)]
@@ -205,7 +204,6 @@ impl TwoSnapshotFifo {
             writer_outcome: writer_outcome_receiver,
             phase,
             writer: Some(writer),
-            second_writer_opened: false,
         }
     }
 
@@ -218,7 +216,6 @@ impl TwoSnapshotFifo {
         match self.second_opened.try_recv() {
             Err(TryRecvError::Empty) => {}
             Ok(()) => {
-                self.second_writer_opened = true;
                 panic!("the CLI opened source B, proving a second root-path read");
             }
             Err(TryRecvError::Disconnected) => {
@@ -270,15 +267,26 @@ impl TwoSnapshotFifo {
         let Some(writer) = self.writer.take() else {
             return WriterOutcome::Finished;
         };
-        if !self.second_writer_opened {
-            self.second_writer_opened = self.second_opened.try_recv().is_ok();
-        }
 
         let mut controls = vec![
             self.open_nonblocking_control_fifo()
                 .expect("open nonblocking FIFO cleanup control"),
         ];
-        let mut replacement_control_opened = self.phase.load(Ordering::SeqCst) >= Self::REPLACED;
+        // Always start `false`, even though `phase` may already read
+        // `REPLACED` here: control #1 above was opened against whichever
+        // inode the pathname pointed to at that moment, which can race
+        // ahead of this read and land on the *first* inode while `phase`
+        // has already advanced. Deciding `true` from `phase` alone can
+        // therefore skip opening a control on the replacement inode
+        // entirely, stranding the writer's second `open` and failing the
+        // `CLEANUP_TIMEOUT` assert below instead of draining it. Starting
+        // `false` lets the loop's own `phase` check decide on its next
+        // iteration, guaranteeing a control on the replacement inode.
+        // Duplicating a control on the same (first) inode when control #1
+        // already happened to land on the replacement is harmless: both
+        // are nonblocking, cleanup only discards what it reads, and it
+        // does not matter which of two draining readers gets which bytes.
+        let mut replacement_control_opened = false;
         let deadline = std::time::Instant::now() + Self::CLEANUP_TIMEOUT;
         let mut outcome = None;
 


### PR DESCRIPTION
## Problem

The two-inode FIFO read-count oracle existed **twice**. The shared copy at
`rust/fslc/tests/support/fifo_snapshot.rs` — used by all three #808 snapshot controls — was
missing every piece of cleanup hardening that the independent copy inside
`issue_796_domain_command_validation.rs` gained during #803's review, so it could **hang
instead of failing**:

1. `release_writer` did a blocking `open` on the FIFO for reading, which blocks until a writer
   attaches. If the writer thread never reached its second `open` — it panicked, or the CLI
   exited before opening the path at all — this blocked forever.
2. `Drop` funnelled into that same blocking `open`. `catch_unwind` catches a panic but cannot
   interrupt a blocking `open`, so an assertion failure unwound into `Drop`, blocked, and **the
   failure was never reported**. This was raised as *major* in #803's round-4 review.
3. `wait_for_output` did `child.kill().expect(...)` before `child.wait()`. A process can exit
   between the poll and the `kill`, so `kill` returns `ESRCH`, `.expect()` panics, and `wait`
   never runs.

Not hypothetical: during #813's development a test passed an option `mutate` does not accept, the
CLI exited with `kind: usage` before opening the path, the writer blocked in `open`, CI cancelled
`rust tests (1/3)` after 30 minutes, and the same test hung locally for 1h33m. The product bug
was a wrong argument (fixed in #813); the reason it became a 30-minute hang instead of an
assertion failure is path 1.

## Contract change

One hardened oracle now serves all six tests. `support/fifo_snapshot.rs` gains the nonblocking
control descriptors (`O_NONBLOCK` via safe `OpenOptionsExt::custom_flags`), the
`WriterOutcome`/`WriterMode` writer protocol, a `ReapedChild` guard whose
`terminate_and_reap_with` calls `wait` unconditionally regardless of `kill`'s result, and a
`CLEANUP_TIMEOUT` that bounds every cleanup path. The duplicate in
`issue_796_domain_command_validation.rs` is deleted; that file now uses the shared module.

The merged module keeps **both** APIs the two copies had: the shared copy's parameterized
`new(label, source_a, source_b)` and #803's `new_with_writer_mode(WriterMode)`. `release_writer`
now returns `WriterOutcome`, and all four call sites assert `WriterOutcome::Finished` rather
than discarding it. Test-only change: no product source is touched.

## Test evidence

New closing negative control, `release_writer_completes_when_cli_never_opens_the_path` in
`rust/fslc/tests/fifo_snapshot_hardening.rs`: it reproduces #813's incident directly
(`fslc mutate <fifo> --this-option-does-not-exist`, rejected with `kind: usage` and exit 2
before any `open`), then calls `release_writer()` **on a helper thread** and bounds the test's
own wait with `recv_timeout(10s)`. That inversion is what makes a regression observable: calling
`release_writer()` on the test thread and asserting `Finished` would never reach the assertion
under a hang, so its green result would be hang-compatible. The test states inline that
`assert_no_second_open()` is **vacuous** in this scenario and that the `recv_timeout` is the
load-bearing oracle.

#803's two abnormal-path controls moved over intact:
`fifo_cleanup_finishes_when_writer_panics_before_rename` and
`child_guard_reaps_after_esrch_kill_error` (which keeps both halves — reading the child's stdout
to EOF to prove it exited, and asserting the injected `ESRCH` surfaced *and* `wait` still
succeeded).

Independent review confirmed the controls by mutation:

| Mutation | Result |
|---|---|
| `release_writer` reverted to the blocking open | `release_writer_completes_when_cli_never_opens_the_path` **fails in ~12s**, red not hung, binary exits normally |
| `terminate_and_reap_with`'s `wait` given an injected `ECHILD` | `child_guard_reaps_after_esrch_kill_error` **fails in 1.54s** |

Worth recording: under the first mutation the **panic control stayed green** (its blocking open
pairs with the panicking writer's *first* open), so the new negative control is the **sole**
mechanized detector of this regression class.

Review round 2 fixed two findings: a real race at `release_writer`'s
`replacement_control_opened` initialization, where control #1 can land on the first inode after
`phase` already reads `REPLACED`, stranding the writer's second `open` and turning the test into
a 5s `CLEANUP_TIMEOUT` flake — now initialized `false` unconditionally so the loop decides; and
the removal of the vestigial `second_writer_opened` field, dead since the blocking cleanup open
it used to gate was deleted.

```
cargo fmt --all -- --check                                          exit 0
cargo clippy -p fslc-rust --all-targets --locked -- -D warnings      clean
fifo_snapshot_hardening                 3 passed
issue_796_domain_command_validation     5 passed
issue_808_run_verify_snapshot           1 passed
issue_808_mutate_snapshot               1 passed
issue_808_testgen_scenarios_snapshot    3 passed
```

13/13. `cargo test --workspace` was deliberately not run: the delta touches no product source
(`git diff --name-only origin/main..HEAD | grep '^rust/.*/src/'` is empty), and the workspace run
costs over three hours here because `corpus_check_sweep` walks the corpus serially.

## Documentation

`changelog.d/819-unify-fifo-snapshot-oracle-hardening.unified.md`; `unified` is declared
category 8 in `changelog.d/README.md` ("two previously-divergent paths merged into one").
No `docs/LANGUAGE.md` or skill change: this is test infrastructure, not language behavior.

Closes #819. Refs #796, #803, #808, #811, #813, #814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
