### PR TITLE
test(ci): give the cache budget audit's workflow wiring a calibrated semantic validator

### DIFF
--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -165,10 +165,10 @@ def validate_workflow(document: Any) -> list[str]:
     if calibration_indices and calibration_indices[0] >= live_audit_index:
         errors.append("calibration step must precede the live-audit step")
 
+    # _named_step_indices selects only Mapping instances, so the unique live
+    # step above is necessarily a mapping.  Keeping a defensive non-mapping
+    # branch here would create an unreachable, uncalibrated diagnostic.
     live_step = steps[live_audit_index]
-    if not isinstance(live_step, Mapping):
-        errors.append("named live-audit step must be a mapping")
-        return errors
     if "if" in live_step:
         errors.append("live-audit step must not declare 'if'")
     if "continue-on-error" in live_step:
@@ -187,7 +187,16 @@ def main() -> int:
     parser.add_argument("--workflow", type=Path, default=DEFAULT_WORKFLOW)
     args = parser.parse_args()
 
-    errors = validate_workflow(load_workflow(args.workflow))
+    try:
+        document = load_workflow(args.workflow)
+    except FileNotFoundError:
+        errors = [f"workflow file '{args.workflow}' does not exist"]
+    except OSError as error:
+        errors = [f"workflow file '{args.workflow}' could not be read: {error.strerror}"]
+    except yaml.YAMLError as error:
+        errors = [f"workflow YAML is invalid: {error}"]
+    else:
+        errors = validate_workflow(document)
     if errors:
         for error in errors:
             print(f"cache-budget-audit workflow wiring: FAIL -- {error}")

