### PR TITLE
fix(docs-site): enforce ja/en LANGUAGE section order, not just count

### DIFF
--- a/changelog.d/741-language-reference-section-order.fixed.md
+++ b/changelog.d/741-language-reference-section-order.fixed.md
@@ -6,6 +6,9 @@ attached a Japanese section body to the wrong English anchor and blurb — exact
 `docs/DESIGN-docs-site.md` D7 and this tool's own docstring already claimed was caught. The
 fix checks each positional pair's leading numeric section prefix (`"2"` from `"2. Types"`/
 `"2. 型"`) and raises `SystemExit` naming both headings and the position on a mismatch, needing
-no new maintained ja/en heading-name table. A rejecting control (a same-count reordering
-fixture) and an accepting control (the real, untouched files) are both in
+no new maintained ja/en heading-name table. That per-position check is only sound if
+`docs/LANGUAGE.md`'s own numbers are unique, so a second assertion now rejects a duplicated
+English section number directly, naming the duplicate, instead of leaving uniqueness an
+unstated precondition. Rejecting controls (a same-count reordering fixture and a duplicate-number
+fixture) and an accepting control (the real, untouched files) are all in
 `tests/test_site_reference_snapshot.py`.

--- a/changelog.d/741-language-reference-section-order.fixed.md
+++ b/changelog.d/741-language-reference-section-order.fixed.md
@@ -1,0 +1,11 @@
+Fixed (#741): `tools/build_site_reference.py` now rejects a `docs/LANGUAGE.ja.md` that
+reorders `## ` sections relative to `docs/LANGUAGE.md` while keeping the section count equal.
+`render_language_tree()` previously compared only `len(ja_sections) == len(en_sections)` and
+then paired the two files positionally, so a same-count reorder passed generation silently and
+attached a Japanese section body to the wrong English anchor and blurb — exactly the drift
+`docs/DESIGN-docs-site.md` D7 and this tool's own docstring already claimed was caught. The
+fix checks each positional pair's leading numeric section prefix (`"2"` from `"2. Types"`/
+`"2. 型"`) and raises `SystemExit` naming both headings and the position on a mismatch, needing
+no new maintained ja/en heading-name table. A rejecting control (a same-count reordering
+fixture) and an accepting control (the real, untouched files) are both in
+`tests/test_site_reference_snapshot.py`.

--- a/docs/DESIGN-docs-site.md
+++ b/docs/DESIGN-docs-site.md
@@ -187,11 +187,13 @@ readable in Japanese, accepting the resulting maintenance cost.
   keys/values, and every fenced code block are left untranslated/byte-identical to the English
   source — only heading text and prose are translated.
 - **How the site stays honest about drift:** `render_language_tree("ja")` in
