### PR TITLE
docs(readme): index the seven unlinked design records

### DIFF
--- a/changelog.d/746-design-doc-index.documented.md
+++ b/changelog.d/746-design-doc-index.documented.md
@@ -1,0 +1,1 @@
+Documented (#746): Index every accepted design record in docs/README.md.

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@
 | [`DESIGN-log-replay.md`](DESIGN-log-replay.md) | Production JSONL replay through refinement mapping syntax: record contract, complete-observation boundary, first-divergence JSON, and Monitor execution |
 | [`DESIGN-scenarios.md`](DESIGN-scenarios.md) | scenarios and the unsat-core diagnostics for coverage |
 | [`DESIGN-seq.md`](DESIGN-seq.md) | Seq<T,N> (partial_op, type whitelist) |
+| [`DESIGN-seq-partial-operations.md`](DESIGN-seq-partial-operations.md) | Accepted Seq partial-operation semantics: out-of-prefix reads report `partial_op` consistently across engines while guarded short-circuit reads remain defined |
 | [`DESIGN-option-struct.md`](DESIGN-option-struct.md) | Option fields in structs |
 | [`DESIGN-divmod.md`](DESIGN-divmod.md) | Integer division `/` and remainder `%` (total definition of division by zero, partial_op, Euclidean) |
 | [`DESIGN-forbidden.md`](DESIGN-forbidden.md) | `forbidden` (negative acceptance criteria / must-forbid) — detecting under-constraint |
@@ -63,6 +64,7 @@
 | [`DESIGN-precedence-policy.md`](DESIGN-precedence-policy.md) | The business-layer no-bypass precedence policy (#75) — why `business` keeps users from writing `state`/`invariant` directly |
 | [`DESIGN-ledger.md`](DESIGN-ledger.md) | `fslc ledger` (turning verifier evidence into a per-requirement-id Markdown audit ledger for PM/audit) |
 | [`DESIGN-assurance-classes.md`](DESIGN-assurance-classes.md) | Assurance-class vocabulary (`proved`/`bounded`/`replay-observed`/`statistical`/`not_run`) shared by `fslc ledger` and `fslc html`, and what each class does/does not guarantee |
+| [`DESIGN-assurance-matrix.md`](DESIGN-assurance-matrix.md) | CI-internal C3 semantic assurance matrix: every semantic-feature/product-surface cell is exercised, a rejecting control, fail-closed unsupported, or reasoned not-applicable |
 | [`DESIGN-triangulated-assurance.md`](DESIGN-triangulated-assurance.md) | CI-internal Triangulated Assurance: raw common observations, explicit observer lineages, executable three-edge agreement, calibration, federated ownership, and P1/P2/P3 pilots |
 | [`DESIGN-document-requirement-claim-ir.md`](DESIGN-document-requirement-claim-ir.md) | `fslc document` foundation (issue #325): the versioned Requirement Claim IR (RCIR) v1 public contract and the deterministic requirement-claim projector |
 | [`DESIGN-document-controlled-language-renderer.md`](DESIGN-document-controlled-language-renderer.md) | ja/en controlled-language renderer (issue #326): converts an RCIR v1 claim set into `fsl_tools::render_requirements_document` prose |
@@ -79,8 +81,12 @@
 | [`DESIGN-blame-assignment.md`](DESIGN-blame-assignment.md) | Counterexample blame assignment (`fslc verify`/`fslc explain`): false-conjunct identification, per-step guard/effect backward slicing, and vacuity blocking-core localization |
 | [`DESIGN-incremental-verify.md`](DESIGN-incremental-verify.md) | `fslc verify`'s persistent verdict cache (`src/fslc/verify_cache.py`): exhaustive cache-key enumeration, cross-depth counterexample reuse, and the soundness argument for why a cached verdict can never be stale |
 | [`DESIGN-verification-cost.md`](DESIGN-verification-cost.md) | Fixed native/Worker verification cost schema, common Z3 statistics, property attribution, and aggregation semantics |
+| [`DESIGN-ci.md`](DESIGN-ci.md) | Accepted merge and product-validation contract: complete Linux evidence before merge, deferred cross-platform validation, and blocking post-merge promotion evidence |
+| [`DESIGN-fsl-logic-test.md`](DESIGN-fsl-logic-test.md) | Accepted finite direct-spec generation and concrete/symbolic agreement test: detector calibration and exploration, never proof by volume or a public-assurance promotion |
+| [`DESIGN-semantic-mutation-gate.md`](DESIGN-semantic-mutation-gate.md) | Accepted soundness-critical native-Rust mutation gate: reviewed semantic faults and scoped generic mutations calibrate detector power without changing product exits |
 | [`DESIGN-conformance-harness.md`](DESIGN-conformance-harness.md) | Dialect corpus conformance harness (`tests/test_dialect_conformance.py`, `tests/dialect_registry.py`): the Monitor/BMC-agreement/oracle safety net over every `.fsl` under `specs/`/`examples/`, with a loud, reviewable exclusion policy — a manual/reference check today, not a CI gate (see the design doc's "Cost and CI wiring") |
 | [`DESIGN-coupled-change-metatest.md`](DESIGN-coupled-change-metatest.md) | Coupled-change metatests: native LSP corpus/index coverage in `rust/fsl-lsp/tests/corpus.rs`, plus frozen Python compatibility and DESIGN-doc map checks |
+| [`DESIGN-referance-local-audit.md`](DESIGN-referance-local-audit.md) | Accepted opt-in local Referance semantic-drift audit: Store-first provenance evidence with CodeReferance as an auxiliary read-only detector, never a CI, merge, product, promotion, or release gate |
 | [`DESIGN-changelog-fragments.md`](DESIGN-changelog-fragments.md) | Accepted #737 decision record: GO for `CHANGELOG.md` `[Unreleased]` fragments (C1), NO-GO for fragmenting the contract documents (C2), with the replay measurement, six fail-closed controls, migration sites, and rollback/reversal rule; implemented by `tools/aggregate_changelog.sh` and `changelog.d/` |
 | [`DESIGN-rust-components.md`](DESIGN-rust-components.md) | Evidence-backed current design for all eleven Rust crates: responsibility and state ownership, dependency direction, contracts, candidates, uncertainty, and reevaluation triggers |
 | [`DESIGN-rust-component-internals.md`](DESIGN-rust-component-internals.md) | Evidence-backed internal design for all eleven Rust crates: value flow, mutable-state ownership, failure and I/O boundaries, targeted dependency normalization, and touch-driven extraction |
@@ -101,6 +107,7 @@
 | [`DESIGN-ui.md`](DESIGN-ui.md) | fsl-ui (screen-transition dialect): spike findings, proposed expansion rules, go/no-go (#9) |
 | [`DESIGN-domain.md`](DESIGN-domain.md) | fsl-domain (`domain`) Functional DDD / async effect dialect: aggregate ownership, command/event decide/evolve lowering, saga/process-manager actions, effect lifecycle state, findings, multi-target scaffolds, and runtime replay |
 | [`DESIGN-effect.md`](DESIGN-effect.md) | fsl-effect lifecycle semantics used by fsl-domain: correlation, retry, timeout, idempotency, and guarantee boundary |
+| [`DESIGN-saga-history.md`](DESIGN-saga-history.md) | Accepted domain design awaiting follow-up implementation: correlation-indexed saga phases preserve one-hot current-event semantics and prevent cross-correlation discharge |
 | [`DESIGN-db.md`](DESIGN-db.md) | fsl-db (`dbsystem`) database compatibility dialect: multi-environment schema/artifact/feature-flag checks, finding schema, rollout assumptions, SQL/Prisma importers, and external preservation/engine evidence boundaries |
 | [`DESIGN-ai-hard.md`](DESIGN-ai-hard.md) | fsl-ai (`ai_component` / recursive `agent`) dialect: tool authority, human approval, forbidden tools, fallback, event replay, agent scope/grant/orchestration/visibility analysis, finding schema, and guarantee boundaries |
 | [`DESIGN-stochastic.md`](DESIGN-stochastic.md) | fsl-stochastic external evidence layer: precomputed eval JSONL, Wilson-bound threshold rules, statistical result schema, status priority, multiple-slice boundary, and external stochastic boundaries |


### PR DESCRIPTION
## Problem

`tests/test_coupled_change_meta.py`'s `test_design_docs_readme_map_bidirectional` requires the
`DESIGN-*.md` files linked from `docs/README.md` to exactly match the design files on disk. It was
failing. Measured on `d7a9d66`:

```
docs/DESIGN-*.md on disk        90
linked from docs/README.md      83
unlinked                         7
dangling links                   0
```

```
DESIGN-assurance-matrix.md        DESIGN-referance-local-audit.md
DESIGN-ci.md                      DESIGN-saga-history.md
DESIGN-fsl-logic-test.md          DESIGN-semantic-mutation-gate.md
DESIGN-seq-partial-operations.md
```

`docs/DESIGN-ci.md` was the one that mattered most: it owns the required-context set, the merge-queue
rejection record, and the sharding contract, and it was unreachable from the documentation index.

The gap is in `docs/README.md`, not in the test, so this is worth fixing independently of whether the
harness is ever wired into CI.

## Scope — deliberately only the content repair

This is one half of #746. It adds seven index entries and nothing else.

**The other half is not a defect, and this PR does not touch it.** #746's headline claim — that
`docs/DESIGN-coupled-change-metatest.md` falsely says these metatests run in the required product gate
— was checked and is a **misreading**. The document is two sentences: the Python checks are described
as *manual compatibility evidence*, and the product-gate statement attaches to the **native LSP corpus
test**, a different artifact. `rust/fsl-syntax/src/causal.rs:10`-`:12` likewise calls the parity check
"a manual compatibility check, **not a CI gate**". So `tools/check-native-integration.sh` containing no
`pytest` is what both documents describe, and it is consistent with `AGENTS.md`'s "one Rust-native
entrypoint, does not execute Python" contract. There are no stale citations to repair, and promoting
these checks to a gate would be a **policy change to an accepted design decision** — argued separately,
not slipped in here. That correction is recorded on the issue.

## Evidence

```
before   pytest tests/test_coupled_change_meta.py -q    4 passed, 1 failed
after    pytest tests/test_coupled_change_meta.py -q    5 passed
```

Re-measured independently after the change: 5 passed. Every added path was `ls`-confirmed to exist, and
there were no dangling links before or after.

Each one-line description was written **from the target document's own opening**, not from its
filename, with the source lines recorded in the implementation report. Two needed care and got it:

- `DESIGN-referance-local-audit.md` — described as an **opt-in local** audit that is explicitly not a
  CI, merge, product, promotion, or release gate, so the index cannot imply otherwise
  (`docs/DESIGN-referance-local-audit.md:3`-`:12`).
- `DESIGN-saga-history.md` — described as an accepted design **awaiting follow-up implementation**, so
  the index cannot imply the feature ships today (`docs/DESIGN-saga-history.md:1`-`:3`, `:46`-`:63`).

A wrong one-line summary in an index is worse than a missing entry, because a reader trusts it instead
of opening the file.

Placement follows the existing topical structure rather than appending to the end: the assurance matrix
beside the other assurance records; CI, FSL Logic Test and the semantic mutation gate with the
integration/verification records; the Referance audit after the coupled-change metatests as opt-in
tooling; saga history beside the domain/effect records; Seq partial operations immediately after
`DESIGN-seq.md`.

## Documentation

`changelog.d/746-design-doc-index.documented.md`, leading `Documented (#746): …` per `CHANGELOG.md`'s
bullet convention. No workflow, integration script, test, or policy document was changed.

Partially addresses #746 — the wiring policy question stays open on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