--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Validate the semantic wiring of the Actions cache-budget audit workflow.
+
+The workflow is parsed before it is inspected so formatting, comments, key
+order, quoting, and plain-versus-block scalar style do not affect this
+contract.  The matching calibration suite derives each rejecting fixture from
+the live workflow rather than carrying a second workflow snapshot.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import re
+import shlex
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "cache-budget-audit.yml"
+AUDIT_JOB_ID = "audit"
+CALIBRATION_STEP_NAME = "Calibrate the audit"
+LIVE_AUDIT_STEP_NAME = "Audit the live cache budget"
+LIVE_AUDIT_COMMAND = ["node", ".github/scripts/run-cache-budget-audit.mjs"]
+REQUIRED_PERMISSIONS = {"actions": "read", "contents": "read"}
+REQUIRED_TRIGGERS = ("schedule", "workflow_dispatch", "push")
+REQUIRED_WATCHED_PATHS = {
+    ".github/scripts/audit-cache-budget.mjs",
+    ".github/scripts/audit-cache-budget.test.mjs",
+    ".github/scripts/run-cache-budget-audit.mjs",
+    ".github/workflows/cache-budget-audit.yml",
+    ".github/workflows/ci.yml",
+    ".github/workflows/merge-readiness.yml",
+}
+
+
+class WorkflowLoader(yaml.SafeLoader):
+    """SafeLoader with YAML 1.2 boolean spelling for GitHub Actions keys."""
+
+
+# PyYAML's YAML 1.1 resolver turns the Actions key ``on`` into ``True``.  GitHub
+# Actions uses YAML 1.2 spelling, where only true/false are booleans, so retain
+# those values while treating ``on`` as the string key it is in the workflow.
+WorkflowLoader.yaml_implicit_resolvers = copy.deepcopy(yaml.SafeLoader.yaml_implicit_resolvers)
+for first_character, resolvers in WorkflowLoader.yaml_implicit_resolvers.items():
+    WorkflowLoader.yaml_implicit_resolvers[first_character] = [
+        resolver for resolver in resolvers if resolver[0] != "tag:yaml.org,2002:bool"
+    ]
+WorkflowLoader.add_implicit_resolver(
+    "tag:yaml.org,2002:bool",
+    re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$"),
+    list("tTfF"),
+)
+
+
+def load_workflow(path: Path) -> Any:
+    """Parse a workflow with the GitHub Actions-compatible safe loader."""
+    return yaml.load(path.read_text(encoding="utf-8"), Loader=WorkflowLoader)
+
+
+def _mapping(value: Any, label: str, errors: list[str]) -> Optional[Mapping[str, Any]]:
+    if not isinstance(value, Mapping):
+        errors.append(f"{label} must be a mapping")
+        return None
+    return value
+
+
+def _named_step_indices(steps: list[Any], name: str) -> list[int]:
+    return [
+        index
+        for index, step in enumerate(steps)
+        if isinstance(step, Mapping) and step.get("name") == name
+    ]
+
+
+def _normalized_argv(command: Any) -> list[str] | None:
+    if not isinstance(command, str):
+        return None
+
+    # A trailing newline is how a one-line YAML block scalar is represented.
+    # Interior line breaks are shell command separators, so they cannot be an
+    # argv-equivalent spelling of the single allowlisted command.
+    normalized = command.strip()
+    if "\n" in normalized or "\r" in normalized:
+        return None
+    try:
+        return shlex.split(normalized, posix=True, comments=False)
+    except ValueError:
+        return None
+
+
+def validate_workflow(document: Any) -> list[str]:
+    """Return every violated cache-budget-audit wiring contract."""
+    errors: list[str] = []
+    workflow = _mapping(document, "workflow", errors)
+    if workflow is None:
+        return errors
+
+    triggers = _mapping(workflow.get("on"), "workflow 'on'", errors)
+    if triggers is not None:
+        for trigger in REQUIRED_TRIGGERS:
+            if trigger not in triggers:
+                errors.append(f"required trigger '{trigger}' is absent")
+
+        schedule = triggers.get("schedule")
+        if "schedule" in triggers and (not isinstance(schedule, list) or not schedule):
+            errors.append("trigger 'schedule' must be a non-empty list")
+
+        # GitHub Actions' bare ``workflow_dispatch:`` spelling is an enabled
+        # event and PyYAML represents it as None.  Treat it as enabled while
+        # rejecting an explicit false value or a malformed configuration.
+        dispatch = triggers.get("workflow_dispatch")
+        if "workflow_dispatch" in triggers and dispatch is False:
+            errors.append("trigger 'workflow_dispatch' must be enabled")
+        elif "workflow_dispatch" in triggers and dispatch is not None and not isinstance(
+            dispatch, Mapping
+        ):
+            errors.append("trigger 'workflow_dispatch' must be an event mapping")
+
+        push = triggers.get("push")
+        if "push" in triggers:
+            push_mapping = _mapping(push, "trigger 'push'", errors)
+            if push_mapping is not None:
+                branches = push_mapping.get("branches")
+                if not isinstance(branches, list) or "main" not in branches:
+                    errors.append("trigger 'push.branches' must contain 'main'")
+                paths = push_mapping.get("paths")
+                if not isinstance(paths, list):
+                    errors.append("trigger 'push.paths' must be a list")
+                else:
+                    missing_paths = REQUIRED_WATCHED_PATHS.difference(paths)
+                    for path in sorted(missing_paths):
+                        errors.append(f"required watched path '{path}' is absent")
+
+    if workflow.get("permissions") != REQUIRED_PERMISSIONS:
+        errors.append("top-level permissions must be exactly actions: read and contents: read")
+
+    jobs = _mapping(workflow.get("jobs"), "workflow jobs", errors)
+    if jobs is None:
+        return errors
+    job = _mapping(jobs.get(AUDIT_JOB_ID), f"job '{AUDIT_JOB_ID}'", errors)
+    if job is None:
+        return errors
+    if "continue-on-error" in job:
+        errors.append("audit job must not declare 'continue-on-error'")
+
+    steps_value = job.get("steps")
+    if not isinstance(steps_value, list):
+        errors.append("audit job steps must be a list")
+        return errors
+    steps = steps_value
+
+    calibration_indices = _named_step_indices(steps, CALIBRATION_STEP_NAME)
+    live_audit_indices = _named_step_indices(steps, LIVE_AUDIT_STEP_NAME)
+    if len(calibration_indices) != 1:
+        errors.append("audit job must contain exactly one named calibration step")
+    if len(live_audit_indices) != 1:
+        errors.append("audit job must contain exactly one named live-audit step")
+        return errors
+
+    live_audit_index = live_audit_indices[0]
+    if calibration_indices and calibration_indices[0] >= live_audit_index:
+        errors.append("calibration step must precede the live-audit step")
+
+    live_step = steps[live_audit_index]
+    if not isinstance(live_step, Mapping):
+        errors.append("named live-audit step must be a mapping")
+        return errors
+    if "if" in live_step:
+        errors.append("live-audit step must not declare 'if'")
+    if "continue-on-error" in live_step:
+        errors.append("live-audit step must not declare 'continue-on-error'")
+    if _normalized_argv(live_step.get("run")) != LIVE_AUDIT_COMMAND:
+        errors.append(
+            "live-audit command must be exactly "
+            "'node .github/scripts/run-cache-budget-audit.mjs'"
+        )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflow", type=Path, default=DEFAULT_WORKFLOW)
+    args = parser.parse_args()
+
+    errors = validate_workflow(load_workflow(args.workflow))
+    if errors:
+        for error in errors:
+            print(f"cache-budget-audit workflow wiring: FAIL -- {error}")
+        return 1
+    print("cache-budget-audit workflow wiring: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cache-budget-audit-wiring.yml
+++ b/.github/workflows/cache-budget-audit-wiring.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: cache budget audit wiring
+
+# This is configuration-conformance evidence for cache-budget-audit.yml, not
+# product verification in docs/DESIGN-ci.md's Rust/WASM/native-Z3 sense.  It
+# uses PyYAML, a third-party repository-tooling dependency, so it deliberately
+# runs in its own workflow rather than in merge-readiness.yml's stdlib-only
+# automation-contracts lane (see tools/check-merge-readiness.sh).
+#
+# The install step defers to pyproject.toml's unpinned dev extra, just as
+# site-reference-freshness.yml does for pytest and markdown.  That declaration
+# is the dependency authority: installing the whole extra prevents a
+# hand-maintained package list from silently becoming stale.
+#
+# This context is intentionally not required yet.  Making it required needs a
+# coordinated, separate rollout through the ruleset contract, fixtures, design
+# record, and live ruleset; this workflow is unfiltered so that future rollout
+# can be evaluated without a path-filter reporting gap.  See issue #802.
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cache-budget-audit-wiring-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  validate:
+    name: cache budget audit wiring
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install the workflow validator's test dependencies
+        run: pip install ".[dev]"
+
+      - name: Calibrate cache budget audit workflow wiring
+        run: python3 -m pytest tests/test_cache_budget_audit_workflow.py -v

--- a/changelog.d/802-cache-budget-audit-wiring.required.md
+++ b/changelog.d/802-cache-budget-audit-wiring.required.md
@@ -1,1 +1,1 @@
-Required (#802): cache-budget audit workflow wiring now has parsed-YAML calibration controls for its triggers, permissions, ordering, failure propagation, and allowlisted live command.
+Required (#802): cache-budget audit workflow wiring now has parsed-YAML calibration controls for every validator rejection and diagnostic CLI input failures.

--- a/changelog.d/802-cache-budget-audit-wiring.required.md
+++ b/changelog.d/802-cache-budget-audit-wiring.required.md
@@ -1,0 +1,1 @@
+Required (#802): cache-budget audit workflow wiring now has parsed-YAML calibration controls for its triggers, permissions, ordering, failure propagation, and allowlisted live command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "markdown>=3"]
+dev = ["pytest>=7", "markdown>=3", "PyYAML>=6"]
 
 [project.urls]
 Homepage = "https://github.com/ymm-oss/fsl"

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "cache-budget-audit.yml"
@@ -87,23 +89,111 @@ def _remove_watched_path(path: str) -> Callable[[dict[str, Any]], None]:
     return mutate
 
 
-Mutation = tuple[str, Callable[[dict[str, Any]], None]]
+def _replace_workflow_with_list(_document: dict[str, Any]) -> list[str]:
+    return ["not a workflow mapping"]
+
+
+def _set_on_to_list(document: dict[str, Any]) -> None:
+    document["on"] = []
+
+
+def _empty_schedule(document: dict[str, Any]) -> None:
+    document["on"]["schedule"] = []
+
+
+def _disable_workflow_dispatch(document: dict[str, Any]) -> None:
+    document["on"]["workflow_dispatch"] = False
+
+
+def _set_workflow_dispatch_to_list(document: dict[str, Any]) -> None:
+    document["on"]["workflow_dispatch"] = []
+
+
+def _set_push_to_list(document: dict[str, Any]) -> None:
+    document["on"]["push"] = []
+
+
+def _set_push_paths_to_mapping(document: dict[str, Any]) -> None:
+    document["on"]["push"]["paths"] = {}
+
+
+def _remove_jobs(document: dict[str, Any]) -> None:
+    del document["jobs"]
+
+
+def _set_audit_job_to_list(document: dict[str, Any]) -> None:
+    document["jobs"][validator.AUDIT_JOB_ID] = []
+
+
+def _remove_steps(document: dict[str, Any]) -> None:
+    del _audit_job(document)["steps"]
+
+
+def _remove_named_step(document: dict[str, Any], name: str) -> None:
+    _audit_job(document)["steps"] = [
+        step for step in _audit_job(document)["steps"] if step.get("name") != name
+    ]
+
+
+def _remove_calibration_step(document: dict[str, Any]) -> None:
+    _remove_named_step(document, validator.CALIBRATION_STEP_NAME)
+
+
+def _remove_live_audit_step(document: dict[str, Any]) -> None:
+    _remove_named_step(document, validator.LIVE_AUDIT_STEP_NAME)
+
+
+def _move_calibration_after_live_audit(document: dict[str, Any]) -> None:
+    steps = _audit_job(document)["steps"]
+    calibration_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == validator.CALIBRATION_STEP_NAME
+    )
+    calibration = steps.pop(calibration_index)
+    live_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == validator.LIVE_AUDIT_STEP_NAME
+    )
+    steps.insert(live_index + 1, calibration)
+
+
+def _remove_live_audit_run(document: dict[str, Any]) -> None:
+    del _live_audit_step(document)["run"]
+
+
+Mutation = tuple[str, Callable[[dict[str, Any]], Any], str]
 MUTATIONS: list[Mutation] = [
-    ("append || true to the live command", _append_true),
-    ("set live-step continue-on-error", _step_continue_on_error),
-    ("set audit-job continue-on-error", _job_continue_on_error),
-    ("add an if to the live step", _step_if),
+    ("replace workflow with a YAML list", _replace_workflow_with_list, "workflow must be a mapping"),
+    ("set on to a list", _set_on_to_list, "workflow 'on' must be a mapping"),
+    ("empty schedule", _empty_schedule, "trigger 'schedule' must be a non-empty list"),
+    ("disable workflow_dispatch", _disable_workflow_dispatch, "trigger 'workflow_dispatch' must be enabled"),
+    ("set workflow_dispatch to a list", _set_workflow_dispatch_to_list, "trigger 'workflow_dispatch' must be an event mapping"),
+    ("set push to a list", _set_push_to_list, "trigger 'push' must be a mapping"),
+    ("set push paths to a mapping", _set_push_paths_to_mapping, "trigger 'push.paths' must be a list"),
+    ("remove jobs", _remove_jobs, "workflow jobs must be a mapping"),
+    ("set audit job to a list", _set_audit_job_to_list, "job 'audit' must be a mapping"),
+    ("remove steps", _remove_steps, "audit job steps must be a list"),
+    ("remove calibration step", _remove_calibration_step, "audit job must contain exactly one named calibration step"),
+    ("remove live-audit step", _remove_live_audit_step, "audit job must contain exactly one named live-audit step"),
+    ("move calibration after live audit", _move_calibration_after_live_audit, "calibration step must precede the live-audit step"),
+    ("remove live-audit run", _remove_live_audit_run, "live-audit command must be exactly 'node .github/scripts/run-cache-budget-audit.mjs'"),
+    ("append || true to the live command", _append_true, "live-audit command must be exactly 'node .github/scripts/run-cache-budget-audit.mjs'"),
+    ("set live-step continue-on-error", _step_continue_on_error, "live-audit step must not declare 'continue-on-error'"),
+    ("set audit-job continue-on-error", _job_continue_on_error, "audit job must not declare 'continue-on-error'"),
+    ("add an if to the live step", _step_if, "live-audit step must not declare 'if'"),
     *[
-        (f"remove permission {permission}", _remove_permission(permission))
+        (
+            f"remove permission {permission}",
+            _remove_permission(permission),
+            "top-level permissions must be exactly actions: read and contents: read",
+        )
         for permission in sorted(validator.REQUIRED_PERMISSIONS)
     ],
     *[
-        (f"remove trigger {trigger}", _remove_trigger(trigger))
+        (f"remove trigger {trigger}", _remove_trigger(trigger), f"required trigger '{trigger}' is absent")
         for trigger in validator.REQUIRED_TRIGGERS
     ],
-    ("replace push main branch", _replace_main_branch),
+    ("replace push main branch", _replace_main_branch, "trigger 'push.branches' must contain 'main'"),
     *[
-        (f"remove watched path {path}", _remove_watched_path(path))
+        (f"remove watched path {path}", _remove_watched_path(path), f"required watched path '{path}' is absent")
         for path in sorted(validator.REQUIRED_WATCHED_PATHS)
     ],
 ]
@@ -113,11 +203,62 @@ def test_real_cache_budget_audit_workflow_is_accepted():
     assert validator.validate_workflow(_real_workflow()) == []
 
 
-@pytest.mark.parametrize(("description", "mutate"), MUTATIONS, ids=[item[0] for item in MUTATIONS])
+@pytest.mark.parametrize(("description", "mutate", "expected"), MUTATIONS, ids=[item[0] for item in MUTATIONS])
 def test_each_single_wiring_mutation_is_rejected(
-    description: str, mutate: Callable[[dict[str, Any]], None]
+    description: str, mutate: Callable[[dict[str, Any]], Any], expected: str
 ):
     document = copy.deepcopy(_real_workflow())
-    mutate(document)
-    errors = validator.validate_workflow(document)
-    assert errors, f"{description}: validator accepted the mutated workflow"
+    mutated = mutate(document)
+    errors = validator.validate_workflow(document if mutated is None else mutated)
+    assert errors == [expected], f"{description}: expected {expected!r}, got {errors!r}"
+
+
+def _run_cli(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR_PATH), "--workflow", str(path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _assert_cli_failure(path: Path, expected: str) -> None:
+    result = _run_cli(path)
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert result.stdout == f"cache-budget-audit workflow wiring: FAIL -- {expected}\n"
+    assert "Traceback" not in output
+
+
+def test_cli_reports_missing_workflow_file(tmp_path: Path):
+    path = tmp_path / "missing.yml"
+    _assert_cli_failure(path, f"workflow file '{path}' does not exist")
+
+
+def test_cli_reports_unparseable_yaml(tmp_path: Path):
+    path = tmp_path / "invalid.yml"
+    path.write_text("on: [\n", encoding="utf-8")
+    result = _run_cli(path)
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert result.stdout.startswith("cache-budget-audit workflow wiring: FAIL -- workflow YAML is invalid:")
+    assert "Traceback" not in output
+
+
+@pytest.mark.parametrize(
+    ("description", "mutate", "expected"),
+    [
+        ("list document", _replace_workflow_with_list, "workflow must be a mapping"),
+        ("mapping without jobs", _remove_jobs, "workflow jobs must be a mapping"),
+        ("audit job without steps", _remove_steps, "audit job steps must be a list"),
+        ("live audit without run", _remove_live_audit_run, "live-audit command must be exactly 'node .github/scripts/run-cache-budget-audit.mjs'"),
+    ],
+)
+def test_cli_reports_malformed_workflow_shape(
+    tmp_path: Path, description: str, mutate: Callable[[dict[str, Any]], Any], expected: str
+):
+    document = copy.deepcopy(_real_workflow())
+    mutated = mutate(document)
+    path = tmp_path / f"{description.replace(' ', '_')}.yml"
+    path.write_text(yaml.safe_dump(document if mutated is None else mutated), encoding="utf-8")
+    _assert_cli_failure(path, expected)

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Calibration for the parsed cache-budget-audit workflow wiring contract."""
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "cache-budget-audit.yml"
+VALIDATOR_PATH = REPO_ROOT / ".github" / "scripts" / "validate-cache-budget-audit-workflow.py"
+
+
+def _load_validator():
+    spec = importlib.util.spec_from_file_location("cache_budget_audit_workflow", VALIDATOR_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = _load_validator()
+
+
+def _real_workflow() -> dict[str, Any]:
+    document = validator.load_workflow(WORKFLOW_PATH)
+    assert isinstance(document, dict)
+    return document
+
+
+def _audit_job(document: dict[str, Any]) -> dict[str, Any]:
+    return document["jobs"][validator.AUDIT_JOB_ID]
+
+
+def _live_audit_step(document: dict[str, Any]) -> dict[str, Any]:
+    return next(
+        step
+        for step in _audit_job(document)["steps"]
+        if step.get("name") == validator.LIVE_AUDIT_STEP_NAME
+    )
+
+
+def _append_true(document: dict[str, Any]) -> None:
+    _live_audit_step(document)["run"] += " || true"
+
+
+def _step_continue_on_error(document: dict[str, Any]) -> None:
+    _live_audit_step(document)["continue-on-error"] = True
+
+
+def _job_continue_on_error(document: dict[str, Any]) -> None:
+    _audit_job(document)["continue-on-error"] = True
+
+
+def _step_if(document: dict[str, Any]) -> None:
+    _live_audit_step(document)["if"] = "always()"
+
+
+def _remove_permission(permission: str) -> Callable[[dict[str, Any]], None]:
+    def mutate(document: dict[str, Any]) -> None:
+        del document["permissions"][permission]
+
+    return mutate
+
+
+def _remove_trigger(trigger: str) -> Callable[[dict[str, Any]], None]:
+    def mutate(document: dict[str, Any]) -> None:
+        del document["on"][trigger]
+
+    return mutate
+
+
+def _replace_main_branch(document: dict[str, Any]) -> None:
+    document["on"]["push"]["branches"] = ["nonexistent-branch"]
+
+
+def _remove_watched_path(path: str) -> Callable[[dict[str, Any]], None]:
+    def mutate(document: dict[str, Any]) -> None:
+        document["on"]["push"]["paths"].remove(path)
+
+    return mutate
+
+
+Mutation = tuple[str, Callable[[dict[str, Any]], None]]
+MUTATIONS: list[Mutation] = [
+    ("append || true to the live command", _append_true),
+    ("set live-step continue-on-error", _step_continue_on_error),
+    ("set audit-job continue-on-error", _job_continue_on_error),
+    ("add an if to the live step", _step_if),
+    *[
+        (f"remove permission {permission}", _remove_permission(permission))
+        for permission in sorted(validator.REQUIRED_PERMISSIONS)
+    ],
+    *[
+        (f"remove trigger {trigger}", _remove_trigger(trigger))
+        for trigger in validator.REQUIRED_TRIGGERS
+    ],
+    ("replace push main branch", _replace_main_branch),
+    *[
+        (f"remove watched path {path}", _remove_watched_path(path))
+        for path in sorted(validator.REQUIRED_WATCHED_PATHS)
+    ],
+]
+
+
+def test_real_cache_budget_audit_workflow_is_accepted():
+    assert validator.validate_workflow(_real_workflow()) == []
+
+
+@pytest.mark.parametrize(("description", "mutate"), MUTATIONS, ids=[item[0] for item in MUTATIONS])
+def test_each_single_wiring_mutation_is_rejected(
+    description: str, mutate: Callable[[dict[str, Any]], None]
+):
+    document = copy.deepcopy(_real_workflow())
+    mutate(document)
+    errors = validator.validate_workflow(document)
+    assert errors, f"{description}: validator accepted the mutated workflow"


### PR DESCRIPTION
## Problem, corrected

The issue body says the cache budget audit's wiring has **no** regression control. Measured on `9754590`,
that overstates it:

- `node --test .github/scripts/audit-cache-budget.test.mjs` passes **65/65**, and
  `tools/check-merge-readiness.sh`'s `check_automation()` lane runs it on **every pull request** — with a
  comment naming its rejecting fixture (removing `ci.yml`'s `save-if` guard must fail the audit).
- Those tests execute the real CLI `main()`/`process.exit` path in a subprocess and prove that an unhealthy
  result and missing credentials both return status 1.
- The workflow itself currently has **zero** `continue-on-error`, `|| true`, `set +e` and `if:` across its 68
  lines, and declares exactly `actions: read` and `contents: read`.

The real gap is narrow and precise: **no test reads `.github/workflows/cache-budget-audit.yml`.** Runner
failure propagates today, but a future edit to that YAML — its triggers, its permissions, or the audit step's
invocation — is rejected by nothing. That is what this PR closes. The correction is recorded on the issue.

One criterion in the issue is also technically wrong and was **not** implemented as written: `if: always()`
does not turn a failed step green — it controls whether a step *runs* after a prior failure, while its exit
status still fails the job. The validator forbids **any** `if` on the audit step so it stays unconditional,
which is a defensible rule, but the rationale is "keep it unconditional", not "always() swallows exit status".

## What it does

`.github/scripts/validate-cache-budget-audit-workflow.py` (200 lines) validates a **parsed YAML document**,
locating the audit job and the named live-audit step semantically, then requiring:

| | |
|---|---|
| triggers | `schedule`, `workflow_dispatch`, `push` all present and non-empty; `push.branches` contains `main`; all six watched paths present |
| permissions | exactly the two read grants |
| ordering | calibration before the live audit |
| tolerance | no `if` and no `continue-on-error` on the step; no job-level tolerance |
| command | **allowlisted** as the single argv-equivalent `node .github/scripts/run-cache-budget-audit.mjs` |

The command is allowlisted rather than substring-scanned. A scalar containing a pipeline, a compound command,
`set +e`, a redirection wrapper, or any extra command is not that command. That makes quoting, indentation,
key order, comments and block-versus-plain YAML irrelevant, so the validator only needs editing when the
protected semantics actually change — the difference between a control that survives and one that gets edited
into uselessness.

## Calibration — the acceptance criterion

`tests/test_cache_budget_audit_workflow.py` parses the real workflow, deep-copies the semantic tree, and
applies **one mutation at a time**, requiring rejection for each. **16 rejecting cases plus 1 accepting case,
17/17 pass.**

The per-item mutations are **derived from the validator's own constants**, not hand-listed:

```python
*[(f"remove permission {p}", _remove_permission(p)) for p in sorted(validator.REQUIRED_PERMISSIONS)],
*[(f"remove trigger {t}",    _remove_trigger(t))    for t in validator.REQUIRED_TRIGGERS],
*[(f"remove watched path {p}", _remove_watched_path(p)) for p in sorted(validator.REQUIRED_WATCHED_PATHS)],
```

So widening what the validator protects automatically widens what the mutation table attacks. A hand-written
list would let the next person add a protected key and forget its mutation.

**Verified independently by the orchestrator, not taken from the implementer's report:** deleting only the
live-step `continue-on-error` check from the validator makes exactly
`test_each_single_wiring_mutation_is_rejected[set live-step continue-on-error]` fail — 1 failed, 16 passed —
and restoring it returns 17/17 with a clean tree. Each mutation is pinned individually, not by a single
umbrella assertion.

## Placement, and the dependency question

A real YAML parser is the right tool, so this cannot join `tools/check-merge-readiness.sh`'s automation lane:
that lane's own comment (`:36`-`:41`) states it stays stdlib-only with no pytest and no third-party
dependency, and that purity — not its speed — is what its placement protects.

It follows `site-reference-freshness.yml`'s precedent instead: third-party-dependent evidence gets its own
unfiltered `pull_request`/`merge_group` workflow. The install step defers to `pyproject.toml`'s unpinned dev
extra, exactly as that workflow does, because deferring to the declaration is what stops a hand-maintained
package list from going stale.

PyYAML is added to that dev extra. **This is not a change to the frozen Python product surface**: `AGENTS.md`
freezes `src/fslc/`'s behavior, and `markdown>=3` is already in the same extra for precisely this reason — it
is a third-party dependency of a repository tooling script (`tools/build_site_reference.py`), not of the
package.

## Deliberately out of scope

**The new context is not made required.** `.github/ruleset-contract.json` and `docs/DESIGN-ci.md`'s
required-context list are untouched. Making a context required is a coordinated rollout across the checked-in
contract, its captured fixtures, the design record and the live ruleset; bundling it here would make this
change hard to revert. The workflow is unfiltered so that rollout can be evaluated later without a
path-filter reporting gap, and its header says so.

The audit's inability to distinguish reclaimable superseded duplicates from genuine growth is filed
separately as #835. Failure-time issue creation is #795, which should extend this validator rather than
introduce a second wiring check.

`changelog.d/802-cache-budget-audit-wiring.required.md`.

Closes #802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
