### PR TITLE
docs(readme): rebuild the README around the native Rust implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ No programming knowledge or Git installation is required — on Mac, open Termin
 run the command above. Windows users should use WSL, or use the developer instructions
 (PowerShell) below.
 
-This places only the versioned release payload under `~/.local/share/fsl`, links the
-commands from `~/.local/bin`, and links the Claude Code skills from `~/.claude/skills/`.
-It does not clone the repository or install examples, documentation, Python sources, or
-Rust sources. `FSL_DATA_DIR` overrides the release-payload location and `FSL_BIN_DIR`
-overrides the command-link location.
+This places only the versioned release payload under `${XDG_DATA_HOME:-~/.local/share}/fsl`,
+links the commands from `~/.local/bin`, and links the Claude Code skills from
+`~/.claude/skills/`. It does not clone the repository or install examples, documentation,
+Python sources, or Rust sources. `FSL_DATA_DIR` overrides the release-payload location
+(taking priority over `XDG_DATA_HOME`) and `FSL_BIN_DIR` overrides the command-link
+location.
 
 What gets installed:
 
@@ -57,9 +58,9 @@ What gets installed:
 - the Claude Code skills (`~/.claude/skills/fsl*`)
 
 The installer verifies both native checksums and rejects a binary whose reported version
-differs from the latest Release tag. It also migrates recognized links to the old Python
-2.7 or `~/.fsl` installations. Use `--no-skill` to skip creating the Claude Code skill
-links.
+differs from the latest Release tag. It also migrates recognized command links that point
+at the old `~/.fsl/.venv/bin` or `~/.fsl/.native/bin` installs (the pre-Rust, fslc
+2.7-era layout). Use `--no-skill` to skip creating the Claude Code skill links.
 
 Uninstall:
 
@@ -68,9 +69,10 @@ rm -rf ~/.local/share/fsl ~/.local/bin/fslc ~/.local/bin/fslc-lsp ~/.claude/skil
 ```
 
 See the [Releases](https://github.com/ymm-oss/fsl/releases) page for the current version. Official releases contain checksummed native binaries,
-the VSCode extension, and Kernel bundles, and — since the v3.0.0 release — a checksummed
-Agent Skill bundle; the installer separately verifies a pinned source-archive checksum for
-compatibility with that original v3.0.0 packaging. The Python compatibility reference
+the VSCode extension, and Kernel bundles; every release after v3.0.0 also contains a
+checksummed Agent Skill bundle, and the installer separately verifies a pinned
+source-archive checksum for the v3.0.0 compatibility path (v3.0.0 predates the checksummed
+skill bundle). The Python compatibility reference
 remains in this repository at version 2.7.0, but this installer does not install it and it
 is not published to PyPI. The Rust workspace crates are not published to crates.io.
 Publishing either surface requires an explicit manifest, workflow, and documentation
@@ -138,8 +140,9 @@ test scaffolds from this spec" or "check whether this log conforms to the spec."
 
 ## Using the CLI directly
 
-Every command below was run against this repository's own `specs/`. Output is JSON on
-stdout (`fslc chain` also writes a human status table to stderr).
+Every command below was run against this repository's own `specs/` (the `document` and
+`ledger` examples below run against `examples/pm/` instead). Except where noted, output
+is JSON on stdout (`fslc chain` also writes a human status table to stderr).
 
 ### Check and verify
 
@@ -167,7 +170,9 @@ full, current list.
 fslc scenarios specs/cart_v1.fsl                          # generate integration-test scaffold JSON
 fslc testgen   specs/cart_v1.fsl -o test_cart_v1.py       # pytest conformance-test scaffold (default target)
 fslc testgen   specs/cart_v1.fsl --target vitest -o cart_v1.test.js
-fslc replay    specs/cart_v1.fsl --trace events.json      # conformance check of a captured full-state trace
+fslc replay    specs/cart_v1.fsl --trace events.json      # conformance check of a captured full-state
+                                                            # trace; events.json is a trace you capture or
+                                                            # build yourself (schema: docs/DESIGN-replay-trace.md)
 fslc replay    specs/cart_v1.fsl --from-log events.jsonl --mapping log_mapping.fsl
                                                             # conformance check of a production event log,
                                                             # mapped into the spec's actions/state by a
@@ -231,7 +236,8 @@ fslc ledger    examples/pm/cancel_system.fsl -o cancel_flow_ledger.md
 ```
 
 `fslc typestate specs/order_workflow.fsl --ts` decides whether typestate (ghost types)
-applies to a design spec and, with `--ts`, emits the TypeScript scaffold directly.
+applies to a design spec and, with `--ts`, emits the TypeScript scaffold directly on
+stdout — TypeScript, not JSON, unlike every other command in this section.
 
 ### The Public Kernel JSON contract
 
@@ -245,9 +251,9 @@ CLI's JSON envelope and this Public Kernel contract**, not a library import. See
 
 ### Editor integration
 
-Every release ships an `fslc-lsp` binary and a VSCode extension (`fsl-vscode-<version>.vsix`).
+Every release ships an `fslc-lsp` binary and a VSCode extension (`fsl-vscode.vsix`).
 Install the extension from the Release page (`code --install-extension
-fsl-vscode-<version>.vsix`, or "Extensions: Install from VSIX…"); it is a thin LSP client
+fsl-vscode.vsix`, or "Extensions: Install from VSIX…"); it is a thin LSP client
 that launches `fslc-lsp` from `PATH` (the install script above puts it there) and gives you
 syntax highlighting, diagnostics, outline, and go-to-definition. See
 [`editors/vscode/README.md`](editors/vscode/README.md).
@@ -257,7 +263,7 @@ syntax highlighting, diagnostics, outline, and go-to-definition. See
 `fslc` has commands not covered above — `version`, `lint`, `migrate`, `fmt`, `sweep`,
 `conformance`, `approval`, and `diff` among them. Run `fslc --help` or `fslc <command>
 --help` for their current arguments, or see [`docs/README.md`](docs/README.md) for the
-design document covering each.
+design document covering most of them (`sweep` has no entry there yet).
 
 `fslc` also has dialect-specific command groups — `ai` (AI hard-contract/agent-structure
 dialect), `domain` (Functional DDD / async effect dialect), `db` (database
@@ -315,8 +321,8 @@ fsl/
 │   └── fsl-lsp/            #   native language server and document index
 ├── src/fslc/               # frozen Python compatibility reference; do not add product behavior here
 ├── docs/                   # docs/README.md maps all of it; LANGUAGE.md is the language reference
-├── specs/                  # sample specs (*.fsl); each file's header comment states the language
-│                           #   feature/idiom it exercises
+├── specs/                  # sample specs (*.fsl); most carry a header comment naming the
+│                           #   language feature/idiom they exercise (not all do — browse the directory)
 ├── examples/               # FSL corpus by audience and topic — pm/, consulting/, e2e/, gallery/, bank/,
 │                           #   layers/, nfr/, domain/, db/, ai/, causal/, and more; see the directory itself
 ├── skills/                 # canonical Agent Skills; .claude/skills/fsl* and .agents/skills/fsl* symlink here
@@ -356,16 +362,33 @@ See [`AGENTS.md`](AGENTS.md) for the full CI-equivalent gate (`cargo fmt`, `carg
 Python is optional and used only for changes explicitly scoped to the frozen
 compatibility reference, or for Python-based repository hooks:
 
