### PR TITLE
fix(compose): propagate undeclared-alias CoreError instead of panicking past the public API

### DIFF
--- a/changelog.d/818-compose-alias-coreerror.fixed.md
+++ b/changelog.d/818-compose-alias-coreerror.fixed.md
@@ -1,0 +1,8 @@
+Fixed (#818): a compose document with an undeclared component alias inside a
+top-level `init` block's `forall` binder no longer panics past the public
+API boundary. `rewrite_compose_statements` now returns `Result` and its
+caller in `lower_compose` propagates with `?`, so `fsl_core::parse_kernel_source`
+returns `Err(CoreError)` with the "unknown alias" message instead of the
+process aborting. A rejecting control exercises the reproduction through
+`parse_kernel_source`; an accepting control confirms a correctly declared
+alias used in a `forall` binder still lowers successfully.

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -342,7 +342,7 @@ pub fn lower_compose(
                 meta,
                 annotations,
             }) => {
-                init.extend(rewrite_compose_statements(statements.clone(), &components));
+                init.extend(rewrite_compose_statements(statements.clone(), &components)?);
                 if init_meta.is_none() {
                     init_meta.clone_from(meta);
                 }
@@ -952,12 +952,11 @@ fn rewrite_compose_item(
 fn rewrite_compose_statements(
     statements: Vec<Statement>,
     components: &BTreeMap<String, Component>,
-) -> Vec<Statement> {
+) -> Result<Vec<Statement>, CoreError> {
     statements
         .into_iter()
         .map(|statement| resolve_alias_statement(statement, components))
-        .collect::<Result<_, _>>()
-        .expect("compose alias validation occurs during lowering")
+        .collect()
 }
 
 fn resolve_alias_statement(

--- a/rust/fsl-core/tests/compose_alias_forall.rs
+++ b/rust/fsl-core/tests/compose_alias_forall.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Regression coverage for issue #818: a compose document with an undeclared
+//! component alias inside a top-level `init` block's `forall` binder used to
+//! panic the process (`rewrite_compose_statements`'s
+//! `.expect("compose alias validation occurs during lowering")` in
+//! `rust/fsl-core/src/compose.rs`) instead of surfacing the `CoreError` its
+//! own signature promised. The panic unwound past the public API boundary,
+//! so a caller of `fsl_core::parse_kernel_source` got no `Result` to handle.
+//!
+//! Both controls go through `parse_kernel_source` directly -- the public
+//! entry point named in the issue -- not an internal helper, because the
+//! defect was specifically that the panic escaped that boundary.
+
+use std::collections::BTreeMap;
+
+use fsl_core::{CoreError, FileResolver, parse_kernel_source};
+
+struct MemoryResolver(BTreeMap<String, String>);
+
+impl FileResolver for MemoryResolver {
+    fn read(&self, path: &str) -> Result<String, CoreError> {
+        self.0.get(path).cloned().ok_or_else(|| CoreError {
+            message: format!("missing {path}"),
+            line: 1,
+            column: 1,
+            origin: None,
+            name_resolution: false,
+        })
+    }
+}
+
+const CORE_COMPONENT: &str = "spec Core { \
+    type UserId = 0..1 \
+    state { flag: Map<UserId, Bool> } \
+    init { forall u: UserId { flag[u] = false } } \
+    action noop() {} \
+}";
+
+fn resolver() -> MemoryResolver {
+    MemoryResolver(BTreeMap::from([(
+        "core.fsl".to_owned(),
+        CORE_COMPONENT.to_owned(),
+    )]))
+}
+
+/// Rejecting control: an undeclared alias referenced in a top-level `init`
+/// block's `forall` binder must return `Err(CoreError)` through
+/// `parse_kernel_source`, not panic.
+#[test]
+fn undeclared_alias_in_forall_binder_returns_core_error_not_panic() {
+    let source = "compose Broken { \
+        state { x: Int } \
+        init { forall u: nonexistent.UserId { x = 0 } } \
+    }";
+
+    let error = parse_kernel_source(source, &resolver())
+        .expect_err("an undeclared alias must fail, not panic");
+
+    assert_eq!(error.message, "unknown alias 'nonexistent'");
+    // This location is a placeholder, not a real source position: the
+    // qualified-name resolver (`resolve_alias_qualified_name`) has no span
+    // to draw from, so it always reports (1, 1) regardless of where the
+    // binder actually appears.
+    assert_eq!(error.line, 1);
+    assert_eq!(error.column, 1);
+}
+
+/// Accepting control: a correctly declared alias used the same way (in a
+/// top-level `init` block's `forall` binder) must still lower successfully,
+/// so the fix does not reject valid compose documents.
+#[test]
+fn declared_alias_in_forall_binder_still_lowers() {
+    let source = "compose Works { \
+        use Core as core from \"core.fsl\" \
+        state { x: Int } \
+        init { forall u: core.UserId { x = 0 } } \
+    }";
+
+    parse_kernel_source(source, &resolver())
+        .expect("a declared alias in a forall binder must lower successfully");
+}


### PR DESCRIPTION
## Problem

A compose document with an **undeclared component alias inside a top-level `init` block's `forall`
binder** panicked the process instead of returning the `CoreError` the lowering path's own signature
promised. The panic unwound **past the public API boundary**, so a caller got no `Result` to handle
and `parse_kernel_source` never returned.

```fsl
compose Broken {
  state { x: Int }
  init {
    forall u: nonexistent.UserId { x = 0 }
  }
}
```

Reproduced on `429b02f` before the fix, through `fsl_core::parse_kernel_source` — the public entry
point `rust/fslc` uses for compose files:

```
thread 'fslc' panicked at fsl-core/src/compose.rs:960:10:
compose alias validation occurs during lowering: CoreError { message: "unknown alias 'nonexistent'", line: 1, column: 1, origin: None, name_resolution: false }
```

No `use` declaration is needed to trigger it. This is an ordinary authoring mistake — a typo'd alias,
or a forgotten `use` line — not a contrived internal state.

The `.expect()`'s own message asserted that "compose alias validation occurs during lowering", i.e.
that this case was already excluded upstream. **That belief was wrong, and it was checked**:
`grep -n "unknown alias"` finds only two producers, both inside the resolution functions themselves
(`sync_action` at `:1024`, `resolve_alias_qualified_name` at `:1141`), and no pass rejects an
undeclared alias before `:960`. This is a missing propagation, not a missed upstream check.

## Contract change

`rewrite_compose_statements` returns `Result<Vec<Statement>, CoreError>`, and its single caller
`lower_compose` (`:345`) `?`-propagates. Only that one link needed changing — the rest of the chain
already propagated:

```
rewrite_compose_statements  :952   Vec<Statement>  ->  Result<Vec<Statement>, CoreError>
lower_compose               :345   already returned Result<KernelSpec, CoreError>  (:256)
parse_kernel_source         :69    already `match ... }?`
parse_kernel_source_with_file :92  wraps it, already propagating
```

After the fix, the CLI returns a normal envelope — `"result": "error"`, `"kind": "semantics"`,
exit 2, no panic. `compose.rs` now contains **no** `expect`, `unwrap` or `panic!` at all.

## Disclosed: this makes a wrong location user-visible for the first time

The `CoreError`'s `line: 1, column: 1` is a **placeholder, not the real location**.
`resolve_alias_qualified_name` (`:1134`–`:1147`) hardcodes it: `QualifiedName` carries no span, and
none is threaded in from `resolve_alias_binder`/`resolve_alias_statement` even though
`Statement::ForAll` does carry a `span`.

Before this fix that placeholder never reached a user, because the process died first. Now the CLI
prints `unknown alias 'nonexistent' at 1:1` for an error that may be on any line. Surfacing a wrong
location is still strictly better than a panic that gives the caller nothing, and inventing a
location would be worse than either — but it is a real defect and it is **new to users**, so it is
filed rather than left in this pull request's description: **#831**. The new test
records the placeholder explicitly so nobody reads `1:1` as verified behavior.

## Test evidence

`rust/fsl-core/tests/compose_alias_forall.rs`, both controls driving
`fsl_core::parse_kernel_source` — the public entry point, not an internal call, because the defect is
precisely that the panic escaped the public boundary:

- **Rejecting**: `undeclared_alias_in_forall_binder_returns_core_error_not_panic` — the reported
  reproduction, asserting `Err` carrying `unknown alias 'nonexistent'`.
- **Accepting**: `declared_alias_in_forall_binder_still_lowers` — a `use Core as core from "core.fsl"`
  component with `forall u: core.UserId { ... }` in a top-level `init`, asserting `Ok`, so the fix is
  shown not to reject valid documents.

Modeled on `rust/fsl-core/tests/duplicate_writes.rs` and `governance_contract.rs`'s resolver pattern
rather than a new fixture style.

```
cargo fmt --all -- --check                                       clean
cargo clippy -p fsl-core --all-targets --locked -- -D warnings    clean
cargo test -p fsl-core                                           121 passed, 0 failed
cargo test -p fslc-rust --test corpus_check_sweep                 3 passed, 0 failed (179s)
```

The corpus sweep matters because this is a lowering path every compose spec under `specs/` and
`examples/` passes through. **No corpus spec changed verdict.**

## Coupled change

No grammar or lowering-visible syntax, no new declaration/binder/reference form, no dialect
construct, and the `CoreError`'s message and shape are unchanged — only now reachable. So
`rust/fsl-lsp/src/index.rs`, `tests/dialect_registry.py`, `docs/LANGUAGE.md` and
`docs/LANGUAGE.ja.md` are untouched and judged not applicable.
`changelog.d/818-compose-alias-coreerror.fixed.md`.

Closes #818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

