### PR TITLE
test(cli): give the causal parse guard on run_verify_from_source an executable control

### DIFF
--- a/changelog.d/812-causal-guard.required.md
+++ b/changelog.d/812-causal-guard.required.md
@@ -1,0 +1,1 @@
+Required (#812): `mutate` now preserves malformed causal parser diagnostics through an executable error-envelope parity control.

--- a/rust/fslc/tests/error_envelope_parity.rs
+++ b/rust/fslc/tests/error_envelope_parity.rs
@@ -562,7 +562,7 @@ const PARITY_REGISTRY: &[CommandRegistration] = &[
             invoke: &["mutate", SPEC_PLACEHOLDER],
         },
         literate: LiterateCoverage::UniformUnsupported,
-        coverage: PARSE_KERNEL_COVERAGE,
+        coverage: MUTATE_COVERAGE,
         not_applicable: &[],
     },
     CommandRegistration {
@@ -662,9 +662,10 @@ enum FailureClass {
 /// have one source form; AI semantic cells must cover both component and
 /// project documents, because their dispatch paths are observably distinct.
 /// `check` and `verify` additionally expose distinct AI-project and causal
-/// parse frontends. Requirements-document approval creation is a separate
-/// `--kind` frontend selection. Compose nested-component parsing is a
-/// documented semantic-resolution boundary, not a direct Parse cell.
+/// parse frontends. `mutate` reaches the causal parse frontend through its
+/// baseline verification. Requirements-document approval creation is a
+/// separate `--kind` frontend selection. Compose nested-component parsing is
+/// a documented semantic-resolution boundary, not a direct Parse cell.
 /// AI Literate cells additionally retain the generic Markdown source form and
 /// exercise Markdown documents whose extracted FSL body is each AI shape.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -1063,6 +1064,16 @@ const PARSE_KERNEL_COVERAGE: &[FailureCoverage] = &[
         fixture: NAME_FIXTURE,
         uniform: SEMANTIC_UNIFORM,
     },
+];
+const MUTATE_COVERAGE: &[FailureCoverage] = &[
+    PARSE_KERNEL_COVERAGE[0],
+    FailureCoverage {
+        class: FailureClass::Parse,
+        fixture: PARSE_CAUSAL_FIXTURE,
+        uniform: PARSE_UNIFORM,
+    },
+    PARSE_KERNEL_COVERAGE[1],
+    PARSE_KERNEL_COVERAGE[2],
 ];
 const DOCUMENT_COVERAGE: &[FailureCoverage] = &[
     FailureCoverage {
@@ -1903,7 +1914,7 @@ fn has_literate_not_applicable(entry: &CommandRegistration) -> bool {
 }
 
 fn coverage_input_shape(command: &str, fixture: &str) -> InputShape {
-    if matches!(command, "check" | "verify") {
+    if matches!(command, "check" | "mutate" | "verify") {
         return match fixture {
             PARSE_AI_PROJECT_FIXTURE | PARSE_AI_PROJECT_DUPLICATE_FIXTURE => InputShape::Project,
             PARSE_CAUSAL_FIXTURE => InputShape::Causal,
@@ -1945,11 +1956,14 @@ fn required_input_shapes(
         InputShape::Causal,
         InputShape::Compose,
     ];
+    const MUTATE_PARSE: &[InputShape] = &[InputShape::Source, InputShape::Causal];
     const APPROVAL_CREATE_PARSE: &[InputShape] =
         &[InputShape::Source, InputShape::RequirementsDocument];
 
     if matches!(entry.key, "check" | "verify") && class == FailureClass::Parse {
         CHECK_PARSE
+    } else if entry.key == "mutate" && class == FailureClass::Parse {
+        MUTATE_PARSE
     } else if entry.key == "approval create" && class == FailureClass::Parse {
         APPROVAL_CREATE_PARSE
     } else if matches!(entry.scope, ParityScope::SpecPath { .. }) && entry.key.starts_with("ai ") {

--- a/rust/fslc/tests/error_envelope_parity.rs
+++ b/rust/fslc/tests/error_envelope_parity.rs
@@ -2491,6 +2491,22 @@ fn parity_registry_exclusions_are_explicit_and_runnable_entries_have_a_spec_slot
 }
 
 #[test]
+fn mutate_coverage_includes_every_kernel_coverage_entry() {
+    // Prevent index-based sharing from leaving mutate narrower when the shared
+    // Kernel coverage grows or is reordered.
+    for expected in PARSE_KERNEL_COVERAGE {
+        assert!(
+            MUTATE_COVERAGE.iter().any(|actual| {
+                actual.class == expected.class && actual.fixture == expected.fixture
+            }),
+            "mutate coverage must include {:?}/{} from PARSE_KERNEL_COVERAGE",
+            expected.class,
+            expected.fixture
+        );
+    }
+}
+
+#[test]
 #[should_panic(expected = "exactly one executable Cell or reasoned NotApplicable")]
 fn missing_classification_spec_path_is_rejected() {
     let empty_coverage = CommandRegistration {


### PR DESCRIPTION
## Problem

#807 gave causal sources their own syntax classification so a malformed causal input keeps its parser
diagnostic instead of being rewritten as an unknown kernel dialect. The check exists on **two** paths,
and only one had an executable control.

| Path | Callers | Control before this PR |
|---|---|---|
| `rust/fslc/src/verification.rs:1848` | the `verify` subcommand | `error_envelope_parity` |
| `rust/fslc/src/main.rs:15294` | `run_mutate`, `run_testgen`, scenarios, html report, `run_mutate_legacy` | **none** |

**Correction from review — which of those callers can actually reach the guard with a malformed causal
input is narrower than the issue's table suggests.** Measured by running each command against
`rust/fslc/tests/fixtures/error_envelope_broken_causal.fsl` with the built binary:

```
mutate      kind=parse  diagnostic_code=FSL-PARSE              <- reaches the guard
testgen     kind=parse  diagnostic_code=FSL-DIALECT-UNKNOWN    <- loads the model first
scenarios   kind=parse  diagnostic_code=FSL-DIALECT-UNKNOWN    <- loads the model first
html        kind=parse  diagnostic_code=FSL-DIALECT-UNKNOWN    <- loads the model first
```

`scenarios` (`rust/fslc/src/main.rs:5099`-`:5121`), `testgen` (`:10745`-`:10750`) and the html report
(`:10871`-`:10879`) each load the model **before** their `run_verify_from_source` call, so a malformed
causal source is already rejected as an unknown dialect and never reaches the guard. Only `mutate`
calls `run_verify_from_source` ahead of generic loading (`:10321`-`:10334`). `run_mutate_legacy` would
also reach it, but it is dead code.

So covering `mutate` is not one case out of five — it is **the complete set of callers that can reach
this guard with a malformed causal input**. The table above lists transitive callers of
`run_verify_from_source`, which is not the same population, and that distinction was not established
until it was measured.

Reproduced on `8ff4d17` before the fix: rewriting the `main.rs` guard to
`if false && fsl_syntax::is_causal_source(source)` left `error_envelope_parity` at
**17 passed, 0 failed**. The same mutation on `verification.rs` does fail. `causal_cli`'s 41 tests do
not close the gap — they exercise the `causal` subcommand, not a causal source handed to `mutate`,
`testgen` or scenarios.

`mutate` and `testgen` are in-use surfaces, and `mutate`'s kill-rate is the project's primary
hollow-spec signal. The malformed-causal diagnostic survived there only because the code happened to
be present; nothing detected its removal.

## Contract change

`mutate` gets its own coverage row in the parity registry, carrying `PARSE_CAUSAL_FIXTURE` alongside
the shared Kernel coverage, plus the two shape-population updates that make the registry actually
exercise it — `coverage_input_shape` now treats `mutate` like `check`/`verify` for the causal shape,
and `required_input_shapes` gains `MUTATE_PARSE`. The `FailureClass` doc comment records **why**
`mutate` reaches the causal parse frontend (through its baseline verification), so the row is not
mistaken for an arbitrary addition.

`mutate` was chosen because it is the most dangerous of the affected commands, and the routing was
verified rather than assumed: `rust/fslc/src/main.rs:10321`-`:10340` shows `run_mutate` reading the
source and passing it to `run_verify_from_source`. Its accepted invocation is exactly `mutate FILE`
(`rust/fslc/cli-contract.json:1731`-`:1749`) — checked deliberately, because a previous control in
this repository passed an option the command does not accept, so the CLI exited with `kind: usage`
**before** reaching the code under test and the control was vacuously green.

## Test evidence — the acceptance criterion

Re-applying the guard mutation makes the new control **red**, at the intended cell:

```
Parse/mutate mismatched Json(JsonExpectation { … diagnostic: Code("FSL-PARSE") … });
exit=2 stdout={ … "diagnostic_code": "FSL-DIALECT-UNKNOWN" … }
test result: FAILED. 16 passed; 1 failed  (36.04s)
```

Restoring the guard returns the suite to green: **17 passed, 0 failed** (47.54s). So the state the
issue reported — mutation invisible — is closed, and the failure lands on `Parse/mutate`, the path
that had no control.

## Second commit: closing an implicit coupling found in review

`MUTATE_COVERAGE` shares the Kernel rows **by index** (`PARSE_KERNEL_COVERAGE[0]`, `[1]`, `[2]`).
Nothing checked that. Adding a fourth entry to `PARSE_KERNEL_COVERAGE`, or reordering it, would
silently leave `mutate` covering only the three positions it names — the same "looks complete, is
quietly narrower than its sibling" shape this repository keeps hitting, and the shape #801 tracks.

`mutate_coverage_includes_every_kernel_coverage_entry` asserts **containment by `(class, fixture)`**,
not length. A length assertion would catch growth but not reordering; containment survives both.
Calibrated: removing one inherited entry makes that test fail, restoring it passes. Suite now
**18 passed, 0 failed** (47.29s).

```
cargo fmt --all -- --check                                       clean
cargo clippy -p fslc-rust --all-targets --locked -- -D warnings   clean
cargo test -p fslc-rust --test error_envelope_parity              18 passed, 0 failed
cargo test -p fslc-rust --test causal_cli                         41 passed, 0 failed
tools/aggregate_changelog.sh check                                PASS
```

Test-only change: no product source is touched, so `cargo test --workspace` was deliberately not run
(it costs over three hours here because `corpus_check_sweep` walks the corpus serially).

## Documentation

`changelog.d/812-causal-guard.required.md`, leading `Required (#812): …` per `CHANGELOG.md`'s bullet
convention. No `docs/LANGUAGE.md` change: this adds a control for existing behavior rather than
changing behavior.

Closes #812. Refs #780, #807, #808, #801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