+**Mac / Linux:**
+
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate         # for fish: source .venv/bin/activate.fish
 pip install -e ".[dev]"           # installs lark, z3-solver, pytest, and an editable fslc for differential testing
 ```
 
-`tests/` (101 `test_*.py` files) drives Rust-contract, parity, and frozen-reference
-compatibility checks from Python; it is not the product gate above, and it is not sized
-or timed here since neither is stable across machines — run it (`pytest`) only if you are
-working on the compatibility surface.
+**Windows (PowerShell):**
+
+```powershell
+py -m venv .venv
+.venv\Scripts\Activate.ps1        # for cmd: .venv\Scripts\activate.bat
+pip install -e ".[dev]"
+```
+
+You can also run it directly without activating the venv:
+`./.venv/bin/python -m fslc ...` (on Windows, `.venv\Scripts\python -m fslc ...`).
+
+`tests/` drives Rust-contract, parity, and frozen-reference compatibility checks from
+Python; it is not the product gate above — run it (`pytest`) only if you are working on
+the compatibility surface. Alongside the differential tests that cross-check the two
+evaluators (Z3-backed BMC and the concrete Monitor), `tests/oracle.py` is a
+**Z3-independent brute-force oracle**: it enumerates bounded reachable states by driving
+the Monitor directly, to catch false negatives — a case wrongly reported
+`verified`/`proved`/`refines` when the oracle finds a state that should have been
+`violated`/`refinement_failed`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Uninstall:
 rm -rf ~/.local/share/fsl ~/.local/bin/fslc ~/.local/bin/fslc-lsp ~/.claude/skills/fsl ~/.claude/skills/fsl-business ~/.claude/skills/fsl-requirements ~/.claude/skills/fsl-design ~/.claude/skills/fsl-design-review ~/.claude/skills/fsl-delivery
 ```
 