-  `tools/build_site_reference.py` reads `docs/LANGUAGE.ja.md` and compares its section count
-  against `docs/LANGUAGE.md`'s. A mismatch raises `SystemExit` at generation time rather than
-  silently shipping a page with a missing or misplaced section — the same "fail loudly on drift"
-  discipline D4/the original docstring already used for `SECTION_BLURBS` coverage, now also
-  covering section-count parity between the two language files.
+  `tools/build_site_reference.py` reads `docs/LANGUAGE.ja.md`, compares its section count against
+  `docs/LANGUAGE.md`'s, and then checks that every positional pair of headings actually
+  corresponds by numeric prefix (see Addendum (#741) below — count parity alone does not imply
+  order parity). A mismatch on either check raises `SystemExit` at generation time rather than
+  silently shipping a page with a missing, misplaced, or reordered section — the same "fail loudly
+  on drift" discipline D4/the original docstring already used for `SECTION_BLURBS` coverage, now
+  also covering section-count and section-order parity between the two language files.
 - **Anchors and blurbs stay keyed off English.** Both the `<details id="...">` slug and the
   `SECTION_BLURBS` lookup are computed from the **English** heading (via `zip(en_sections,
   render_sections)`), never the Japanese one. This keeps `#7-the-verifier-fslc`-style cross-page
@@ -205,9 +207,10 @@ readable in Japanese, accepting the resulting maintenance cost.
   `docs/LANGUAGE.md` for this reason.
 - **Out of scope for this document:** any machine-translation or CI-enforced
   translation-freshness pipeline (e.g. auto-flagging which English section changed since the last
-  Japanese sync) is a separate future task, not implemented here. Today the only enforcement is
-  the section-count parity check above — it catches an added/removed/reordered section, not a
-  paragraph that changed English wording without a matching Japanese edit.
+  Japanese sync) is a separate future task, not implemented here. Today the enforcement above (the
+  section-count check plus the Addendum (#741) heading-correspondence check) catches an
+  added/removed/reordered section; it does not catch a paragraph that changed English wording
+  without a matching Japanese edit.
 - **Addendum (#630) — CI enforcement of generated-page freshness, and where it lives.**
   `tests/test_site_reference_snapshot.py` — the check D4 flagged as "recommended for the separate
   generation-pipeline task" — already existed and already regenerates both pages into memory and
@@ -257,6 +260,32 @@ readable in Japanese, accepting the resulting maintenance cost.
   `#688` frozen-`cli.py` asymmetry this addendum flagged is unchanged by any of this and stays
   open: requiring the check makes a frozen-reference argparse edit force a site update exactly as
   before, and the two surfaces' actual flag/subcommand parity remains unmeasured.
+- **Addendum (#741) — the count check alone did not enforce "order," despite this document and
+  the tool docstring already claiming it did.** `render_language_tree()`'s section-count comparison
+  (above) only asserted `len(ja_sections) == len(en_sections)`; it paired the two languages
+  **positionally** (`zip(en_sections, render_sections)`) and never compared the paired headings.
+  Swapping two `## ` sections in `docs/LANGUAGE.ja.md` left the count unchanged, so generation
+  succeeded and silently attached each swapped Japanese section body to the **wrong** English
+  anchor/blurb (verified: both real files have 18 sections — the unnumbered lead "設計原則"/"Design
+  principles" plus `## 1.` … `## 17.` in identical order in both languages — and a reordering
+  fixture reproduced the mispairing before the fix). The fix adds a second check in the same
+  function: for every positional pair, the leading numeric prefix of the heading (`"2"` from
+  `"2. Types"`/`"2. 型"`; `None` for the unnumbered lead section) must match, raising `SystemExit`
+  naming both headings and the 1-based position on a mismatch, in the same style as the
+  count-mismatch message. This needs no new maintained ja↔en heading-name table because both files
+  already share one numbering scheme; it would not detect a reorder among sections that do not
+  carry a numeric prefix, but only the lead section lacks one today, and there is only one such
+  section, so no such reorder is currently possible.
+- **Addendum (#741) — the freshness gate cannot substitute for this check, by construction.**
+  `tests/test_site_reference_snapshot.py` and the `site reference freshness` required context
+  (Addendum (#630) above) only compare the **committed** `docs/intro/*.html` against a **fresh
+  regeneration** from the same current sources. That construction can only ever catch a *stale*
+  page — one that no longer matches what today's sources would produce. It structurally cannot
+  catch a page that is *wrongly* generated from correctly-committed-but-misaligned sources: if a
+  reordered `docs/LANGUAGE.ja.md` were ever committed alongside its (mispaired) regenerated HTML,
+  the freshness gate would see them agree and pass, enforcing the drift instead of catching it.
+  Order correctness has to be asserted inside the generator itself (the check above), not
+  delegated to the freshness comparison.
 
 ## 2. Chapter → category mapping
 

--- a/docs/DESIGN-docs-site.md
+++ b/docs/DESIGN-docs-site.md
@@ -188,12 +188,15 @@ readable in Japanese, accepting the resulting maintenance cost.
   source — only heading text and prose are translated.
 - **How the site stays honest about drift:** `render_language_tree("ja")` in
   `tools/build_site_reference.py` reads `docs/LANGUAGE.ja.md`, compares its section count against
-  `docs/LANGUAGE.md`'s, and then checks that every positional pair of headings actually
-  corresponds by numeric prefix (see Addendum (#741) below — count parity alone does not imply
-  order parity). A mismatch on either check raises `SystemExit` at generation time rather than
-  silently shipping a page with a missing, misplaced, or reordered section — the same "fail loudly
-  on drift" discipline D4/the original docstring already used for `SECTION_BLURBS` coverage, now
-  also covering section-count and section-order parity between the two language files.
+  `docs/LANGUAGE.md`'s, checks that `docs/LANGUAGE.md`'s own numeric section prefixes are unique,
+  and then checks that every positional pair of headings actually corresponds by numeric prefix
+  (see the "heading-correspondence check, not just count" addendum below — count parity alone does
+  not imply order parity, and per-position prefix matching alone does not imply the prefixes are
+  unambiguous). A mismatch on any of these checks raises `SystemExit` at generation time rather
+  than silently shipping a page with a missing, misplaced, duplicated, or reordered section — the
+  same "fail loudly on drift" discipline D4/the original docstring already used for
+  `SECTION_BLURBS` coverage, now also covering section-count and section-order parity between the
+  two language files.
 - **Anchors and blurbs stay keyed off English.** Both the `<details id="...">` slug and the
   `SECTION_BLURBS` lookup are computed from the **English** heading (via `zip(en_sections,
   render_sections)`), never the Japanese one. This keeps `#7-the-verifier-fslc`-style cross-page
@@ -208,9 +211,9 @@ readable in Japanese, accepting the resulting maintenance cost.
 - **Out of scope for this document:** any machine-translation or CI-enforced
   translation-freshness pipeline (e.g. auto-flagging which English section changed since the last
   Japanese sync) is a separate future task, not implemented here. Today the enforcement above (the
-  section-count check plus the Addendum (#741) heading-correspondence check) catches an
-  added/removed/reordered section; it does not catch a paragraph that changed English wording
-  without a matching Japanese edit.
+  section-count check plus the "heading-correspondence check, not just count" addendum's order and
+  uniqueness checks) catches an added/removed/reordered section; it does not catch a paragraph that
+  changed English wording without a matching Japanese edit.
 - **Addendum (#630) — CI enforcement of generated-page freshness, and where it lives.**
   `tests/test_site_reference_snapshot.py` — the check D4 flagged as "recommended for the separate
   generation-pipeline task" — already existed and already regenerates both pages into memory and
@@ -260,23 +263,30 @@ readable in Japanese, accepting the resulting maintenance cost.
   `#688` frozen-`cli.py` asymmetry this addendum flagged is unchanged by any of this and stays
   open: requiring the check makes a frozen-reference argparse edit force a site update exactly as
   before, and the two surfaces' actual flag/subcommand parity remains unmeasured.
-- **Addendum (#741) — the count check alone did not enforce "order," despite this document and
-  the tool docstring already claiming it did.** `render_language_tree()`'s section-count comparison
-  (above) only asserted `len(ja_sections) == len(en_sections)`; it paired the two languages
-  **positionally** (`zip(en_sections, render_sections)`) and never compared the paired headings.
-  Swapping two `## ` sections in `docs/LANGUAGE.ja.md` left the count unchanged, so generation
-  succeeded and silently attached each swapped Japanese section body to the **wrong** English
-  anchor/blurb (verified: both real files have 18 sections — the unnumbered lead "設計原則"/"Design
-  principles" plus `## 1.` … `## 17.` in identical order in both languages — and a reordering
-  fixture reproduced the mispairing before the fix). The fix adds a second check in the same
-  function: for every positional pair, the leading numeric prefix of the heading (`"2"` from
-  `"2. Types"`/`"2. 型"`; `None` for the unnumbered lead section) must match, raising `SystemExit`
-  naming both headings and the 1-based position on a mismatch, in the same style as the
-  count-mismatch message. This needs no new maintained ja↔en heading-name table because both files
-  already share one numbering scheme; it would not detect a reorder among sections that do not
-  carry a numeric prefix, but only the lead section lacks one today, and there is only one such
-  section, so no such reorder is currently possible.
-- **Addendum (#741) — the freshness gate cannot substitute for this check, by construction.**
+- **Addendum (#741) — heading-correspondence check, not just count.** `render_language_tree()`'s
+  section-count comparison (above) only asserted `len(ja_sections) == len(en_sections)`; it paired
+  the two languages **positionally** (`zip(en_sections, render_sections)`) and never compared the
+  paired headings. Swapping two `## ` sections in `docs/LANGUAGE.ja.md` left the count unchanged,
+  so generation succeeded and silently attached each swapped Japanese section body to the **wrong**
+  English anchor/blurb (verified: both real files have 18 sections — the unnumbered lead
+  "設計原則"/"Design principles" plus `## 1.` … `## 17.` in identical order in both languages — and
+  a reordering fixture reproduced the mispairing before the fix). The fix adds a second check in
+  the same function: for every positional pair, the leading numeric prefix of the heading (`"2"`
+  from `"2. Types"`/`"2. 型"`; `None` for the unnumbered lead section) must match, raising
+  `SystemExit` naming both headings and the 1-based position on a mismatch, in the same style as
+  the count-mismatch message. This needs no new maintained ja↔en heading-name table because both
+  files already share one numbering scheme. Two residual limits are explicit rather than silently
+  assumed: it would not detect a reorder among sections that do not carry a numeric prefix, but
+  only the lead section lacks one today and there is only one such section, so no such reorder is
+  currently possible today; and the per-position check is only sound if `docs/LANGUAGE.md`'s
+  numeric prefixes are themselves unique — two English sections sharing a number would make a
+  matching ja-side swap of just those two prefix-equal at every position and slip through
+  undetected — so `render_language_tree()` also asserts that uniqueness directly, over
+  `docs/LANGUAGE.md`'s sections alone, and raises `SystemExit` naming the duplicated number and its
+  headings before the per-position loop ever runs, rather than leaving uniqueness an unstated
+  precondition.
+- **Addendum (#741) — the freshness gate cannot substitute for the correspondence check, by
+  construction.**
   `tests/test_site_reference_snapshot.py` and the `site reference freshness` required context
   (Addendum (#630) above) only compare the **committed** `docs/intro/*.html` against a **fresh
   regeneration** from the same current sources. That construction can only ever catch a *stale*

--- a/tests/test_site_reference_snapshot.py
+++ b/tests/test_site_reference_snapshot.py
@@ -53,6 +53,19 @@ options:
     assert mod._normalize_argparse_help(older) == mod._normalize_argparse_help(newer)
 
 
+def _rejoin_language_md(lead: str, sections: list[tuple[str, str]]) -> str:
+    """Rebuild a LANGUAGE.md-shaped text from split_language_md() output.
+
+    This is the exact inverse of split_language_md(): each (heading, body) pair
+    round-trips as "\\n## {heading}\\n{body}", and a final trailing newline is
+    appended once. A caller that builds a reordered/mutated fixture from this must
+    first verify the *unmutated* round-trip is byte-identical to the real source
+    file — see the assertions in the tests below — before trusting a mutated
+    variant built the same way.
+    """
+    return lead + "".join(f"\n## {heading}\n{body}" for heading, body in sections) + "\n"
+
+
 def test_language_reference_accepts_aligned_real_files():
     """Accepting control: the untouched, correctly section-aligned real files must
     still generate successfully through the heading-correspondence check added for
@@ -74,19 +87,65 @@ def test_language_reference_rejects_reordered_ja_sections(tmp_path, monkeypatch)
     mod = _load_tool()
     ja_text = (REPO_ROOT / "docs" / "LANGUAGE.ja.md").read_text(encoding="utf-8")
     sections = mod.split_language_md(ja_text)
+    lead = ja_text.split("\n## ", 1)[0]
+
+    # The reconstruction must round-trip byte-identically on the *unswapped*
+    # sections before a swapped variant built the same way can be trusted to
+    # test what this test claims it tests.
+    assert _rejoin_language_md(lead, sections) == ja_text
+
     idx2 = next(i for i, (h, _) in enumerate(sections) if h.startswith("2."))
     idx3 = next(i for i, (h, _) in enumerate(sections) if h.startswith("3."))
     swapped = list(sections)
     swapped[idx2], swapped[idx3] = swapped[idx3], swapped[idx2]
     assert len(swapped) == len(sections)  # the count check alone would not catch this
 
-    lead = ja_text.split("\n## ", 1)[0]
-    swapped_text = lead + "".join(f"\n## {heading}{body}" for heading, body in swapped)
     swapped_path = tmp_path / "LANGUAGE.ja.swapped.md"
-    swapped_path.write_text(swapped_text, encoding="utf-8")
+    swapped_path.write_text(_rejoin_language_md(lead, swapped), encoding="utf-8")
     monkeypatch.setattr(mod, "LANGUAGE_MD_JA", swapped_path)
 
     with pytest.raises(SystemExit, match=r"section #3.*does not correspond"):
+        mod.render_language_tree("ja")
+
+
+def test_language_reference_rejects_duplicate_en_section_numbers(tmp_path, monkeypatch):
+    """Rejecting control for the section-number-uniqueness precondition added
+    alongside issue #741's heading-correspondence check: that check only detects a
+    docs/LANGUAGE.ja.md reorder if docs/LANGUAGE.md's numeric section prefixes are
+    themselves unique. If two English sections shared a number, a matching swap on
+    the ja side would be prefix-equal at every position and slip through
+    undetected — so uniqueness must be an enforced precondition, not an unstated
+    assumption. The duplicate-numbered variant is a tmp_path fixture built from the
+    real LANGUAGE.md at test time — the committed docs/LANGUAGE.md is never
+    touched. SECTION_BLURBS is patched only to add an entry for the one renamed
+    heading, so the unrelated "unknown SECTION_BLURBS entry" check does not
+    preempt the check under test.
+    """
+    mod = _load_tool()
+    en_text = (REPO_ROOT / "docs" / "LANGUAGE.md").read_text(encoding="utf-8")
+    sections = mod.split_language_md(en_text)
+    lead = en_text.split("\n## ", 1)[0]
+
+    # Same fidelity guarantee as the reorder control above.
+    assert _rejoin_language_md(lead, sections) == en_text
+
+    idx3 = next(i for i, (h, _) in enumerate(sections) if h.startswith("3."))
+    heading3, body3 = sections[idx3]
+    duplicated_heading = heading3.replace("3.", "2.", 1)
+    monkeypatch.setitem(mod.SECTION_BLURBS, duplicated_heading, mod.SECTION_BLURBS[heading3])
+
+    renumbered = list(sections)
+    renumbered[idx3] = (duplicated_heading, body3)
+    # Now two sections (the original "2." section and this renamed one) share
+    # numeric prefix "2" — a duplicate, not a reorder: count is unchanged and no
+    # section moved position.
+    assert len(renumbered) == len(sections)
+
+    dup_path = tmp_path / "LANGUAGE.duplicate.md"
+    dup_path.write_text(_rejoin_language_md(lead, renumbered), encoding="utf-8")
+    monkeypatch.setattr(mod, "LANGUAGE_MD", dup_path)
+
+    with pytest.raises(SystemExit, match=r"more than one '## ' section numbered"):
         mod.render_language_tree("ja")
 
 

--- a/tests/test_site_reference_snapshot.py
+++ b/tests/test_site_reference_snapshot.py
@@ -53,6 +53,43 @@ options:
     assert mod._normalize_argparse_help(older) == mod._normalize_argparse_help(newer)
 
 
+def test_language_reference_accepts_aligned_real_files():
+    """Accepting control: the untouched, correctly section-aligned real files must
+    still generate successfully through the heading-correspondence check added for
+    issue #741 — a rejecting test alone would not show the normal path still works.
+    """
+    mod = _load_tool()
+    assert mod.render_language_tree("ja")
+    assert mod.render_language_tree("en")
+
+
+def test_language_reference_rejects_reordered_ja_sections(tmp_path, monkeypatch):
+    """Rejecting control for issue #741: swapping two '## ' sections in
+    docs/LANGUAGE.ja.md leaves the section *count* unchanged but breaks positional
+    heading correspondence with docs/LANGUAGE.md. The generator must reject this
+    instead of silently pairing each Japanese section body with the wrong English
+    anchor/blurb. The swapped variant is a tmp_path fixture built from the real
+    LANGUAGE.ja.md at test time — the committed docs/LANGUAGE.ja.md is never touched.
+    """
+    mod = _load_tool()
+    ja_text = (REPO_ROOT / "docs" / "LANGUAGE.ja.md").read_text(encoding="utf-8")
+    sections = mod.split_language_md(ja_text)
+    idx2 = next(i for i, (h, _) in enumerate(sections) if h.startswith("2."))
+    idx3 = next(i for i, (h, _) in enumerate(sections) if h.startswith("3."))
+    swapped = list(sections)
+    swapped[idx2], swapped[idx3] = swapped[idx3], swapped[idx2]
+    assert len(swapped) == len(sections)  # the count check alone would not catch this
+
+    lead = ja_text.split("\n## ", 1)[0]
+    swapped_text = lead + "".join(f"\n## {heading}{body}" for heading, body in swapped)
+    swapped_path = tmp_path / "LANGUAGE.ja.swapped.md"
+    swapped_path.write_text(swapped_text, encoding="utf-8")
+    monkeypatch.setattr(mod, "LANGUAGE_MD_JA", swapped_path)
+
+    with pytest.raises(SystemExit, match=r"section #3.*does not correspond"):
+        mod.render_language_tree("ja")
+
+
 @pytest.mark.parametrize("page_id", ["language", "cli"])
 def test_generated_reference_pages_are_fresh(page_id):
     mod = _load_tool()

--- a/tools/build_site_reference.py
+++ b/tools/build_site_reference.py
@@ -13,9 +13,11 @@ off the English heading text so cross-page links and SECTION_BLURBS stay stable 
 of language. The ja page also adds a Japanese lead paragraph and a Japanese one-line
 description per top-level section, sourced from SECTION_BLURBS below. If LANGUAGE.md grows
 a top-level ("## ") section that isn't in SECTION_BLURBS, or LANGUAGE.md/LANGUAGE.ja.md fall
-out of section-count sync, this script fails loudly instead of silently shipping an
-incomplete or misaligned reference — this is where the "language feature moves all of its
-files together" rule (CLAUDE.md) reaches this site.
+out of section-count sync, or a same-count LANGUAGE.ja.md reorders sections relative to
+LANGUAGE.md (checked by comparing each positional pair's leading numeric section prefix; see
+issue #741), this script fails loudly instead of silently shipping an incomplete or
+misaligned reference — this is where the "language feature moves all of its files together"
+rule (CLAUDE.md) reaches this site.
 
 Output is deterministic (no timestamps/commit hashes) so regeneration produces a clean,
 reviewable diff only when the sources actually changed. Run after any change to
@@ -158,6 +160,17 @@ def split_language_md(text: str):
     return sections
 
 
+_SECTION_NUMBER = re.compile(r"^(\d+)\.")
+
+
+def _section_number(heading: str) -> str | None:
+    """Return a '## ' heading's leading numeric prefix (e.g. "2" from "2. Types"),
+    or None for an unnumbered heading (the lead "Design principles" / "設計原則" section).
+    """
+    m = _SECTION_NUMBER.match(heading)
+    return m.group(1) if m else None
+
+
 GITHUB_BLOB = "https://github.com/ymm-oss/fsl/blob/main/docs/"
 
 # LANGUAGE.md links to sibling docs/ files with bare relative hrefs
@@ -196,6 +209,20 @@ def render_language_tree(lang: str) -> str:
                 "(same count, same order) — reconcile docs/LANGUAGE.ja.md with the "
                 "current docs/LANGUAGE.md before regenerating (see docs/DESIGN-docs-site.md D7)."
             )
+        for position, ((en_heading, _), (ja_heading, _)) in enumerate(
+            zip(en_sections, render_sections), start=1
+        ):
+            en_number = _section_number(en_heading)
+            ja_number = _section_number(ja_heading)
+            if en_number != ja_number:
+                raise SystemExit(
+                    "build_site_reference: docs/LANGUAGE.ja.md section "
+                    f"#{position} ({ja_heading!r}) does not correspond to "
+                    f"docs/LANGUAGE.md section #{position} ({en_heading!r}). The two files "
+                    "must stay section-aligned 1:1 (same count, same order) — reconcile "
+                    "docs/LANGUAGE.ja.md with the current docs/LANGUAGE.md before "
+                    "regenerating (see docs/DESIGN-docs-site.md D7)."
+                )
     else:
         render_sections = en_sections
 

--- a/tools/build_site_reference.py
+++ b/tools/build_site_reference.py
@@ -209,6 +209,30 @@ def render_language_tree(lang: str) -> str:
                 "(same count, same order) — reconcile docs/LANGUAGE.ja.md with the "
                 "current docs/LANGUAGE.md before regenerating (see docs/DESIGN-docs-site.md D7)."
             )
+
+        # The per-position correspondence check below only detects a reorder if
+        # docs/LANGUAGE.md's numeric section prefixes are unique — two English
+        # sections sharing a number would make a matching ja-side swap
+        # prefix-equal at every position and slip through undetected. Assert the
+        # precondition instead of silently relying on it (docs/DESIGN-docs-site.md
+        # D7's "unique section numbers" addendum).
+        numbers_to_headings: dict[str, list[str]] = {}
+        for en_heading, _ in en_sections:
+            number = _section_number(en_heading)
+            if number is not None:
+                numbers_to_headings.setdefault(number, []).append(en_heading)
+        duplicates = {n: hs for n, hs in numbers_to_headings.items() if len(hs) > 1}
+        if duplicates:
+            number, headings = sorted(duplicates.items())[0]
+            raise SystemExit(
+                "build_site_reference: docs/LANGUAGE.md has more than one '## ' "
+                f"section numbered {number!r}: {headings!r}. The positional "
+                "heading-correspondence check assumes docs/LANGUAGE.md's section "
+                "numbers are unique in order to detect a docs/LANGUAGE.ja.md reorder "
+                "— renumber the duplicate section(s) in docs/LANGUAGE.md before "
+                "regenerating (see docs/DESIGN-docs-site.md D7)."
+            )
+
         for position, ((en_heading, _), (ja_heading, _)) in enumerate(
             zip(en_sections, render_sections), start=1
         ):


### PR DESCRIPTION
## Problem

`docs/DESIGN-docs-site.md` D7 states the two canonical language files are kept section-aligned 1:1 —
"the same count **and order** of `## ` headings" — and claims the generation-time check catches an
added, removed, or **reordered** section. `tools/build_site_reference.py`'s docstring repeated it.

**The check enforced count only.** `render_language_tree()` raised `SystemExit` when
`len(ja_sections) != len(en_sections)`, then paired the two languages **positionally** with
`zip(en_sections, render_sections)` and never compared the paired headings. The English heading of
each pair supplies the anchor slug and the `SECTION_BLURBS` lookup; the Japanese heading and body
were rendered under it unchecked.

Reproduced on `429b02f` before the fix: swapping the "2."/"3." sections in a copy of
`docs/LANGUAGE.ja.md` left the count at 18, `render_language_tree("ja")` **returned normally**, and
the output rendered anchor `id="2-types"` carrying the Japanese heading `3. 式` and its body.

**And the freshness gate cannot substitute for the missing check, by construction.**
`tests/test_site_reference_snapshot.py` and the required `site reference freshness` context compare
the *committed* HTML against a *fresh regeneration from the same sources*. That can only catch a
**stale** page. It structurally cannot catch a **wrongly generated** one: commit a reordered
`LANGUAGE.ja.md` alongside its mispaired HTML and the gate sees them agree and passes — enforcing
the drift instead of catching it. Order has to be asserted inside the generator.

## Contract change

A second check in the same function: for every positional pair, the heading's leading numeric prefix
must match (`"2"` from `"2. Types"` / `"2. 型"`; `None` for the unnumbered lead section), raising
`SystemExit` naming both headings and the 1-based position, phrased as a sibling of the existing
count-mismatch message.

This needs **no new maintained ja↔en heading table**, because both files already share one numbering
scheme — measured: both have 18 `## ` sections, an unnumbered lead ("Design principles" / "設計原則")
followed by `## 1.` … `## 17.` in identical order. The residual limitation is recorded in D7: a
reorder among *unnumbered* sections would not be caught, but only the lead section lacks a prefix
today, so no such reorder is currently possible.

## Test evidence

- **Rejecting control** — `test_language_reference_rejects_reordered_ja_sections` builds the swapped
  variant in `tmp_path` from the real file's content at test time and points `LANGUAGE_MD_JA` at it
  via `monkeypatch`; the committed `docs/LANGUAGE.ja.md` is never written. It asserts
  `len(swapped) == len(sections)` inline, so the test itself records that the count check alone
  cannot catch this.
- **Accepting control** — `test_language_reference_accepts_aligned_real_files` generates both trees
  from the untouched real files, so the fix is shown not to break the normal path.

**Calibration verified by mutation**: removing only the new correspondence loop makes the rejecting
control fail with `DID NOT RAISE SystemExit` while the other four tests stay green — so that control
is the only mechanized detector of this regression, and it does detect it. Restored afterwards;
5/5 pass.

These controls are machine-enforced, not dormant: `site-reference-freshness.yml:77` runs
`pytest tests/test_site_reference_snapshot.py` — the whole file — and that context is a required
status check in the `main safety and CI` ruleset, on every pull request with no path filter.

`python3 tools/build_site_reference.py` succeeds and `docs/intro/` is byte-identical: the change adds
a check without altering how correctly-aligned files render.

## Documentation

`docs/DESIGN-docs-site.md` D7's two bullets that named count comparison as the mechanism are
corrected, plus two addenda: one recording the gap and its fix with the residual limitation, one
recording the freshness gate's structural inability to substitute for it. `docs/LANGUAGE.md` and
`docs/LANGUAGE.ja.md` are untouched — they are correctly aligned today, and editing a canonical
source to satisfy a check would be backwards.

`changelog.d/741-language-reference-section-order.fixed.md`.

Closes #741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
