### PR TITLE
fix(runtime): enforce init assign-once per concrete key across forall and flat writes

### DIFF
--- a/changelog.d/821-design-bridge-init-key-granularity.documented.md
+++ b/changelog.d/821-design-bridge-init-key-granularity.documented.md
@@ -1,0 +1,6 @@
+Documented (#821): corrected `docs/DESIGN-bridge.md` §1.3's init-determinism
+bullet, whose limiting clause ("... rather than a `forall`-bound variable")
+described the pre-fix explicit-engine behavior instead of the per-concrete-key
+contract `docs/LANGUAGE.md` already stated. The bullet now says a later flat
+`m[K] = ...` write to a key a `forall` bulk assignment already covered is a
+duplicate too, matching the corrected runtime check.

--- a/changelog.d/821-init-write-key-granularity.fixed.md
+++ b/changelog.d/821-init-write-key-granularity.fixed.md
@@ -1,0 +1,7 @@
+Fixed (#821): the explicit-engine init duplicate-write check now rejects a `forall i { m[i]
+= ... }` write that overlaps a later flat `m[K] = ...` write to the same concrete key `K`,
+whether or not the two values agree. It previously tracked forall-indexed writes at
+whole-variable granularity while flat writes were tracked per key, so an overlapping flat
+write with an agreeing value was silently accepted and one with a conflicting value fell
+through to the unrelated "init constraints are unsatisfiable" diagnostic instead of the
+duplicate-write rule's own message.

--- a/docs/DESIGN-bridge.md
+++ b/docs/DESIGN-bridge.md
@@ -85,12 +85,14 @@ Concrete execution requires a deterministic initial state. Static check at
 `Monitor` construction:
 
 - init assigns to every state variable **exactly once** (forall bulk assignment allowed).
-  For a Map/index target (`m[K] = ...`), "once" is per concrete key when the
-  key is a literal or enum member rather than a `forall`-bound variable: flat
+  For a Map/index target (`m[K] = ...`), "once" is per concrete key,
+  including a key a `forall`-bound variable already covered: flat
   `m[K1] = ...` / `m[K2] = ...` statements for two *different* keys are not a
   duplicate (this is exactly how a dialect like fsl-db populates a map one
-  column at a time); the same key assigned twice, or a key that is itself a
-  bound loop variable (where two iterations could alias), still is.
+  column at a time), but the same key assigned twice — whether by two flat
+  statements, by a `forall` and a later flat write to one of its covered
+  keys, or by a bound loop variable whose two iterations could alias each
+  other — still is.
 - The RHS of init may reference only const and **already-assigned** state
   variables (evaluated top to bottom). A violation is `FslError(kind="semantics")`
   + hint "runtime monitor requires a deterministic init".

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -923,9 +923,18 @@ fn logical_var(target: &LValue) -> Option<&str> {
 /// Falls back to `InitWriteKey::Root` (whole-variable) whenever `coverage`
 /// is not `Coverage::Keys` for an `Index` target — including `Full`,
 /// `Fields`, and unresolved (`None`, e.g. a dynamic key or a nested lvalue).
-/// That fallback is at least as strict as treating the write as touching
-/// the entire variable, so it never accepts something today's coarser
-/// `Root`-only classification would have rejected.
+/// That fallback never *accepts* something the coarser, pre-#821
+/// `Root`-only classification would have rejected: every write this
+/// function buckets under `Root` was already bucketed there before. It is
+/// not, however, "as strict as touching the entire variable" in the
+/// collision sense: `Root(name)` never collides with
+/// `ConcreteIndex(name, _)`, so a `None`-coverage target is simply not
+/// collision-checked against any concrete key at all. A `forall`-bound
+/// index used through a non-`Var` key expression (e.g. `m[i - i]`) is one
+/// such target; two iterations of it aliasing each other, or it aliasing a
+/// separate `m[K] = ...`, can still go undetected here when the values
+/// agree. That gap is pre-existing (identical on `origin/main`) and is not
+/// fixed by this change.
 fn init_write_keys(target: &LValue, coverage: Option<&Coverage>) -> BTreeSet<InitWriteKey> {
     if let (LValue::Index(name, _), Some(Coverage::Keys(keys))) = (target, coverage) {
         return keys

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -46,7 +46,7 @@ pub struct ExplicitResult {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 enum InitWriteKey {
     Root(String),
-    ConcreteIndex(String, String),
+    ConcreteIndex(String, Value),
 }
 
 /// Verify a finite kernel model using level-synchronous concrete BFS.
@@ -654,8 +654,9 @@ fn walk_init(
             Statement::Assign { target, value, .. } => {
                 let logical = logical_var(target)
                     .ok_or_else(|| runtime_error("invalid init assignment target"))?;
-                let key = init_write_key(target, bound_names);
-                if possibly_assigned.contains(&key) {
+                let contribution = assignment_coverage(target, bound_names, model);
+                let keys = init_write_keys(target, contribution.as_ref());
+                if keys.iter().any(|key| possibly_assigned.contains(key)) {
                     let scope = if in_forall { "init forall" } else { "init" };
                     return Err(runtime_error(format!(
                         "state variable '{logical}' assigned more than once in {scope}"
@@ -665,12 +666,12 @@ fn walk_init(
                     check_init_expr(key_expr, &definitely_assigned, model)?;
                 }
                 check_init_expr(value, &definitely_assigned, model)?;
-                if let Some(contribution) = assignment_coverage(target, bound_names, model) {
+                if let Some(contribution) = contribution {
                     let previous = definitely_assigned.remove(logical);
                     definitely_assigned
                         .insert(logical.to_owned(), join_coverage(previous, contribution));
                 }
-                possibly_assigned.insert(key);
+                possibly_assigned.extend(keys);
             }
             Statement::ForAll {
                 binder, statements, ..
@@ -908,26 +909,36 @@ fn logical_var(target: &LValue) -> Option<&str> {
     }
 }
 
-fn init_write_key(
-    target: &LValue,
-    bound_names: &BTreeMap<String, Option<Vec<Value>>>,
-) -> InitWriteKey {
-    if let LValue::Index(name, index) = target {
-        match index {
-            Expr::Var(key) if !bound_names.contains_key(key) => {
-                return InitWriteKey::ConcreteIndex(name.clone(), format!("var:{key}"));
-            }
-            Expr::Num(key) => {
-                return InitWriteKey::ConcreteIndex(name.clone(), format!("num:{key}"));
-            }
-            _ => {}
-        }
+/// Concrete per-key write identities a single init assignment touches, for
+/// duplicate-write detection at the granularity `docs/LANGUAGE.md` §12
+/// requires: "assign exactly once" is per concrete key, not per variable.
+///
+/// This reuses `assignment_coverage`'s resolution rather than computing a
+/// second, independent classification (issue #821): a `forall i { m[i] =
+/// ... }` whose index is the binder itself resolves to `Coverage::Keys` of
+/// every binder value, so it collides key-for-key with a later concrete
+/// write to any of those same keys, and an enum-member key resolves to the
+/// same `Value` a numeric literal denoting it would.
+///
+/// Falls back to `InitWriteKey::Root` (whole-variable) whenever `coverage`
+/// is not `Coverage::Keys` for an `Index` target — including `Full`,
+/// `Fields`, and unresolved (`None`, e.g. a dynamic key or a nested lvalue).
+/// That fallback is at least as strict as treating the write as touching
+/// the entire variable, so it never accepts something today's coarser
+/// `Root`-only classification would have rejected.
+fn init_write_keys(target: &LValue, coverage: Option<&Coverage>) -> BTreeSet<InitWriteKey> {
+    if let (LValue::Index(name, _), Some(Coverage::Keys(keys))) = (target, coverage) {
+        return keys
+            .iter()
+            .cloned()
+            .map(|key| InitWriteKey::ConcreteIndex(name.clone(), key))
+            .collect();
     }
-    InitWriteKey::Root(
+    BTreeSet::from([InitWriteKey::Root(
         logical_var(target)
             .expect("kernel lvalue has a logical root")
             .to_owned(),
-    )
+    )])
 }
 
 fn binder_name(binder: &Binder) -> &str {

--- a/rust/fsl-runtime/tests/explicit_engine.rs
+++ b/rust/fsl-runtime/tests/explicit_engine.rs
@@ -225,6 +225,84 @@ fn forall_init_writing_conflicting_values_to_the_same_location_is_unsatisfiable(
     assert!(result.violation.is_none());
 }
 
+/// Issue #821: `docs/LANGUAGE.md`'s "assign exactly once" rule is per
+/// concrete key, not per variable. A `forall i { m[i] = ... }` write and a
+/// later flat `m[K] = ...` write must collide when `K` is one of the keys
+/// the `forall` already covered, whether or not the values agree — before
+/// the fix, `init_write_key` collapsed every forall-indexed write to
+/// `Root(name)` (whole-variable), a different bucket from the flat write's
+/// `ConcreteIndex`, so the overlap was never detected.
+#[test]
+fn init_forall_write_collides_with_later_concrete_write_to_the_same_key() {
+    // Rejecting control (case 1, issue #821): conflicting values on the
+    // same key. Before the fix this fell through to the unrelated
+    // "init constraints are unsatisfiable" diagnostic instead of the
+    // duplicate-write rule's own message.
+    let conflicting = model(
+        "spec Probe { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { forall i: Idx { m[i] = true } m[0] = false } \
+         action noop() { } }",
+    );
+    let error = fsl_runtime::verify_explicit(conflicting, 1, 100)
+        .expect_err("forall write and overlapping concrete write to the same key are rejected");
+    assert_eq!(
+        error.message,
+        "state variable 'm' assigned more than once in init"
+    );
+
+    // Rejecting control (case 2, issue #821): the values happen to agree.
+    // Before the fix this was silently accepted with no error at all.
+    let agreeing = model(
+        "spec Probe { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { forall i: Idx { m[i] = true } m[0] = true } \
+         action noop() { } }",
+    );
+    let error = fsl_runtime::verify_explicit(agreeing, 1, 100).expect_err(
+        "forall write and overlapping concrete write to the same key are rejected even when values agree",
+    );
+    assert_eq!(
+        error.message,
+        "state variable 'm' assigned more than once in init"
+    );
+
+    // Rejecting control: the same overlap through an enum-member key
+    // instead of a numeric literal, exercising the enum-resolution arm of
+    // `assignment_coverage` rather than `Expr::Num`.
+    let enum_overlap = model(
+        "spec Probe { enum Key { A, B } state { m: Map<Key, Bool> } \
+         init { forall k: Key { m[k] = true } m[A] = true } \
+         action noop() { } }",
+    );
+    let error = fsl_runtime::verify_explicit(enum_overlap, 1, 100)
+        .expect_err("forall write and overlapping enum-member concrete write are rejected");
+    assert_eq!(
+        error.message,
+        "state variable 'm' assigned more than once in init"
+    );
+
+    // Accepting control: an injective `forall` write on its own, with no
+    // overlapping concrete write, must stay accepted.
+    let lone_forall = model(
+        "spec Probe { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { forall i: Idx { m[i] = true } } \
+         action noop() { } }",
+    );
+    let result =
+        fsl_runtime::verify_explicit(lone_forall, 1, 100).expect("lone injective forall accepted");
+    assert!(result.violation.is_none());
+
+    // Accepting control: a forall covering one key and a separate flat
+    // write to a genuinely different key must stay accepted.
+    let disjoint = model(
+        "spec Probe { type Idx = 0..2 state { m: Map<Idx, Bool>, n: Map<Idx, Bool> } \
+         init { forall i: Idx { m[i] = true } n[0] = true n[1] = false n[2] = true } \
+         action noop() { } }",
+    );
+    let result = fsl_runtime::verify_explicit(disjoint, 1, 100)
+        .expect("forall write and flat writes to a distinct map's keys are not duplicates");
+    assert!(result.violation.is_none());
+}
+
 #[test]
 fn explicit_violation_trace_replays_through_the_monitor() {
     let model = model(

--- a/rust/fsl-runtime/tests/explicit_engine.rs
+++ b/rust/fsl-runtime/tests/explicit_engine.rs
@@ -291,15 +291,52 @@ fn init_forall_write_collides_with_later_concrete_write_to_the_same_key() {
         fsl_runtime::verify_explicit(lone_forall, 1, 100).expect("lone injective forall accepted");
     assert!(result.violation.is_none());
 
-    // Accepting control: a forall covering one key and a separate flat
-    // write to a genuinely different key must stay accepted.
-    let disjoint = model(
+    // Accepting control: a forall on one map and flat writes to a wholly
+    // separate map are trivially not duplicates (different logical roots,
+    // not disjoint keys on the same map). See the three same-map controls
+    // below for the case this change actually had to get right.
+    let disjoint_variables = model(
         "spec Probe { type Idx = 0..2 state { m: Map<Idx, Bool>, n: Map<Idx, Bool> } \
          init { forall i: Idx { m[i] = true } n[0] = true n[1] = false n[2] = true } \
          action noop() { } }",
     );
-    let result = fsl_runtime::verify_explicit(disjoint, 1, 100)
-        .expect("forall write and flat writes to a distinct map's keys are not duplicates");
+    let result = fsl_runtime::verify_explicit(disjoint_variables, 1, 100)
+        .expect("forall write and flat writes to an unrelated map's keys are not duplicates");
+    assert!(result.violation.is_none());
+
+    // Accepting control: two `forall` blocks over disjoint subranges of the
+    // *same* map's key domain must not collide with each other.
+    let disjoint_foralls = model(
+        "spec Probe { type Idx = 0..3 state { m: Map<Idx, Bool> } \
+         init { forall i in 0..1 { m[i] = true } forall j in 2..3 { m[j] = false } } \
+         action noop() { } }",
+    );
+    let result = fsl_runtime::verify_explicit(disjoint_foralls, 1, 100)
+        .expect("two foralls over disjoint subranges of the same map do not collide");
+    assert!(result.violation.is_none());
+
+    // Accepting control: a forall covering one subrange and a flat write to
+    // a key outside that subrange, on the *same* map, must not collide.
+    let forall_then_flat = model(
+        "spec Probe { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { forall i in 0..1 { m[i] = true } m[2] = false } \
+         action noop() { } }",
+    );
+    let result = fsl_runtime::verify_explicit(forall_then_flat, 1, 100)
+        .expect("a forall and a same-map flat write to a key it does not cover do not collide");
+    assert!(result.violation.is_none());
+
+    // Accepting control: the same shape in the opposite order -- the flat
+    // write first, the forall second -- since detection must not depend on
+    // statement order.
+    let flat_then_forall = model(
+        "spec Probe { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { m[2] = false forall i in 0..1 { m[i] = true } } \
+         action noop() { } }",
+    );
+    let result = fsl_runtime::verify_explicit(flat_then_forall, 1, 100).expect(
+        "a same-map flat write followed by a forall that does not cover its key do not collide",
+    );
     assert!(result.violation.is_none());
 }
 


### PR DESCRIPTION
## Problem

`init`'s "assigned more than once" duplicate-write check and its separate definite-assignment
coverage tracking classified the same statement shape at **different granularity**, and the
duplicate rule used the coarser one:

- `init_write_key()` collapsed every `forall`-indexed write on a variable to one
  `InitWriteKey::Root(name)` — whole-variable granularity — because a `forall`-bound index did not
  match its `ConcreteIndex` arm.
- `assignment_coverage()` (`rust/fsl-runtime/src/explicit.rs:610`), on the same statements, already
  resolved a `forall`-bound index to `Coverage::Keys(binder_values)` — per-key — and resolved
  enum-member keys to a `Value`.

So a `forall` write and a later flat write to a key the `forall` already covered hashed to two
different `InitWriteKey` values and never collided. Measured before the fix:

| Case | Result |
|---|---|
| `forall i { m[i] = true }` then `m[0] = false` (conflicting) | `Err("init constraints are unsatisfiable")` — rejected, but by an unrelated downstream mechanism with the wrong diagnostic |
| `forall i { m[i] = true }` then `m[0] = true` (agreeing) | **`Ok`, no error at all** |

`InitWriteKey::ConcreteIndex(String, String)` compounded it by keying on *formatted source text*
(`var:{key}` / `num:{key}`) where `assignment_coverage` keys on a resolved `Value`, so an
enum-member key and a numeric literal denoting the same value also failed to collide.

## Contract change, and the conflict it required resolving

`docs/LANGUAGE.md:1774`–`1780` and `docs/DESIGN-bridge.md:84`–`93` both scope this rule to
`Monitor` construction, so `check` and symbolic BMC not enforcing it is consistent with both
documents and `fsl-runtime` is the correct place for the fix — no `fsl-core` change is in scope.

But the two documents disagreed on granularity. `docs/DESIGN-bridge.md:88`–`89` carried a limiting
clause `docs/LANGUAGE.md` does not — "per concrete key **when the key is a literal or enum member
rather than a `forall`-bound variable**" — and that clause described the pre-fix behavior.
`AGENTS.md` forbids silently choosing between disagreeing tier-1 sources, so this was escalated and
decided: **`docs/LANGUAGE.md` wins**, and `docs/DESIGN-bridge.md` §1.3's stale exclusion is
corrected in this pull request (`c88239b`). The corrected bullet keeps `forall` bulk assignment
allowed, keeps distinct-key flat writes as non-duplicates, and keeps the fsl-db
"populates a map one column at a time" rationale that explains why per-key granularity exists.

Implementation: `InitWriteKey::ConcreteIndex(String, Value)` unifies on the resolved `Value`;
`init_write_key` becomes `init_write_keys`, reusing `assignment_coverage`'s resolution so a
`forall`-bound index expands into every binder value. Where that resolution is unavailable — a
dynamic index, a nested lvalue, or a binder domain that cannot be statically enumerated — it falls
back to `Root(name)`, exactly as before. A free non-enum `Var` index now also falls back to `Root`
where it previously had its own textual bucket, which is **stricter**, not more permissive.

## Test evidence

Rejecting controls (`rust/fsl-runtime/tests/explicit_engine.rs`): both cases above plus an
enum-member-key variant, each asserting the exact message
`state variable 'm' assigned more than once in init`. Accepting controls: a lone injective
`forall`, and a `forall` on one map alongside disjoint-key flat writes on another — so the change
is shown not to over-reject.

```
cargo fmt --all -- --check                                          clean
cargo clippy -p fsl-runtime --all-targets --locked -- -D warnings    clean, 0 warnings
cargo test -p fsl-runtime      explicit_engine 9/9, monitor_regression 12/12, refinement 10/10
cargo test -p fsl-verifier     all pass
cargo test -p fslc-rust --test corpus_check_sweep    3/3 over 214 .fsl files
tools/aggregate_changelog.sh check                                   PASS
```

**Corpus impact is zero**, established three ways: `corpus_check_sweep` reports no verdict change;
a source-level scan of all 214 corpus files for any indexed variable written twice in `init` with a
non-literal key found 0 candidates; and running the fixed `fslc verify --engine explicit --depth 1`
over all 214 files produced 0 hits of the new diagnostic.

## Enforcement boundary, measured — read before merging

The rule lives at `Monitor` construction by design, so after this fix the same spec is judged
differently by different engines:

```
check                     result=ok
verify (default = bmc)    result=verified
verify --engine explicit  result=error  "state variable 'm' assigned more than once in init"
verify --engine auto      result=verified, engine_fallback.reason carries that message
```

This is consistent with both `docs/LANGUAGE.md:1774` and `docs/DESIGN-bridge.md:84`, which state
the check as a precondition of concrete execution rather than a static language rule: symbolic BMC
does not need a deterministic init, it just conjoins the init constraints. Before this fix all
engines accepted the agreeing-values case, so the fix does introduce a new asymmetry — a
deliberate one, in the direction of the documented contract, and `--engine auto` surfaces the
concrete engine's finding as `engine_fallback.reason` where previously it surfaced nothing.

## Documentation

`docs/DESIGN-bridge.md` §1.3, as above. `docs/LANGUAGE.md` and `docs/LANGUAGE.ja.md` are unchanged:
`:1777` already stated the intended rule correctly, so this is implementation-to-contract
alignment. `docs/DESIGN-bridge.ja.md` does not exist, and `tools/build_site_reference.py` reads
only `LANGUAGE.md`/`LANGUAGE.ja.md`, so the required site-reference check is structurally
unaffected. Two fragments: `821-init-write-key-granularity.fixed.md` for the code and
`821-design-bridge-init-key-granularity.documented.md` for the design-record correction.

Closes #821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