-The current release is **v4.3.0**. Official releases contain checksummed native binaries,
+See the [Releases](https://github.com/ymm-oss/fsl/releases) page for the current version. Official releases contain checksummed native binaries,
 the VSCode extension, and Kernel bundles, and — since the v3.0.0 release — a checksummed
 Agent Skill bundle; the installer separately verifies a pinned source-archive checksum for
 compatibility with that original v3.0.0 packaging. The Python compatibility reference
@@ -313,7 +313,7 @@ fsl/
 │   ├── fslc/               #   native CLI and JSON/process contract
 │   ├── fsl-wasm/           #   browser Worker surface
 │   └── fsl-lsp/            #   native language server and document index
-├── src/fslc/               # frozen Python compatibility reference (63 modules; do not add product behavior here)
+├── src/fslc/               # frozen Python compatibility reference; do not add product behavior here
 ├── docs/                   # docs/README.md maps all of it; LANGUAGE.md is the language reference
 ├── specs/                  # sample specs (*.fsl); each file's header comment states the language
 │                           #   feature/idiom it exercises

--- a/README.md
+++ b/README.md
@@ -2,109 +2,88 @@
 
 FSL is a formal specification language for application development, designed with
 the primary goal of being **written, verified, and repaired by generative AI**.
-The verifier `fslc` uses Lark + Z3 to perform **bounded model checking (BMC)**
-and **infinite-depth proofs via k-induction**, and always returns results as
-**machine-readable JSON** (for the LLM write→verify→repair loop).
-It also includes `fslc scenarios`, which generates integration-test scaffolds from a spec.
+
+The verifier is **`fslc`**, distributed as a native Rust executable with **Z3 bundled in**.
+It performs **bounded model checking (BMC)** and **infinite-depth proofs via k-induction**
+(plus a Z3-free explicit-state engine for the solver-independent path), and always returns
+results as **machine-readable JSON**, for the LLM write → verify → repair loop. It also
+includes `fslc scenarios` and `fslc testgen`, which generate integration-test scaffolds
+from a spec.
 
 Specs can be written in **three layered dialects — consulting (business) / requirements / design (spec)** —
-chained via refinement so that requirement IDs propagate transparently across all diagnostics. Non-functional requirements are also supported, down to SLAs (discrete time).
+chained via refinement so that requirement IDs propagate transparently across all diagnostics.
+Non-functional requirements are also supported, down to SLAs (discrete time).
+
 For the language specification, semantics, and output JSON see [`docs/LANGUAGE.md`](docs/LANGUAGE.md);
 for a map of all the documentation see [`docs/README.md`](docs/README.md).
 
-## First steps
+> **A note on this repository's two implementations.** The native Rust workspace under
+> [`rust/`](rust/) is the authoritative implementation — it is what every command below
+> runs, and what ships in Releases. `src/fslc/` is a **frozen Python compatibility
+> reference** kept for differential testing; it is not the product, and new behavior does
+> not land there. See [`AGENTS.md`](AGENTS.md) if you are contributing.
 
-The basic way to use FSL is **not** for a person to memorize the FSL syntax and write it by hand;
-instead, you install `fslc` and the Agent Skill and then have an AI agent write the spec,
-reading the verification results as it repairs it.
+## Install
 
-1. **Install FSL and the skill**
+Most people should use **the install script** — it sets up `fslc`, `fslc-lsp`, and the
+Claude Code Agent Skills together, and is the only route that also gets you skill
+integration. Use one of the other two routes only if it specifically fits you:
 
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/ymm-oss/fsl/main/install.sh | bash
-   ```
+- Just want the `fslc` binary, nothing else (no PATH setup, no skills)? [Download a single
+  executable](#download-a-single-executable-instead).
+- Building `fslc` yourself, or need the frozen Python reference for compatibility work?
+  [Developer setup](#developer-setup-building-from-source).
 
-   A standard install gives you the verifier `fslc` and the Claude Code skills
-   under `~/.claude/skills/`. If you want AI to write FSL in another project too,
-   load these skills there.
+### The install script (recommended)
 
-2. **Ask an AI agent to build it using the requirements skill**
-
-   ```text
-   Use $fsl-requirements to write a requirements spec for a cancellation request flow.
-   Only approved orders can be canceled; cancellation after shipping is not allowed; refunds must not run twice.
-   Verify it, fix any problems, and keep iterating until there are none.
-   ```
-
-   For PM use, start with `$fsl-requirements`; for consulting/business-flow work,
-   start with `$fsl-business`.
-   The AI follows the language reference and repair protocol in the skill,
-   creates the `.fsl` file, and verifies it with `fslc`.
-
-   **Note:** what the verifier guarantees is "no contradictions or counterexamples within the scope of what is written in the spec."
-   A human should confirm that the spec the AI wrote correctly represents the original business rules, requirements, and exceptional conditions,
-   and, when a counterexample appears, that the revised interpretation is reasonable as a matter of business.
-
-3. **If needed, have it generate tests and implementation hookup too**
-
-   Turning acceptance criteria into scenarios, pytest conformance-test scaffolds, and conformance checking
-   of existing event logs against the spec can all be chained from the same `.fsl` spec. For this too,
-   it is enough to ask the AI: "also build test scaffolds from this spec" or "check whether this log conforms to the spec."
-
-## Directory layout
-
-```
-fsl/
-├── README.md
-├── pyproject.toml          # dependencies (lark, z3-solver) and the fslc command definition
-├── docs/
-│   ├── README.md           # map of docs (start here)
-│   ├── LANGUAGE.md         # language reference — read this if you are writing specs
-│   └── DESIGN-*.md         # authoritative design contracts and distilled findings
-├── specs/                  # sample specs (*.fsl) — all the correct ones are proved at k=1
-│   ├── cart_v1.fsl         #   basic form of Option / ensures / reachable
-│   ├── cart_v1_buggy.fsl   #   missing guard — returns the shortest type_bound violation counterexample
-│   ├── order_workflow.fsl  #   enum / struct / Set / sum
-│   ├── auth_lockout.fsl    #   lockout + ghost variable + auxiliary invariant
-│   ├── inventory_reservation.fsl  # conservation-law invariant
-│   ├── payment.fsl         #   partial refunds + ledger + auxiliary invariant
-│   ├── rate_limiter.fsl    #   token bucket
-│   ├── mutex_queue.fsl     #   FIFO mutex (Option + Seq)
-│   ├── job_pipeline.fsl    #   job queue with retries (Seq + struct)
-│   ├── audit_log.fsl       #   append-only log + Seq aggregation idiom
-│   ├── order_system.fsl    #   compose: cart_v1 + payment with synchronized checkout/capture
-│   ├── bank{,_impl,_refines,_system}.fsl  # refinement + compose chain
-│   ├── seat_booking*.fsl   #   refinement with a conditional mapping
-│   ├── repair_loop.fsl     #   self-spec of fslc's own workflow
-│   └── cart_{buggy,fixed}.fsl     # v0-compatible samples
-├── examples/
-│   ├── pm/                 # for PM/PdM (cancellation flow: business + requirements)
-│   ├── consulting/         # for consulting (As-Is/To-Be control checks)
-│   ├── e2e/                # three-role integration (consulting → PM → engineer → implementation)
-│   ├── gallery/            # case-study gallery (valid examples / invalid-example catalog / adversarial)
-│   ├── bank/               # conformance tests against a plain Python implementation (8/8)
-│   ├── layers/             # three-layer chain (business → requirements → design)
-│   └── nfr/                # discrete-time SLA (urgency discipline, time-budget invariant)
-├── src/fslc/               # verifier package
-│   ├── __init__.py         #   public API: parse / build_spec / verify
-│   ├── __main__.py         #   for python -m fslc
-│   ├── grammar.py          #   Lark grammar + AST transformer
-│   ├── parser.py           #   parse(src) -> AST
-│   ├── model.py            #   build_spec / type→Z3 sort / constant evaluation / FslError
-│   ├── bmc.py              #   verify / prove (k-induction) / scenarios / trace generation
-│   ├── runtime.py          #   Monitor concrete interpreter (no Z3 required)
-│   ├── testgen.py          #   pytest conformance-test scaffold generation
-│   ├── html_report.py      #   self-contained HTML review report rendering
-│   └── cli.py              #   CLI and JSON output / error envelope
-└── tests/                  # pytest (v0-compat / v1 / induction / scenarios / runtime /
-                            #         dialects / NFR / independent-oracle cross-checking, trace soundness)
+```bash
+curl -fsSL https://raw.githubusercontent.com/ymm-oss/fsl/main/install.sh | bash
 ```
 
-## Easiest of all: just download the executable (no Python needed)
+No programming knowledge or Git installation is required — on Mac, open Terminal.app and
+run the command above. Windows users should use WSL, or use the developer instructions
+(PowerShell) below.
 
-`fslc` is distributed as a **single native executable**. You need neither a Python install,
-`pip`, nor a separately installed Z3. Just grab the one file for your OS from GitHub **Releases**
-and it runs.
+This places only the versioned release payload under `~/.local/share/fsl`, links the
+commands from `~/.local/bin`, and links the Claude Code skills from `~/.claude/skills/`.
+It does not clone the repository or install examples, documentation, Python sources, or
+Rust sources. `FSL_DATA_DIR` overrides the release-payload location and `FSL_BIN_DIR`
+overrides the command-link location.
+
+What gets installed:
+
+- the native Rust `fslc` and `fslc-lsp` commands (used from `~/.local/bin`; Python is not
+  required) — the [VSCode extension](#editor-integration) launches `fslc-lsp` from `PATH`
+- the Claude Code skills (`~/.claude/skills/fsl*`)
+
+The installer verifies both native checksums and rejects a binary whose reported version
+differs from the latest Release tag. It also migrates recognized links to the old Python
+2.7 or `~/.fsl` installations. Use `--no-skill` to skip creating the Claude Code skill
+links.
+
+Uninstall:
+
+```bash
+rm -rf ~/.local/share/fsl ~/.local/bin/fslc ~/.local/bin/fslc-lsp ~/.claude/skills/fsl ~/.claude/skills/fsl-business ~/.claude/skills/fsl-requirements ~/.claude/skills/fsl-design ~/.claude/skills/fsl-design-review ~/.claude/skills/fsl-delivery
+```
+
+The current release is **v4.3.0**. Official releases contain checksummed native binaries,
+the VSCode extension, and Kernel bundles, and — since the v3.0.0 release — a checksummed
+Agent Skill bundle; the installer separately verifies a pinned source-archive checksum for
+compatibility with that original v3.0.0 packaging. The Python compatibility reference
+remains in this repository at version 2.7.0, but this installer does not install it and it
+is not published to PyPI. The Rust workspace crates are not published to crates.io.
+Publishing either surface requires an explicit manifest, workflow, and documentation
+change.
+
+Maintainers cut releases using the documented [`docs/RELEASE.md`](docs/RELEASE.md)
+procedure and the internal [`release` Agent Skill](.claude/skills/release/SKILL.md).
+
+### Download a single executable instead
+
+`fslc` is a **single native executable**. You need neither a Python install, `pip`, nor a
+separately installed Z3 — grab the one file for your OS from GitHub **Releases** and it
+runs, with no skill integration and no PATH setup.
 
 | OS / arch | File to download |
 | --- | --- |
@@ -119,142 +98,187 @@ chmod +x fslc-macos-arm64
 ./fslc-macos-arm64 verify spec.fsl
 ```
 
-> **macOS note**: a downloaded executable will be blocked by Gatekeeper.
-> The first time only, remove the quarantine attribute:
-> `xattr -d com.apple.quarantine ./fslc-macos-arm64`
+> **macOS note**: a downloaded executable will be blocked by Gatekeeper. The first time
+> only, remove the quarantine attribute: `xattr -d com.apple.quarantine ./fslc-macos-arm64`
 > (or right-click in Finder → "Open" once).
 
 Each file ships with a companion `*.sha256`. You can verify it with
-`shasum -a 256 -c fslc-macos-arm64.sha256`.
-
-The Linux binaries target the Ubuntu 24.04 ABI baseline (glibc 2.39 or newer).
+`shasum -a 256 -c fslc-macos-arm64.sha256`. The Linux binaries target the Ubuntu 24.04 ABI
+baseline (glibc 2.39 or newer).
 
 > This binary bundles Z3, so all features including `verify` work without a separately
-> installed solver. Normal operating-system runtime libraries still apply. If you need skill integration or editable development,
-> use the setup instructions below.
+> installed solver. Normal operating-system runtime libraries still apply.
 
-## Easy setup (for PMs, consultants, and non-engineers)
+## Write your first spec with an AI agent
 
-No programming knowledge or Git installation is required. The installer keeps
-the native commands and Agent Skills on one published Release tag.
+The basic way to use FSL is **not** for a person to memorize the FSL syntax and write it
+by hand; instead, you have an AI agent write the spec, reading the verification results
+as it repairs it.
 
-1. **Open a terminal** (on Mac, "Terminal.app"; search your apps for "terminal").
-2. **Run the install command**:
-
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/ymm-oss/fsl/main/install.sh | bash
-   ```
-
-This places only the versioned release payload under `~/.local/share/fsl`, links
-the commands from `~/.local/bin`, and links the Claude Code skills from
-`~/.claude/skills/`. It does not clone the repository or install examples,
-documentation, Python sources, or Rust sources. `FSL_DATA_DIR` overrides the
-release-payload location and `FSL_BIN_DIR` overrides the command-link location.
-
-What gets installed:
-
-- the native Rust `fslc` and `fslc-lsp` commands (used from `~/.local/bin`; Python is not required)
-  — the VSCode extension launches `fslc-lsp` from `PATH`
-- the Claude Code skills (`~/.claude/skills/fsl*`)
-
-The installer verifies both native checksums and rejects a binary whose reported
-version differs from the latest Release tag. It also migrates recognized links
-to the old Python 2.7 or `~/.fsl` installations. Use `--no-skill` to skip creating
-the Claude Code skill links.
-
-Windows users should use WSL or refer to the developer instructions (PowerShell).
-
-Uninstall:
-
-```bash
-rm -rf ~/.local/share/fsl ~/.local/bin/fslc ~/.local/bin/fslc-lsp ~/.claude/skills/fsl ~/.claude/skills/fsl-business ~/.claude/skills/fsl-requirements ~/.claude/skills/fsl-design ~/.claude/skills/fsl-design-review ~/.claude/skills/fsl-delivery
+```text
+Use $fsl-requirements to write a requirements spec for a cancellation request flow.
+Only approved orders can be canceled; cancellation after shipping is not allowed; refunds must not run twice.
+Verify it, fix any problems, and keep iterating until there are none.
 ```
 
-Official releases contain checksummed native binaries, VSCode extension, and
-Kernel bundles. Releases after v3.0.0 also contain the checksummed Agent Skill
-bundle; the installer verifies a pinned source-archive checksum for the v3.0.0
-compatibility path. The Python
-compatibility reference remains in this repository at version 2.7.0, but this
-installer does not install it and it is not published to PyPI. The Rust workspace
-crates are not published to crates.io. Publishing either surface requires an
-explicit manifest, workflow, and documentation change.
-Maintainers cut releases using the documented [`docs/RELEASE.md`](docs/RELEASE.md)
-procedure and the internal [`release` Agent Skill](.claude/skills/release/SKILL.md).
+For PM use, start with `$fsl-requirements`; for consulting/business-flow work, start with
+`$fsl-business`. The AI follows the language reference and repair protocol in the skill,
+creates the `.fsl` file, and verifies it with `fslc`.
 
-## Developer setup
+**Note:** what the verifier guarantees is "no contradictions or counterexamples within the
+scope of what is written in the spec." A human should confirm that the spec the AI wrote
+correctly represents the original business rules, requirements, and exceptional
+conditions, and, when a counterexample appears, that the revised interpretation is
+reasonable as a matter of business.
 
-First get the repository:
-
-```bash
-git clone https://github.com/ymm-oss/fsl && cd fsl
-```
-
-The commands below install the retained Python reference implementation for differential
-testing. There are only two runtime dependencies: `lark` (pure Python) and `z3-solver`
-(a prebuilt wheel that bundles the native libz3). **No C++ compiler or separate Z3 install is needed**,
-and on Mac / Windows / Linux it is all done with just `pip install` (requires Python 3.9+).
-
-**Mac / Linux:**
-
-```bash
-python3 -m venv .venv
-source .venv/bin/activate         # for fish: source .venv/bin/activate.fish
-pip install -e ".[dev]"           # installs lark, z3-solver, pytest and does an editable install of fslc
-```
-
-**Windows (PowerShell):**
-
-```powershell
-py -m venv .venv
-.venv\Scripts\Activate.ps1        # for cmd: .venv\Scripts\activate.bat
-pip install -e ".[dev]"
-```
-
-You can also run it directly without activating the venv:
-`./.venv/bin/python -m fslc ...` (on Windows, `.venv\Scripts\python -m fslc ...`).
+Turning acceptance criteria into scenarios, test-scaffold generation in several target
+languages, and conformance checking of existing event logs against the spec can all be
+chained from the same `.fsl` spec. For this too, it is enough to ask the AI: "also build
+test scaffolds from this spec" or "check whether this log conforms to the spec."
 
 ## Using the CLI directly
 
+Every command below was run against this repository's own `specs/`. Output is JSON on
+stdout (`fslc chain` also writes a human status table to stderr).
+
+### Check and verify
+
 ```bash
-fslc check  specs/cart_v1.fsl                    # syntax/types only (fast loop)
-fslc verify specs/cart_v1.fsl --depth 8          # BMC: verified + shortest counterexample/witness
-fslc verify specs/cart_v1.fsl --engine induction # k-induction: proved (infinite depth)
-fslc scenarios specs/cart_v1.fsl                 # generate integration-test scaffold JSON
-fslc replay specs/cart_v1.fsl --trace events.json  # conformance check of an event log
-fslc testgen specs/cart_v1.fsl -o test_cart_v1.py  # generate a pytest conformance-test scaffold
+fslc check  specs/cart_v1.fsl                        # syntax/types only (fast loop)
+fslc verify specs/cart_v1.fsl --depth 8               # BMC: verified + shortest counterexample/witness
+fslc verify specs/cart_v1.fsl --engine induction      # k-induction: proved (infinite depth)
+fslc verify specs/cart_v1.fsl --engine explicit       # Z3-free explicit-state BFS
+fslc verify specs/cart_v1.fsl --engine auto           # explicit-state first, transparent BMC fallback
+```
+
+`cart_v1_buggy.fsl` returns the shortest counterexample trace for the automatic bounds
+check (`type_bound`). `verify` also has `--explicit-budget` (exceeding the explicit
+engine's visited-state budget returns `unknown_budget` rather than a false `verified`),
+`--property`/`--exclude-property` to scope which invariant/`trans`/`leadsTo`/`reachable`
+obligation runs, `--instances`/`--values` to override verify-block bounds, `--lemma` for
+induction candidate auxiliary invariants, `--from-state` to continue BMC from a captured
+Monitor/replay state snapshot, `--requirements` to scope by requirement id, `--deadlock
+{warn,error,ignore}`, and `--edition {current,next}`. See `fslc verify --help` for the
+full, current list.
+
+### Scenarios, test generation, and log conformance
+
+```bash
+fslc scenarios specs/cart_v1.fsl                          # generate integration-test scaffold JSON
+fslc testgen   specs/cart_v1.fsl -o test_cart_v1.py       # pytest conformance-test scaffold (default target)
+fslc testgen   specs/cart_v1.fsl --target vitest -o cart_v1.test.js
+fslc replay    specs/cart_v1.fsl --trace events.json      # conformance check of a captured full-state trace
+fslc replay    specs/cart_v1.fsl --from-log events.jsonl --mapping log_mapping.fsl
+                                                            # conformance check of a production event log,
+                                                            # mapped into the spec's actions/state by a
+                                                            # refinement-syntax mapping file you author
+                                                            # (see docs/DESIGN-log-replay.md)
+```
+
+`testgen --target` also accepts `swift`, `kotlin`, `dart`, and `phpunit`.
+
+### Refinement and composition
+
+```bash
 fslc refine specs/cart_impl.fsl specs/cart_v1.fsl specs/cart_refines.fsl --depth 8
                                                   # check whether the detailed spec refines the abstract spec
                                                   # mapping files can opt into preserve progress for upper leadsTo
-fslc chain fsl-project.toml --keep-going          # run business -> requirements -> design -> impl from a manifest
-fslc verify specs/order_system.fsl --depth 8    # compose: synchronized composition of cart + payment
-
-# Validation suite (closes the gap between spec ≠ intent; see docs/DESIGN-{forbidden,vacuity,...})
-fslc verify specs/cart_v1.fsl --vacuity error   # detect vacuous properties (unreachable antecedent/trigger, always-true requires)
-fslc verify specs/cart_v1.fsl --strict-tags     # match untagged declarations (fabrication candidates) and unreferenced requirements (omission candidates)
-fslc mutate specs/cart_v1.fsl                    # spec mutation: bounded mutant-set sensitivity of the property net (survivors are a review queue)
-fslc explain specs/cart_v1.fsl                   # skeleton enumeration + counterfactuals (what would happen without this rule)
-fslc analyze specs/cart_v1.fsl --profile ai-review # structural review findings (not proof failures)
-fslc html specs/cart_v1.fsl -o cart_report.html  # self-contained HTML report for team review
-fslc typestate specs/order_workflow.fsl --ts    # state machine → applicability check for phantom types + TS scaffold
-# (in the requirements dialect, the forbidden block can also write "operation sequences that should be rejected")
-
-# Can also be run as a module without installing
-python -m fslc verify specs/cart_v1_buggy.fsl
+fslc verify specs/order_system.fsl --depth 8     # compose: synchronized composition of cart + payment
 ```
 
-The output is JSON on stdout (`fslc chain` also writes its human status table to
-stderr). Exit codes: 0 = verified / proved / refines /
-conformant / generated / mutated / explained / analyzed / typestate; 1 = violated /
-refinement_failed / reachable_failed / unknown_cti / nonconformant;
-2 = spec error (`error`, including vacuity under `--vacuity error`); 3 = internal error.
-`cart_v1_buggy.fsl` returns the shortest counterexample trace for the automatic bounds check (`type_bound`).
+`fslc chain` runs an entire business → requirements → design → impl pipeline from a
+project manifest (a small TOML file naming each layer's spec, its refinement mapping, and
+an optional implementation-conformance command) that you write for your own project —
+there is no shared example manifest at the repository root, since a manifest is inherently
+project-specific. `docs/DESIGN-*.md` and the `fsl-delivery` skill describe the manifest
+shape; running it looks like:
+
+```bash
+fslc chain fsl-project.toml --keep-going
+```
+
+### Validation suite (closes the gap between spec ≠ intent)
+
+```bash
+fslc verify  specs/cart_v1.fsl --vacuity error    # detect vacuous properties (unreachable antecedent/trigger, always-true requires)
+fslc verify  specs/cart_v1.fsl --strict-tags      # match untagged declarations (fabrication candidates) and unreferenced requirements (omission candidates)
+fslc mutate  specs/cart_v1.fsl                    # bounded mutant-set sensitivity of the property net (survivors are a review queue)
+fslc explain specs/cart_v1.fsl                    # skeleton enumeration + counterfactuals (what would happen without this rule)
+fslc analyze specs/cart_v1.fsl --profile ai-review  # structural review findings (not proof failures)
+```
+
+`analyze` also emits structural projections (`--projection {tsg, action_dependency_graph,
+action_state_graph, code_audit, impact_graph, property_state_graph,
+requirement_property_graph, refinement_graph, traceability_graph}`) in `--format {dot,
+json, mermaid}`, and `--export tag-review` for declaration-level tag/formula review
+tuples.
+
+### Reports, requirements documents, and audit ledgers
+
+```bash
+fslc html      specs/cart_v1.fsl -o cart_report.html       # self-contained HTML report for team review
+fslc document generate examples/pm/cancel_system.fsl -o cancel_flow.md
+                                                              # render a controlled-language requirements
+                                                              # document (ja/en) from a checked spec
+fslc document claims  examples/pm/cancel_system.fsl          # emit the same content as a Requirement Claim IR (RCIR) JSON set
+fslc document check   examples/pm/cancel_system.fsl cancel_flow.md
+                                                              # detect drift between a generated document and
+                                                              # a fresh re-render of its spec
+fslc ledger    examples/pm/cancel_system.fsl -o cancel_flow_ledger.md
+                                                              # business audit ledger (markdown) by requirement id,
+                                                              # optionally scored against an implementation trace
+                                                              # (--impl-log) or checked digest-bound approvals
+```
+
+`fslc typestate specs/order_workflow.fsl --ts` decides whether typestate (ghost types)
+applies to a design spec and, with `--ts`, emits the TypeScript scaffold directly.
+
+### The Public Kernel JSON contract
+
+```bash
+fslc kernel specs/cart_v1.fsl              # normalized public Kernel JSON (schema fslc/kernel/kernel.v1)
+```
+
+Since the Rust crates are not published, **the supported programmatic surface is the
+CLI's JSON envelope and this Public Kernel contract**, not a library import. See
+[`docs/DESIGN-kernel-contract.md`](docs/DESIGN-kernel-contract.md).
+
+### Editor integration
+
+Every release ships an `fslc-lsp` binary and a VSCode extension (`fsl-vscode-<version>.vsix`).
+Install the extension from the Release page (`code --install-extension
+fsl-vscode-<version>.vsix`, or "Extensions: Install from VSIX…"); it is a thin LSP client
+that launches `fslc-lsp` from `PATH` (the install script above puts it there) and gives you
+syntax highlighting, diagnostics, outline, and go-to-definition. See
+[`editors/vscode/README.md`](editors/vscode/README.md).
+
+### Everything else
+
+`fslc` has commands not covered above — `version`, `lint`, `migrate`, `fmt`, `sweep`,
+`conformance`, `approval`, and `diff` among them. Run `fslc --help` or `fslc <command>
+--help` for their current arguments, or see [`docs/README.md`](docs/README.md) for the
+design document covering each.
+
+`fslc` also has dialect-specific command groups — `ai` (AI hard-contract/agent-structure
+dialect), `domain` (Functional DDD / async effect dialect), `db` (database
+compatibility dialect), `compat` (shared compatibility commands), and `causal`
+(review-only causal hypothesis graphs). These exist and are documented under `docs/`
+(`DESIGN-ai-hard.md`, `DESIGN-domain.md`, `DESIGN-db.md`, `DESIGN-causal.md`); this README
+does not tutorialize them.
+
+### Exit codes
+
+0 = verified / proved / refines / conformant / generated / mutated / explained / analyzed
+/ typestate; 1 = violated / refinement_failed / reachable_failed / unknown_cti /
+unknown_budget / nonconformant; 2 = spec error (`error`, including vacuity under
+`--vacuity error`); 3 = internal error.
 
 ## Skills for AI agents
 
-Because FSL is a language not present in training data, when an AI agent (such as Claude Code)
-writes a spec, the **Agent Skills** supply the language specification, role-specific
-workflow, and repair protocol into context. For easy distribution and discovery,
-the canonical copies live under [`skills/`](skills/) at the repository root:
+Because FSL is a language not present in training data, when an AI agent (such as Claude
+Code) writes a spec, the **Agent Skills** supply the language specification,
+role-specific workflow, and repair protocol into context. For easy distribution and
+discovery, the canonical copies live under [`skills/`](skills/) at the repository root:
 
 - [`skills/fsl/SKILL.md`](skills/fsl/SKILL.md) — shared verifier workflow / repair protocol / minimal syntax
 - [`skills/fsl/reference.md`](skills/fsl/reference.md) — condensed, complete language-reference card
@@ -263,38 +287,89 @@ the canonical copies live under [`skills/`](skills/) at the repository root:
 - [`skills/fsl-design/SKILL.md`](skills/fsl-design/SKILL.md) — engineering design specs and refinement to requirements
 - [`skills/fsl-design-review/SKILL.md`](skills/fsl-design-review/SKILL.md) — design review, variant checks, and substitutability judgment
 - [`skills/fsl-delivery/SKILL.md`](skills/fsl-delivery/SKILL.md) — end-to-end workflow orchestration across planning, requirements, design, and implementation conformance
+- [`skills/fsl-from-code/SKILL.md`](skills/fsl-from-code/SKILL.md) — reverse-engineer a design-layer spec from existing source code
+- [`skills/fsl-requirements-document/SKILL.md`](skills/fsl-requirements-document/SKILL.md) — generate and re-verify a human-readable requirements document from a checked spec
 
-Claude Code working in this repository recognizes them automatically via `.claude/skills/`
-(symbolic links to `skills/*`). To use them in another project,
-copy the relevant `skills/fsl*` directories into that project's `.claude/skills/` or into `~/.claude/skills/`,
-or point the `gh` skill extension at `skills/` as the distribution source.
-See [`skills/README.md`](skills/README.md) for details.
+The install script above links the first six into `~/.claude/skills/`; `fsl-from-code` and
+`fsl-requirements-document` are not part of that installed set today, but are checked into
+this repository's own `.claude/skills/` and `.agents/skills/` as symlinks to `skills/*`. To
+use any of them in another project, copy the relevant `skills/fsl*` directories into that
+project's `.claude/skills/` or into `~/.claude/skills/`, or point the `gh` skill extension
+at `skills/` as the distribution source. See [`skills/README.md`](skills/README.md) for
+details.
 
-## Tests
+## Repository layout
+
+```
+fsl/
+├── README.md
+├── rust/                   # authoritative implementation — see AGENTS.md "Project structure"
+│   ├── fsl-syntax/         #   lexer, parsers, source locations, and surface AST
+│   ├── fsl-core/           #   typed kernel model, validation, resolution, and dialect lowering
+│   ├── fsl-runtime/        #   solver-independent Monitor and explicit-state/BFS behavior
+│   ├── fsl-solver*/        #   backend-neutral solver boundary plus native and browser Z3 backends
+│   ├── fsl-verifier/       #   BMC, induction, refinement, liveness, and scenarios
+│   ├── fsl-tools/          #   analysis, mutation, report, typestate, and test generation tools
+│   ├── fslc/               #   native CLI and JSON/process contract
+│   ├── fsl-wasm/           #   browser Worker surface
+│   └── fsl-lsp/            #   native language server and document index
+├── src/fslc/               # frozen Python compatibility reference (63 modules; do not add product behavior here)
+├── docs/                   # docs/README.md maps all of it; LANGUAGE.md is the language reference
+├── specs/                  # sample specs (*.fsl); each file's header comment states the language
+│                           #   feature/idiom it exercises
+├── examples/               # FSL corpus by audience and topic — pm/, consulting/, e2e/, gallery/, bank/,
+│                           #   layers/, nfr/, domain/, db/, ai/, causal/, and more; see the directory itself
+├── skills/                 # canonical Agent Skills; .claude/skills/fsl* and .agents/skills/fsl* symlink here
+└── tests/                  # Python-driven Rust contract, parity, and compatibility tests
+```
+
+`specs/` and `examples/` are FSL corpus and reproducing cases; browse them directly rather
+than relying on a hand-maintained inventory here, since a per-file list is exactly what
+went stale in this document before. Two specs worth knowing up front because other
+sections use them: `specs/cart_v1.fsl` (basic `Option`/`ensures`/`reachable`, used
+throughout this README) and `specs/order_system.fsl` (a `compose` of cart + payment).
+
+## Developer setup (building from source)
 
 ```bash
-pytest
+git clone https://github.com/ymm-oss/fsl && cd fsl
 ```
 
-301 tests (+69 skipped) verify all features (v0-compat / type system / k-induction / leadsTo /
-scenarios / runtime / refine / compose / three-layer dialects / NFR) (about 260 seconds).
-The two evaluators (Z3 and the concrete Monitor) cross-check each other via differential tests of witness replay, and in addition
-a **Z3-independent brute-force oracle** (`tests/oracle.py`) checks for false negatives (misses where something that should be violated/
-refinement_failed is wrongly reported as verified/proved/refines).
+The native Rust workspace under `rust/` is what you build and test:
 
-## Library API
-
-```python
-from fslc import parse, build_spec, verify, prove
-
-spec   = build_spec(parse(open("specs/cart_v1.fsl").read()))
-result = verify(spec, depth=8)              # BMC. dict (same structure as the CLI)
-result = prove(spec, k_ind=1, base_depth=8) # k-induction (proved / unknown_cti)
+```bash
+cargo run --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc -- check specs/cart_v1.fsl
+cargo run --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc -- verify specs/cart_v1.fsl --depth 8
+cargo run --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc -- verify specs/cart_v1.fsl --engine induction
 ```
+
+The complete required product gate is Rust-native and does not execute Python:
+
+```bash
+./tools/check-native-integration.sh
+```
+
+See [`AGENTS.md`](AGENTS.md) for the full CI-equivalent gate (`cargo fmt`, `cargo clippy
+--workspace --all-targets -D warnings`, `cargo test --workspace`, `cargo build
+--workspace`) and the narrower gates for solver, logic-semantics, and corpus changes.
+
+Python is optional and used only for changes explicitly scoped to the frozen
+compatibility reference, or for Python-based repository hooks:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate         # for fish: source .venv/bin/activate.fish
+pip install -e ".[dev]"           # installs lark, z3-solver, pytest, and an editable fslc for differential testing
+```
+
+`tests/` (101 `test_*.py` files) drives Rust-contract, parity, and frozen-reference
+compatibility checks from Python; it is not the product gate above, and it is not sized
+or timed here since neither is stable across machines — run it (`pytest`) only if you are
+working on the compatibility surface.
 
 ## License
 
 Distributed under the [Apache License 2.0](LICENSE). Copyright 2026 Ryoichi Izumita.
 
-The dependencies `lark` and `z3-solver` are both under the MIT License (compatible with Apache-2.0).
-See [`NOTICE`](NOTICE) for details.
+The frozen Python reference's dependencies, `lark` and `z3-solver`, are both under the MIT
+License (compatible with Apache-2.0). See [`NOTICE`](NOTICE) for details.

--- a/changelog.d/827-readme-native-identity.documented.md
+++ b/changelog.d/827-readme-native-identity.documented.md
@@ -1,0 +1,10 @@
+Rewrote the root `README.md` around the native Rust workspace (`rust/`) as the
+authoritative implementation, replacing the stale "Lark + Z3" / `src/fslc/`
+product framing, a 47-line directory tree with no `rust/` entry, a
+`pytest`/"Library API" contract that AGENTS.md no longer treats as the
+product gate, and three overlapping, self-contradicting install paths with
+one consolidated install section, a `rust/` crate layout, the full native
+CLI surface (`kernel`, `document`, `ledger`, `mutate`, `refine`, `chain`,
+multi-target `testgen`, `replay --from-log/--mapping`, `analyze`
+projections), and the Public Kernel JSON contract as the supported
+programmatic surface in place of a Python library import.

--- a/changelog.d/827-readme-native-identity.documented.md
+++ b/changelog.d/827-readme-native-identity.documented.md
@@ -1,10 +1,12 @@
-Rewrote the root `README.md` around the native Rust workspace (`rust/`) as the
-authoritative implementation, replacing the stale "Lark + Z3" / `src/fslc/`
-product framing, a 47-line directory tree with no `rust/` entry, a
-`pytest`/"Library API" contract that AGENTS.md no longer treats as the
-product gate, and three overlapping, self-contradicting install paths with
-one consolidated install section, a `rust/` crate layout, the full native
-CLI surface (`kernel`, `document`, `ledger`, `mutate`, `refine`, `chain`,
-multi-target `testgen`, `replay --from-log/--mapping`, `analyze`
-projections), and the Public Kernel JSON contract as the supported
-programmatic surface in place of a Python library import.
+Documented (#827): the root `README.md` rebuilt around the native Rust
+workspace (`rust/`) as the authoritative implementation, replacing the stale
+"Lark + Z3" / `src/fslc/` product framing, a 47-line directory tree with no
+`rust/` entry, a `pytest` / "Library API" contract that `AGENTS.md` no longer
+treats as the product gate, and three overlapping, self-contradicting install
+paths. In their place: one consolidated install section with a chooser, a
+`rust/` crate layout, the native CLI surface that was missing (`kernel`,
+`document`, `ledger`, multi-target `testgen`, `replay --from-log/--mapping`,
+`--engine explicit|auto`, `analyze` projections), editor integration, and the
+Public Kernel JSON contract as the supported programmatic surface in place of
+a Python library import. The `specs/`/`examples/` per-file inventories are
+deliberately not restored -- a hand-maintained list is what went stale.


### PR DESCRIPTION
## Problem

An audit of `README.md` against the repository confirmed the maintainer's report that it is both out
of date and hard to follow. The deepest defect is not staleness but **identity**: the README
documented the frozen Python compatibility reference as the product, contradicting `AGENTS.md`'s
authority order in five places.

| Line | Was | Reality |
|---|---|---|
| `:5` | "The verifier `fslc` uses Lark + Z3" | the shipped `fslc` is native Rust with Z3 bundled and no Lark |
| `:56`–`:101` | a 47-line layout whose top entry was `pyproject.toml` "dependencies (lark, z3-solver)" and whose centre was `src/fslc/` labelled "verifier package" with nine files listed | **`rust/` appeared nowhere in the layout**; `src/fslc/` holds 63 modules and is the frozen reference |
| `:273`–`:283` | "Tests" told the reader to run `pytest`, claiming "301 tests (+69 skipped) … about 260 seconds" | the required product gate is `./tools/check-native-integration.sh`, which does not execute Python; `tests/` now holds 101 `test_*.py` files, so the figure cannot be current |
| `:285`–`:293` | "Library API" showing `from fslc import parse, build_spec, verify, prove` | those imports exist, but the Rust crates are unpublished, so the supported programmatic surface is the CLI JSON envelope and the Public Kernel contract (`fslc kernel`) |
| `:299` | dependencies "lark and z3-solver" | true of the Python reference only |

A contributor following the old README landed in the surface `AGENTS.md` forbids adding behavior to.

Also measured stale: the `examples/` list named 7 directories where **21** exist; the `specs/` list
omitted `cart_impl.fsl` and `cart_refines.fsl`, which the README's *own* `refine` example used; the
skills list omitted `fsl-from-code` and `fsl-requirements-document`; 16 of 27 subcommands were
absent, including `document` and `ledger`; `--engine` was documented as `induction` only where it
accepts `{bmc,induction,explicit,auto}`; `testgen --target` (6 targets) read as pytest-only;
`replay --from-log --mapping` was missing entirely; and `fslc chain fsl-project.toml` **could not be
run** — no such manifest exists outside test fixtures.

Structurally: three overlapping install routes with no chooser, in self-contradicting order — the
recommended installer, then a section headed "Easiest of all", then "Easy setup" whose command was
byte-identical to the first; six unsignposted audience switches; and a 47-line contributor-oriented
directory tree sitting second, ahead of every install and usage section.

## What changed

```
identity paragraph + a "two implementations" note naming rust/ as authoritative
## Install                          one section, each route once, with a chooser
## Write your first spec with an AI agent
## Using the CLI directly           grouped by workflow, 7 subsections + exit codes
## Skills for AI agents
## Repository layout                rust/ first, per-crate one-liners from AGENTS.md
## Developer setup (building from source)
## License
```

Newly present: `fslc document`, `fslc ledger`, `fslc kernel` as the programmatic surface, editor
integration (`fslc-lsp` and the VSCode extension shipped in every release but previously mentioned
only inside installer prose), `--engine explicit|auto` with `--explicit-budget`/`unknown_budget`,
`testgen --target`, and `replay --from-log --mapping`.

`fslc chain`'s manifest is now described honestly as something the user authors for their own
project, with no path claimed to exist in the repository.

The `specs/`/`examples/` per-file inventories are **deliberately not restored**. The README now says
to browse those directories, because a hand-maintained per-file list is precisely what went stale
here. Two reviewer findings applied the same standard to the rewrite itself: a `63 modules` count and
a pinned "current release is v4.3.0" were both removed, the latter because `docs/RELEASE.md` has no
step touching `README.md` and `is_release_bump_path` names only `rust/Cargo.lock`,
`rust/Cargo.toml` and the domain baseline fixture — so the pin would have gone wrong at the next
release with no gate to notice. A fact needing no maintenance beats a fact with a new unenforced
maintenance obligation.

## Evidence

**Every command shown was executed** against the native `fslc 4.3.0` binary, with its exit code
confirmed: `check`, `verify --depth 8`, `verify --engine {induction,explicit,auto}`,
`verify --engine explicit --explicit-budget 1` (exit 1, `unknown_budget`), `scenarios`, `testgen -o`
and `--target vitest`, `refine`, `verify specs/order_system.fsl`, `--vacuity error`, `--strict-tags`,
`mutate`, `explain`, `analyze --profile ai-review`, `html -o`, `typestate --ts`, `version`,
`document generate`/`claims`, `ledger`, `kernel`, `verify specs/cart_v1_buggy.fsl` (exit 1,
`type_bound`), `replay --trace` (`conformant`), and `replay --from-log --mapping` (`conformant`) —
the last against a mapping and log built to match `docs/DESIGN-log-replay.md`'s own illustration
using `specs/cart_v1.fsl`'s real actions, rather than a test fixture.

Every path and file the new text names was confirmed to exist. Both anchor links in the Install
chooser resolve. `tools/aggregate_changelog.sh check` passes.

`rust/fslc/tests/mutation_docs_contract.rs:84` includes the root `README.md` in a test forbidding the
overstated `mutate` survivor claim, compared with all whitespace stripped. Both banned strings were
grepped for and are absent; the safe "survivors are a review queue" framing is retained.

No CLI maturity or completeness matrix was hand-authored — #342 owns that, and a hand-written one
here would be unverifiable and superseded. Explanatory content belonging to #625, #626, #627, #628
and #762 is referenced through `docs/`, not duplicated. The AI dialect and the DDD/`domain` notation
are acknowledged in one neutral line rather than promoted, since they have no users yet.

There is no `README.ja.md`, so no translation counterpart moves with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
