### PR TITLE
fix(ci): report cache budget audit failures through a privilege-separated reporter

### DIFF
--- a/.github/scripts/capture-cache-budget-audit-summary-fixture.mjs
+++ b/.github/scripts/capture-cache-budget-audit-summary-fixture.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+
+const [commit] = process.argv.slice(2);
+if (!/^[0-9a-f]{40}$/.test(commit ?? "")) {
+  throw new Error("usage: capture-cache-budget-audit-summary-fixture.mjs <40-hex-writer-commit>");
+}
+
+class FixtureClient {
+  constructor(completedRuns) {
+    this.completedRuns = completedRuns;
+    this.issues = [];
+    this.comments = [];
+    this.labels = new Set();
+    this.nextIssue = 100;
+    this.nextComment = 1000;
+  }
+
+  async listCompletedWorkflowRuns(_workflowId, _branch, page) {
+    return this.completedRuns.slice((page - 1) * 100, page * 100);
+  }
+
+  async ensureLabel(label) {
+    this.labels.add(label);
+  }
+
+  async listIssues(_label, page) {
+    return this.issues.slice((page - 1) * 100, page * 100);
+  }
+
+  async listIssueComments(number, page) {
+    return this.comments
+      .filter((comment) => comment.issue === number)
+      .slice((page - 1) * 100, page * 100);
+  }
+
+  async createIssue(issue) {
+    const created = { ...issue, number: this.nextIssue, state: "open" };
+    this.nextIssue += 1;
+    this.issues.push(created);
+    return created;
+  }
+
+  async createIssueComment(number, body) {
+    this.comments.push({
+      id: this.nextComment,
+      issue: number,
+      body,
+      user: { login: "github-actions[bot]" },
+    });
+    this.nextComment += 1;
+  }
+
+  async updateIssueComment(commentId, body) {
+    this.comments.find((comment) => comment.id === commentId).body = body;
+  }
+
+  async deleteIssueComment(commentId) {
+    this.comments.splice(
+      this.comments.findIndex((comment) => comment.id === commentId),
+      1,
+    );
+  }
+
+  async updateIssue(number, update) {
+    Object.assign(this.issues.find((issue) => issue.number === number), update);
+  }
+}
+
+function workflowRun(overrides = {}) {
+  return {
+    id: 41,
+    workflow_id: 7,
+    run_number: 12,
+    run_attempt: 1,
+    conclusion: "failure",
+    event: "schedule",
+    head_branch: "main",
+    head_repository: { full_name: "ymm-oss/fsl" },
+    head_sha: "0123456789abcdef0123456789abcdef01234567",
+    html_url: "https://github.com/ymm-oss/fsl/actions/runs/41",
+    ...overrides,
+  };
+}
+
+// This is deliberately a capture tool, not a test dependency. Regeneration
+// requires the original writer commit to be locally available; that deliberate
+// prerequisite prevents a squash merge from silently changing test inputs.
+const source = execFileSync(
+  "git",
+  ["show", `${commit}:.github/scripts/report-cache-budget-audit.mjs`],
+  { encoding: "utf8" },
+);
+const { reconcileCacheBudgetAudit } = await import(
+  `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`,
+);
+const client = new FixtureClient([workflowRun({ id: 41, run_number: 12 })]);
+await reconcileCacheBudgetAudit({
+  client,
+  repository: "ymm-oss/fsl",
+  defaultBranch: "main",
+  workflowRun: workflowRun({ id: 42, run_number: 13 }),
+});
+const summary = client.comments.find((comment) =>
+  comment.body.includes("cache-budget-audit-occurrence-summary"),
+);
+if (!summary) {
+  throw new Error("historical writer did not produce an occurrence summary");
+}
+process.stdout.write(`${summary.body}\n`);

--- a/.github/scripts/capture-cache-budget-audit-summary-fixture.mjs
+++ b/.github/scripts/capture-cache-budget-audit-summary-fixture.mjs
@@ -109,4 +109,4 @@ const summary = client.comments.find((comment) =>
 if (!summary) {
   throw new Error("historical writer did not produce an occurrence summary");
 }
-process.stdout.write(`${summary.body}\n`);
+process.stdout.write(summary.body);

--- a/.github/scripts/fixtures/cache-budget-audit-summary-fixtures.mjs
+++ b/.github/scripts/fixtures/cache-budget-audit-summary-fixtures.mjs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// These are actual outputs captured from historical writers, not reconstructed
+// test text. Regeneration deliberately requires the source commit named below:
+// use the recorded capture command only after making that original object
+// available, then update its writer/output digests in the same review.
+export const HISTORICAL_SUMMARY_FIXTURES = Object.freeze([
+  Object.freeze({
+    id: "original-unqualified",
+    provenance: Object.freeze({
+      writerCommit: "cbb00dca5acf99742743a22dd33affa29378d85e",
+      writerSha256: "3dc17ad18cd035bb9ef197742e283d47e4d6d00169941255aef837cb673185e9",
+      captureCommand: "node .github/scripts/capture-cache-budget-audit-summary-fixture.mjs cbb00dca5acf99742743a22dd33affa29378d85e",
+      outputSha256: "6ea77d6d6b95de9f6acbfec0a00cfd4d13aae0135d436969aa1de34d2937d649",
+    }),
+    body: `<!-- cache-budget-audit-occurrence-summary -->
+<!-- cache-budget-audit-occurrence:42:1 -->
+<!-- cache-budget-audit-cursor:13:1 -->
+Detailed recurrence comments are capped at 20; this rolling summary records the latest recurrence.
+Coalesced failed attempts: 1.
+Recent coalesced identities: 41:1.
+
+- Workflow run: [42](https://github.com/ymm-oss/fsl/actions/runs/41)
+- Trigger: \`schedule\`
+- Conclusion: \`failure\``,
+  }),
+  Object.freeze({
+    id: "interval-qualified",
+    provenance: Object.freeze({
+      writerCommit: "0237fb1fe2b30911ddd5cdf60de1020810e72164",
+      writerSha256: "d8618cd5d2bf8d8c99c8b0093d7e55b34fd37240f71ee30cfed32a85bea90833",
+      captureCommand: "node .github/scripts/capture-cache-budget-audit-summary-fixture.mjs 0237fb1fe2b30911ddd5cdf60de1020810e72164",
+      outputSha256: "81b01087c076b23e2a804ff0398d62b84017780d73a07b0d72f113fbe12b1ddf",
+    }),
+    body: `<!-- cache-budget-audit-occurrence-summary -->
+<!-- cache-budget-audit-occurrence:42:1 -->
+<!-- cache-budget-audit-cursor:13:1 -->
+This rolling summary records coalesced failures and the latest recurrence.
+Observable coalesced failed attempts in this summary interval: 1.
+Recent observable coalesced identities: 41:1.
+
+- Workflow run: [42](https://github.com/ymm-oss/fsl/actions/runs/41)
+- Trigger: \`schedule\`
+- Conclusion: \`failure\``,
+  }),
+]);

--- a/.github/scripts/report-cache-budget-audit.mjs
+++ b/.github/scripts/report-cache-budget-audit.mjs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+export const CACHE_BUDGET_AUDIT_LABEL = "ci/cache-budget-audit";
+export const TRUSTED_AUDIT_EVENTS = new Set([
+  "push",
+  "schedule",
+  "workflow_dispatch",
+]);
+
+function shortSha(sha) {
+  return sha?.slice(0, 12) ?? "unknown";
+}
+
+export function cacheBudgetAuditMarker() {
+  return "<!-- cache-budget-audit -->";
+}
+
+export function occurrenceMarker(runId, runAttempt) {
+  return `<!-- cache-budget-audit-occurrence:${runId}:${runAttempt ?? 1} -->`;
+}
+
+function recoveryMarker(runId, runAttempt, issueNumber) {
+  return `<!-- cache-budget-audit-recovery:${runId}:${runAttempt ?? 1}:${issueNumber} -->`;
+}
+
+export function isNewerRun(candidate, current) {
+  if (candidate.run_number !== current.run_number) {
+    return candidate.run_number > current.run_number;
+  }
+  return (candidate.run_attempt ?? 1) > (current.run_attempt ?? 1);
+}
+
+export function isTrustedAuditRun(workflowRun, defaultBranch, repository) {
+  return (
+    TRUSTED_AUDIT_EVENTS.has(workflowRun.event) &&
+    workflowRun.head_branch === defaultBranch &&
+    workflowRun.head_repository?.full_name === repository
+  );
+}
+
+export function latestTrustedAuditRun(runs, defaultBranch, repository) {
+  return runs
+    .filter((run) => isTrustedAuditRun(run, defaultBranch, repository))
+    .reduce(
+      (latest, run) => (!latest || isNewerRun(run, latest) ? run : latest),
+      null,
+    );
+}
+
+function issueBody({ repository, workflowRun }) {
+  const occurrence = occurrenceMarker(workflowRun.id, workflowRun.run_attempt);
+  const commitUrl = `https://github.com/${repository}/commit/${workflowRun.head_sha}`;
+
+  return [
+    cacheBudgetAuditMarker(),
+    occurrence,
+    "",
+    "The trusted Actions cache-budget audit failed on the default branch.",
+    "",
+    `- Commit: [\`${shortSha(workflowRun.head_sha)}\`](${commitUrl})`,
+    `- Workflow run: [${workflowRun.id}](${workflowRun.html_url})`,
+    `- Trigger: \`${workflowRun.event}\``,
+    `- Conclusion: \`${workflowRun.conclusion ?? "unknown"}\``,
+    "",
+    "Logs are intentionally not copied into this issue. Use the workflow link above.",
+    "Keep this issue open until a later trusted cache-budget audit succeeds on the default branch.",
+  ].join("\n");
+}
+
+function occurrenceComment({ workflowRun }) {
+  return [
+    occurrenceMarker(workflowRun.id, workflowRun.run_attempt),
+    `The failure recurred on [\`${shortSha(workflowRun.head_sha)}\`](https://github.com/${workflowRun.repository.full_name}/commit/${workflowRun.head_sha}).`,
+    "",
+    `- Workflow run: [${workflowRun.id}](${workflowRun.html_url})`,
+    `- Trigger: \`${workflowRun.event}\``,
+    `- Conclusion: \`${workflowRun.conclusion ?? "unknown"}\``,
+  ].join("\n");
+}
+
+function recoveryComment({ workflowRun, issue }) {
+  return [
+    recoveryMarker(workflowRun.id, workflowRun.run_attempt, issue.number),
+    `Recovered on [\`${shortSha(workflowRun.head_sha)}\`](https://github.com/${workflowRun.repository.full_name}/commit/${workflowRun.head_sha}).`,
+    "",
+    `Cache-budget audit run [${workflowRun.id}](${workflowRun.html_url}) completed successfully. Reopen the issue if the audit fails again.`,
+  ].join("\n");
+}
+
+async function issueContains(client, issue, marker) {
+  if ((issue.body ?? "").includes(marker)) {
+    return true;
+  }
+  const comments = await client.listIssueComments(issue.number);
+  return comments.some((comment) => (comment.body ?? "").includes(marker));
+}
+
+/**
+ * Reconcile one canonical cache-budget issue against the newest completed
+ * trusted audit.  The trigger is deliberately not treated as authoritative:
+ * a delayed workflow_run event is redirected to newer completed health.
+ */
+export async function reconcileCacheBudgetAudit({
+  client,
+  repository,
+  defaultBranch,
+  workflowRun,
+}) {
+  if (!isTrustedAuditRun(workflowRun, defaultBranch, repository)) {
+    throw new Error("refusing to report an untrusted cache-budget audit run");
+  }
+
+  const triggeringRunId = workflowRun.id;
+  const completedRuns = await client.listCompletedWorkflowRuns(
+    workflowRun.workflow_id,
+    defaultBranch,
+  );
+  const latest = latestTrustedAuditRun(
+    [...completedRuns, workflowRun],
+    defaultBranch,
+    repository,
+  );
+  if (latest) {
+    workflowRun = latest;
+  }
+  workflowRun.repository = { full_name: repository };
+
+  await client.ensureLabel(CACHE_BUDGET_AUDIT_LABEL);
+  const issues = await client.listIssues(CACHE_BUDGET_AUDIT_LABEL);
+  const issue = issues.find(
+    (candidate) =>
+      !candidate.pull_request &&
+      (candidate.body ?? "").includes(cacheBudgetAuditMarker()),
+  );
+  const failed = workflowRun.conclusion !== "success";
+  let created = 0;
+  let updated = 0;
+  let closed = 0;
+
+  if (failed) {
+    if (!issue) {
+      await client.createIssue({
+        title: "[cache budget audit] Actions cache budget audit failed on main",
+        body: issueBody({ repository, workflowRun }),
+        labels: [CACHE_BUDGET_AUDIT_LABEL],
+      });
+      created = 1;
+    } else {
+      let changed = false;
+      const occurrence = occurrenceMarker(workflowRun.id, workflowRun.run_attempt);
+      if (!(await issueContains(client, issue, occurrence))) {
+        await client.createIssueComment(issue.number, occurrenceComment({ workflowRun }));
+        changed = true;
+      }
+      if (issue.state !== "open") {
+        await client.updateIssue(issue.number, { state: "open" });
+        issue.state = "open";
+        changed = true;
+      }
+      if (changed) {
+        updated = 1;
+      }
+    }
+  } else if (issue?.state === "open") {
+    const recovery = recoveryMarker(
+      workflowRun.id,
+      workflowRun.run_attempt,
+      issue.number,
+    );
+    if (!(await issueContains(client, issue, recovery))) {
+      await client.createIssueComment(
+        issue.number,
+        recoveryComment({ workflowRun, issue }),
+      );
+    }
+    await client.updateIssue(issue.number, { state: "closed" });
+    closed = 1;
+  }
+
+  const result = { created, updated, closed, failed };
+  if (workflowRun.id !== triggeringRunId) {
+    result.redirectedFromRunId = triggeringRunId;
+    result.reconciledRunId = workflowRun.id;
+  }
+  return result;
+}
+
+export class GitHubRestClient {
+  constructor({ token, repository }) {
+    const [owner, repo] = repository.split("/");
+    if (!owner || !repo) {
+      throw new Error(`invalid GITHUB_REPOSITORY: ${repository}`);
+    }
+    this.token = token;
+    this.owner = owner;
+    this.repo = repo;
+  }
+
+  async request(method, path, body) {
+    const response = await fetch(`https://api.github.com${path}`, {
+      method,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "fsl-cache-budget-audit-reporter",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    if (response.status === 204) {
+      return null;
+    }
+    const text = await response.text();
+    if (!response.ok) {
+      const error = new Error(
+        `GitHub API ${method} ${path} failed (${response.status}): ${text}`,
+      );
+      error.status = response.status;
+      throw error;
+    }
+    return text ? JSON.parse(text) : null;
+  }
+
+  repoPath(suffix) {
+    return `/repos/${this.owner}/${this.repo}${suffix}`;
+  }
+
+  async listCompletedWorkflowRuns(workflowId, branch) {
+    const response = await this.request(
+      "GET",
+      this.repoPath(
+        `/actions/workflows/${workflowId}/runs?branch=${encodeURIComponent(branch)}&status=completed&per_page=100`,
+      ),
+    );
+    return response.workflow_runs;
+  }
+
+  async ensureLabel(name) {
+    const labelPath = this.repoPath(`/labels/${encodeURIComponent(name)}`);
+    try {
+      await this.request("GET", labelPath);
+    } catch (error) {
+      if (error.status !== 404) {
+        throw error;
+      }
+      await this.request("POST", this.repoPath("/labels"), {
+        name,
+        color: "b60205",
+        description: "Failure detected by the Actions cache budget audit",
+      });
+    }
+  }
+
+  async listIssues(label) {
+    return this.request(
+      "GET",
+      this.repoPath(
+        `/issues?state=all&labels=${encodeURIComponent(label)}&per_page=100`,
+      ),
+    );
+  }
+
+  async listIssueComments(number) {
+    return this.request(
+      "GET",
+      this.repoPath(`/issues/${number}/comments?per_page=100`),
+    );
+  }
+
+  async createIssue(issue) {
+    return this.request("POST", this.repoPath("/issues"), issue);
+  }
+
+  async createIssueComment(number, body) {
+    return this.request(
+      "POST",
+      this.repoPath(`/issues/${number}/comments`),
+      { body },
+    );
+  }
+
+  async updateIssue(number, update) {
+    return this.request("PATCH", this.repoPath(`/issues/${number}`), update);
+  }
+}
+
+async function main() {
+  const event = JSON.parse(
+    await readFile(process.env.GITHUB_EVENT_PATH, "utf8"),
+  );
+  const workflowRun = event.workflow_run;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const defaultBranch = event.repository?.default_branch;
+  if (!repository || !defaultBranch || !workflowRun) {
+    throw new Error("workflow_run event, repository, and default branch are required");
+  }
+  if (!isTrustedAuditRun(workflowRun, defaultBranch, repository)) {
+    console.log("Skipping untrusted cache-budget audit run.");
+    return;
+  }
+  const result = await reconcileCacheBudgetAudit({
+    client: new GitHubRestClient({
+      token: process.env.GITHUB_TOKEN,
+      repository,
+    }),
+    repository,
+    defaultBranch,
+    workflowRun,
+  });
+  console.log(JSON.stringify(result));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.stack ?? error.message);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/report-cache-budget-audit.mjs
+++ b/.github/scripts/report-cache-budget-audit.mjs
@@ -16,6 +16,7 @@ export const TRUSTED_AUDIT_EVENTS = new Set([
 
 const CURRENT_COALESCED_COUNT_PREFIX = "Observable coalesced failed attempts since this summary was created";
 const CURRENT_COALESCED_IDENTITIES_PREFIX = "Recent observable coalesced identities";
+const INTERVAL_COALESCED_COUNT_PREFIX = "Observable coalesced failed attempts in this summary interval";
 const LEGACY_COALESCED_COUNT_PREFIX = "Coalesced failed attempts";
 const LEGACY_COALESCED_IDENTITIES_PREFIX = "Recent coalesced identities";
 
@@ -168,17 +169,24 @@ function parsedIdentity(identity) {
 
 function parsedCoalesced(comment) {
   const body = comment.body ?? "";
-  // The immediately preceding writer used the legacy prefixes below. Read them
-  // only to migrate existing summaries; remove this branch only in an explicit
-  // schema migration after verifying that no legacy summaries remain.
+  // Writers before f3b57eb used the interval prefix; the original writer used
+  // the unqualified prefixes. Read both only to migrate existing summaries;
+  // remove them only in an explicit schema migration after verifying no such
+  // summaries remain.
   const countMatch = singleSummaryMatch(
     body,
-    /(?:Observable coalesced failed attempts since this summary was created|Coalesced failed attempts): ([^\n]*)\./g,
+    new RegExp(
+      `(?:${CURRENT_COALESCED_COUNT_PREFIX}|${INTERVAL_COALESCED_COUNT_PREFIX}|${LEGACY_COALESCED_COUNT_PREFIX}): ([^\\n]*)\\.`,
+      "g",
+    ),
     "coalesced failure count",
   );
   const identitiesMatch = singleSummaryMatch(
     body,
-    /(?:Recent observable coalesced identities|Recent coalesced identities): ([^\n]*)\./g,
+    new RegExp(
+      `(?:${CURRENT_COALESCED_IDENTITIES_PREFIX}|${LEGACY_COALESCED_IDENTITIES_PREFIX}): ([^\\n]*)\\.`,
+      "g",
+    ),
     "coalesced identities",
   );
   const count = canonicalDecimalInteger(countMatch[1], "coalesced failure count", 0);
@@ -245,7 +253,7 @@ async function listAllPages(fetchPage) {
 
 function hasReporterCommentPrefix(body) {
   return (
-    body.startsWith("<!-- cache-budget-audit-occurrence:") ||
+    /^<!-- cache-budget-audit-occurrence:[1-9]\d*:[1-9]\d* -->/.test(body) ||
     body.startsWith(occurrenceSummaryMarker()) ||
     body.startsWith(recoverySummaryMarker())
   );
@@ -312,14 +320,18 @@ async function consolidateOccurrenceSummary(client, plan) {
 }
 
 function nextCoalescedState(coalesced, failures) {
-  if (coalesced.count > Number.MAX_SAFE_INTEGER - failures.length) {
+  const recordedIdentities = new Set(coalesced.identities);
+  const unseenFailures = failures.filter(
+    (failure) => !recordedIdentities.has(runIdentity(failure)),
+  );
+  if (coalesced.count > Number.MAX_SAFE_INTEGER - unseenFailures.length) {
     throw invalidOccurrenceSummary("coalesced failure count would exceed the safe integer limit");
   }
   return {
-    count: coalesced.count + failures.length,
+    count: coalesced.count + unseenFailures.length,
     identities: [
       ...coalesced.identities,
-      ...failures.map(runIdentity),
+      ...unseenFailures.map(runIdentity),
     ].slice(-MAX_RECENT_COALESCED_IDENTITIES),
   };
 }

--- a/.github/scripts/report-cache-budget-audit.mjs
+++ b/.github/scripts/report-cache-budget-audit.mjs
@@ -102,9 +102,9 @@ function occurrenceSummaryComment({ workflowRun, occurrenceRun = workflowRun, co
     occurrenceSummaryMarker(),
     occurrenceMarker(occurrenceRun.id, occurrenceRun.run_attempt),
     coalescingCursorMarker(workflowRun),
-    "Detailed recurrence comments are capped at 20; this rolling summary records the latest recurrence.",
-    `Coalesced failed attempts: ${coalesced.count}.`,
-    `Recent coalesced identities: ${coalesced.identities.length ? coalesced.identities.join(", ") : "none"}.`,
+    "This rolling summary records coalesced failures and the latest recurrence.",
+    `Observable coalesced failed attempts in this summary interval: ${coalesced.count}.`,
+    `Recent observable coalesced identities: ${coalesced.identities.length ? coalesced.identities.join(", ") : "none"}.`,
     "",
     `- Workflow run: [${workflowRun.id}](${workflowRun.html_url})`,
     `- Trigger: \`${workflowRun.event}\``,
@@ -128,10 +128,14 @@ function singleSummaryMatch(body, expression, field) {
   return matches[0];
 }
 
-function nonNegativeSafeInteger(value, field) {
+function canonicalDecimalInteger(value, field, minimum) {
+  const expression = minimum === 0 ? /^(?:0|[1-9]\d*)$/ : /^[1-9]\d*$/;
+  if (typeof value !== "string" || !expression.test(value)) {
+    throw invalidOccurrenceSummary(`${field} must be a canonical decimal safe integer`);
+  }
   const number = Number(value);
-  if (!Number.isSafeInteger(number) || number < 0) {
-    throw invalidOccurrenceSummary(`${field} must be a non-negative safe integer`);
+  if (!Number.isSafeInteger(number) || number < minimum || String(number) !== value) {
+    throw invalidOccurrenceSummary(`${field} must be a canonical decimal safe integer`);
   }
   return number;
 }
@@ -142,34 +146,44 @@ function parsedCursor(comment) {
     /<!-- cache-budget-audit-cursor:([^: >]+):([^ >]+) -->/g,
     "cursor marker",
   );
-  const runNumber = nonNegativeSafeInteger(match[1], "cursor run number");
-  const runAttempt = nonNegativeSafeInteger(match[2], "cursor run attempt");
-  if (runNumber === 0 || runAttempt === 0) {
-    throw invalidOccurrenceSummary("cursor run number and attempt must be positive");
-  }
+  const runNumber = canonicalDecimalInteger(match[1], "cursor run number", 1);
+  const runAttempt = canonicalDecimalInteger(match[2], "cursor run attempt", 1);
   return { run_number: runNumber, run_attempt: runAttempt };
+}
+
+function parsedIdentity(identity) {
+  const [runId, runAttempt, ...rest] = identity.split(":");
+  if (rest.length > 0 || runId === undefined || runAttempt === undefined) {
+    throw invalidOccurrenceSummary("coalesced identities must be a bounded run_id:run_attempt list");
+  }
+  canonicalDecimalInteger(runId, "coalesced identity run ID", 1);
+  canonicalDecimalInteger(runAttempt, "coalesced identity run attempt", 1);
+  return identity;
 }
 
 function parsedCoalesced(comment) {
   const body = comment.body ?? "";
   const countMatch = singleSummaryMatch(
     body,
-    /Coalesced failed attempts: ([^\n]*)\./g,
+    /Observable coalesced failed attempts in this summary interval: ([^\n]*)\./g,
     "coalesced failure count",
   );
   const identitiesMatch = singleSummaryMatch(
     body,
-    /Recent coalesced identities: ([^\n]*)\./g,
+    /Recent observable coalesced identities: ([^\n]*)\./g,
     "coalesced identities",
   );
-  const count = nonNegativeSafeInteger(countMatch[1], "coalesced failure count");
+  const count = canonicalDecimalInteger(countMatch[1], "coalesced failure count", 0);
   const identitiesText = identitiesMatch[1];
-  const identities = identitiesText === "none" ? [] : identitiesText.split(", ");
+  const identities = identitiesText === "none" ? [] : identitiesText.split(", ").map(parsedIdentity);
   if (
     identities.length > MAX_RECENT_COALESCED_IDENTITIES ||
-    identities.some((identity) => !/^\d+:\d+$/.test(identity))
+    new Set(identities).size !== identities.length
   ) {
-    throw invalidOccurrenceSummary("coalesced identities must be a bounded run_id:run_attempt list");
+    throw invalidOccurrenceSummary("coalesced identities must be a unique bounded run_id:run_attempt list");
+  }
+  if (count < identities.length) {
+    throw invalidOccurrenceSummary("coalesced failure count must cover every recorded identity");
   }
   return { count, identities };
 }
@@ -315,9 +329,9 @@ export async function reconcileCacheBudgetAudit({
   const completedRuns = await listAllPages((page) =>
     client.listCompletedWorkflowRuns(workflowRun.workflow_id, defaultBranch, page),
   );
-  // GitHub's workflow-runs list endpoint exposes only the latest attempt for
-  // a run ID. Do not infer superseded attempts this reporter could not observe;
-  // coalesced evidence records only attempts returned by that endpoint.
+  // GitHub's workflow-runs list endpoint exposes only the latest attempt for a
+  // run ID. Preserve any distinct trusted triggering attempt too: coalesced
+  // evidence covers attempts observable through either source, never inferred ones.
   const trustedRuns = [...new Map(
     [...completedRuns, workflowRun]
       .filter((run) => isTrustedAuditRun(run, defaultBranch, repository))
@@ -351,6 +365,9 @@ export async function reconcileCacheBudgetAudit({
   let comments = issue ? await reporterComments(client, issue) : [];
   let summary = issue ? await canonicalOccurrenceSummary(client, comments) : null;
   let cursor = issue ? (summary ? parsedCursor(summary) : recordedCursor(issue, comments, trustedRuns)) : null;
+  if (cursor && isNewerRun(cursor, workflowRun)) {
+    throw invalidOccurrenceSummary("cursor must not be newer than observable trusted health");
+  }
   let coalesced = summary ? parsedCoalesced(summary) : { count: 0, identities: [] };
   let coalescedFailures = trustedRuns.filter(
     (run) =>
@@ -459,10 +476,10 @@ export async function reconcileCacheBudgetAudit({
         ? workflowRun
         : coalescedFailures.at(-1) ?? workflowRun;
       if (summary) {
-        await client.updateIssueComment(
-          summary.id,
-          occurrenceSummaryComment({ workflowRun, occurrenceRun, coalesced }),
-        );
+        const nextSummary = occurrenceSummaryComment({ workflowRun, occurrenceRun, coalesced });
+        if (summary.body !== nextSummary) {
+          await client.updateIssueComment(summary.id, nextSummary);
+        }
       } else if (comments.length >= MAX_REPORTER_COMMENTS) {
         const replacement = comments.at(-1);
         await client.updateIssueComment(

--- a/.github/scripts/report-cache-budget-audit.mjs
+++ b/.github/scripts/report-cache-budget-audit.mjs
@@ -4,6 +4,8 @@ import { readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
 export const CACHE_BUDGET_AUDIT_LABEL = "ci/cache-budget-audit";
+export const REPORTER_BOT_LOGIN = "github-actions[bot]";
+export const MAX_DETAILED_OCCURRENCE_COMMENTS = 20;
 export const TRUSTED_AUDIT_EVENTS = new Set([
   "push",
   "schedule",
@@ -20,6 +22,14 @@ export function cacheBudgetAuditMarker() {
 
 export function occurrenceMarker(runId, runAttempt) {
   return `<!-- cache-budget-audit-occurrence:${runId}:${runAttempt ?? 1} -->`;
+}
+
+function occurrenceSummaryMarker() {
+  return "<!-- cache-budget-audit-occurrence-summary -->";
+}
+
+function recoverySummaryMarker() {
+  return "<!-- cache-budget-audit-recovery-summary -->";
 }
 
 function recoveryMarker(runId, runAttempt, issueNumber) {
@@ -81,8 +91,21 @@ function occurrenceComment({ workflowRun }) {
   ].join("\n");
 }
 
+function occurrenceSummaryComment({ workflowRun }) {
+  return [
+    occurrenceSummaryMarker(),
+    occurrenceMarker(workflowRun.id, workflowRun.run_attempt),
+    "Detailed recurrence comments are capped at 20; this rolling summary records the latest recurrence.",
+    "",
+    `- Workflow run: [${workflowRun.id}](${workflowRun.html_url})`,
+    `- Trigger: \`${workflowRun.event}\``,
+    `- Conclusion: \`${workflowRun.conclusion ?? "unknown"}\``,
+  ].join("\n");
+}
+
 function recoveryComment({ workflowRun, issue }) {
   return [
+    recoverySummaryMarker(),
     recoveryMarker(workflowRun.id, workflowRun.run_attempt, issue.number),
     `Recovered on [\`${shortSha(workflowRun.head_sha)}\`](https://github.com/${workflowRun.repository.full_name}/commit/${workflowRun.head_sha}).`,
     "",
@@ -90,11 +113,36 @@ function recoveryComment({ workflowRun, issue }) {
   ].join("\n");
 }
 
+async function listAllPages(fetchPage) {
+  const entries = [];
+  for (let page = 1; ; page += 1) {
+    const pageEntries = await fetchPage(page);
+    entries.push(...pageEntries);
+    if (pageEntries.length < 100) {
+      return entries;
+    }
+  }
+}
+
+function isReporterComment(comment) {
+  return comment.user?.login === REPORTER_BOT_LOGIN;
+}
+
+async function reporterComments(client, issue) {
+  // Unbounded pagination is acceptable for this scheduled operational path,
+  // rather than a merge hot path: an old marker must not silently defeat
+  // idempotency after 100 comments.
+  const comments = await listAllPages((page) =>
+    client.listIssueComments(issue.number, page),
+  );
+  return comments.filter(isReporterComment);
+}
+
 async function issueContains(client, issue, marker) {
   if ((issue.body ?? "").includes(marker)) {
     return true;
   }
-  const comments = await client.listIssueComments(issue.number);
+  const comments = await reporterComments(client, issue);
   return comments.some((comment) => (comment.body ?? "").includes(marker));
 }
 
@@ -114,9 +162,8 @@ export async function reconcileCacheBudgetAudit({
   }
 
   const triggeringRunId = workflowRun.id;
-  const completedRuns = await client.listCompletedWorkflowRuns(
-    workflowRun.workflow_id,
-    defaultBranch,
+  const completedRuns = await listAllPages((page) =>
+    client.listCompletedWorkflowRuns(workflowRun.workflow_id, defaultBranch, page),
   );
   const latest = latestTrustedAuditRun(
     [...completedRuns, workflowRun],
@@ -129,7 +176,9 @@ export async function reconcileCacheBudgetAudit({
   workflowRun.repository = { full_name: repository };
 
   await client.ensureLabel(CACHE_BUDGET_AUDIT_LABEL);
-  const issues = await client.listIssues(CACHE_BUDGET_AUDIT_LABEL);
+  const issues = await listAllPages((page) =>
+    client.listIssues(CACHE_BUDGET_AUDIT_LABEL, page),
+  );
   const issue = issues.find(
     (candidate) =>
       !candidate.pull_request &&
@@ -152,7 +201,31 @@ export async function reconcileCacheBudgetAudit({
       let changed = false;
       const occurrence = occurrenceMarker(workflowRun.id, workflowRun.run_attempt);
       if (!(await issueContains(client, issue, occurrence))) {
-        await client.createIssueComment(issue.number, occurrenceComment({ workflowRun }));
+        const comments = await reporterComments(client, issue);
+        const detailedOccurrences = comments.filter((comment) =>
+          (comment.body ?? "").includes("<!-- cache-budget-audit-occurrence:"),
+        );
+        if (detailedOccurrences.length < MAX_DETAILED_OCCURRENCE_COMMENTS) {
+          await client.createIssueComment(
+            issue.number,
+            occurrenceComment({ workflowRun }),
+          );
+        } else {
+          const summary = comments.find((comment) =>
+            (comment.body ?? "").includes(occurrenceSummaryMarker()),
+          );
+          if (summary) {
+            await client.updateIssueComment(
+              summary.id,
+              occurrenceSummaryComment({ workflowRun }),
+            );
+          } else {
+            await client.createIssueComment(
+              issue.number,
+              occurrenceSummaryComment({ workflowRun }),
+            );
+          }
+        }
         changed = true;
       }
       if (issue.state !== "open") {
@@ -171,10 +244,21 @@ export async function reconcileCacheBudgetAudit({
       issue.number,
     );
     if (!(await issueContains(client, issue, recovery))) {
-      await client.createIssueComment(
-        issue.number,
-        recoveryComment({ workflowRun, issue }),
+      const comments = await reporterComments(client, issue);
+      const summary = comments.find((comment) =>
+        (comment.body ?? "").includes(recoverySummaryMarker()),
       );
+      if (summary) {
+        await client.updateIssueComment(
+          summary.id,
+          recoveryComment({ workflowRun, issue }),
+        );
+      } else {
+        await client.createIssueComment(
+          issue.number,
+          recoveryComment({ workflowRun, issue }),
+        );
+      }
     }
     await client.updateIssue(issue.number, { state: "closed" });
     closed = 1;
@@ -229,11 +313,11 @@ export class GitHubRestClient {
     return `/repos/${this.owner}/${this.repo}${suffix}`;
   }
 
-  async listCompletedWorkflowRuns(workflowId, branch) {
+  async listCompletedWorkflowRuns(workflowId, branch, page) {
     const response = await this.request(
       "GET",
       this.repoPath(
-        `/actions/workflows/${workflowId}/runs?branch=${encodeURIComponent(branch)}&status=completed&per_page=100`,
+        `/actions/workflows/${workflowId}/runs?branch=${encodeURIComponent(branch)}&status=completed&per_page=100&page=${page}`,
       ),
     );
     return response.workflow_runs;
@@ -255,19 +339,19 @@ export class GitHubRestClient {
     }
   }
 
-  async listIssues(label) {
+  async listIssues(label, page) {
     return this.request(
       "GET",
       this.repoPath(
-        `/issues?state=all&labels=${encodeURIComponent(label)}&per_page=100`,
+        `/issues?state=all&labels=${encodeURIComponent(label)}&per_page=100&page=${page}`,
       ),
     );
   }
 
-  async listIssueComments(number) {
+  async listIssueComments(number, page) {
     return this.request(
       "GET",
-      this.repoPath(`/issues/${number}/comments?per_page=100`),
+      this.repoPath(`/issues/${number}/comments?per_page=100&page=${page}`),
     );
   }
 
@@ -279,6 +363,14 @@ export class GitHubRestClient {
     return this.request(
       "POST",
       this.repoPath(`/issues/${number}/comments`),
+      { body },
+    );
+  }
+
+  async updateIssueComment(commentId, body) {
+    return this.request(
+      "PATCH",
+      this.repoPath(`/issues/comments/${commentId}`),
       { body },
     );
   }

--- a/.github/scripts/report-cache-budget-audit.mjs
+++ b/.github/scripts/report-cache-budget-audit.mjs
@@ -116,28 +116,78 @@ function runIdentity(workflowRun) {
   return `${workflowRun.id}:${workflowRun.run_attempt ?? 1}`;
 }
 
-function parsedCursor(comment) {
-  const match = (comment.body ?? "").match(
-    /<!-- cache-budget-audit-cursor:(\d+):(\d+) -->/,
-  );
-  if (!match) {
-    return null;
+function invalidOccurrenceSummary(message) {
+  return new Error(`invalid cache-budget-audit occurrence summary: ${message}`);
+}
+
+function singleSummaryMatch(body, expression, field) {
+  const matches = [...body.matchAll(expression)];
+  if (matches.length !== 1) {
+    throw invalidOccurrenceSummary(`${field} must appear exactly once`);
   }
-  return { run_number: Number(match[1]), run_attempt: Number(match[2]) };
+  return matches[0];
+}
+
+function nonNegativeSafeInteger(value, field) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 0) {
+    throw invalidOccurrenceSummary(`${field} must be a non-negative safe integer`);
+  }
+  return number;
+}
+
+function parsedCursor(comment) {
+  const match = singleSummaryMatch(
+    comment.body ?? "",
+    /<!-- cache-budget-audit-cursor:([^: >]+):([^ >]+) -->/g,
+    "cursor marker",
+  );
+  const runNumber = nonNegativeSafeInteger(match[1], "cursor run number");
+  const runAttempt = nonNegativeSafeInteger(match[2], "cursor run attempt");
+  if (runNumber === 0 || runAttempt === 0) {
+    throw invalidOccurrenceSummary("cursor run number and attempt must be positive");
+  }
+  return { run_number: runNumber, run_attempt: runAttempt };
 }
 
 function parsedCoalesced(comment) {
-  const count = Number(
-    (comment.body ?? "").match(/Coalesced failed attempts: (\d+)\./)?.[1] ?? 0,
+  const body = comment.body ?? "";
+  const countMatch = singleSummaryMatch(
+    body,
+    /Coalesced failed attempts: ([^\n]*)\./g,
+    "coalesced failure count",
   );
-  const identities = (comment.body ?? "")
-    .match(/Recent coalesced identities: (.+)\./)?.[1]
-    ?.split(", ")
-    .filter((identity) => identity !== "none") ?? [];
-  return {
-    count: Number.isSafeInteger(count) && count >= 0 ? count : 0,
-    identities,
-  };
+  const identitiesMatch = singleSummaryMatch(
+    body,
+    /Recent coalesced identities: ([^\n]*)\./g,
+    "coalesced identities",
+  );
+  const count = nonNegativeSafeInteger(countMatch[1], "coalesced failure count");
+  const identitiesText = identitiesMatch[1];
+  const identities = identitiesText === "none" ? [] : identitiesText.split(", ");
+  if (
+    identities.length > MAX_RECENT_COALESCED_IDENTITIES ||
+    identities.some((identity) => !/^\d+:\d+$/.test(identity))
+  ) {
+    throw invalidOccurrenceSummary("coalesced identities must be a bounded run_id:run_attempt list");
+  }
+  return { count, identities };
+}
+
+function occurrenceSummaryState(comment) {
+  return { cursor: parsedCursor(comment), coalesced: parsedCoalesced(comment) };
+}
+
+function sameOccurrenceSummaryState(left, right) {
+  return (
+    left.cursor.run_number === right.cursor.run_number &&
+    left.cursor.run_attempt === right.cursor.run_attempt &&
+    left.coalesced.count === right.coalesced.count &&
+    left.coalesced.identities.length === right.coalesced.identities.length &&
+    left.coalesced.identities.every(
+      (identity, index) => identity === right.coalesced.identities[index],
+    )
+  );
 }
 
 function recordedCursor(issue, comments, runs) {
@@ -200,7 +250,29 @@ async function canonicalSummary(client, comments, marker) {
 }
 
 async function canonicalOccurrenceSummary(client, comments) {
-  return canonicalSummary(client, comments, occurrenceSummaryMarker());
+  const summaries = comments.filter((comment) =>
+    (comment.body ?? "").includes(occurrenceSummaryMarker()),
+  );
+  if (summaries.length <= 1) {
+    if (summaries[0]) {
+      occurrenceSummaryState(summaries[0]);
+    }
+    return summaries[0] ?? null;
+  }
+
+  const canonical = summaries.at(-1);
+  const canonicalState = occurrenceSummaryState(canonical);
+  if (
+    summaries
+      .slice(0, -1)
+      .some((summary) => !sameOccurrenceSummaryState(occurrenceSummaryState(summary), canonicalState))
+  ) {
+    throw invalidOccurrenceSummary("duplicate summaries disagree");
+  }
+  await Promise.all(
+    summaries.slice(0, -1).map((summary) => client.deleteIssueComment(summary.id)),
+  );
+  return canonical;
 }
 
 async function canonicalRecoverySummary(client, comments) {
@@ -243,6 +315,9 @@ export async function reconcileCacheBudgetAudit({
   const completedRuns = await listAllPages((page) =>
     client.listCompletedWorkflowRuns(workflowRun.workflow_id, defaultBranch, page),
   );
+  // GitHub's workflow-runs list endpoint exposes only the latest attempt for
+  // a run ID. Do not infer superseded attempts this reporter could not observe;
+  // coalesced evidence records only attempts returned by that endpoint.
   const trustedRuns = [...new Map(
     [...completedRuns, workflowRun]
       .filter((run) => isTrustedAuditRun(run, defaultBranch, repository))
@@ -260,7 +335,6 @@ export async function reconcileCacheBudgetAudit({
   }
   workflowRun.repository = { full_name: repository };
 
-  await client.ensureLabel(CACHE_BUDGET_AUDIT_LABEL);
   const issues = await listAllPages((page) =>
     client.listIssues(CACHE_BUDGET_AUDIT_LABEL, page),
   );
@@ -293,6 +367,7 @@ export async function reconcileCacheBudgetAudit({
     coalescedFailures = coalescedFailures.filter(
       (run) => runIdentity(run) !== runIdentity(directFailure),
     );
+    await client.ensureLabel(CACHE_BUDGET_AUDIT_LABEL);
     issue = await client.createIssue({
       title: "[cache budget audit] Actions cache budget audit failed on main",
       body: issueBody({ repository, workflowRun: directFailure }),

--- a/.github/scripts/report-cache-budget-audit.mjs
+++ b/.github/scripts/report-cache-budget-audit.mjs
@@ -14,6 +14,11 @@ export const TRUSTED_AUDIT_EVENTS = new Set([
   "workflow_dispatch",
 ]);
 
+const CURRENT_COALESCED_COUNT_PREFIX = "Observable coalesced failed attempts since this summary was created";
+const CURRENT_COALESCED_IDENTITIES_PREFIX = "Recent observable coalesced identities";
+const LEGACY_COALESCED_COUNT_PREFIX = "Coalesced failed attempts";
+const LEGACY_COALESCED_IDENTITIES_PREFIX = "Recent coalesced identities";
+
 function shortSha(sha) {
   return sha?.slice(0, 12) ?? "unknown";
 }
@@ -102,9 +107,9 @@ function occurrenceSummaryComment({ workflowRun, occurrenceRun = workflowRun, co
     occurrenceSummaryMarker(),
     occurrenceMarker(occurrenceRun.id, occurrenceRun.run_attempt),
     coalescingCursorMarker(workflowRun),
-    "This rolling summary records coalesced failures and the latest recurrence.",
-    `Observable coalesced failed attempts in this summary interval: ${coalesced.count}.`,
-    `Recent observable coalesced identities: ${coalesced.identities.length ? coalesced.identities.join(", ") : "none"}.`,
+    "This rolling summary records coalesced failures and its displayed workflow run.",
+    `${CURRENT_COALESCED_COUNT_PREFIX}: ${coalesced.count}.`,
+    `${CURRENT_COALESCED_IDENTITIES_PREFIX}: ${coalesced.identities.length ? coalesced.identities.join(", ") : "none"}.`,
     "",
     `- Workflow run: [${workflowRun.id}](${workflowRun.html_url})`,
     `- Trigger: \`${workflowRun.event}\``,
@@ -163,14 +168,17 @@ function parsedIdentity(identity) {
 
 function parsedCoalesced(comment) {
   const body = comment.body ?? "";
+  // The immediately preceding writer used the legacy prefixes below. Read them
+  // only to migrate existing summaries; remove this branch only in an explicit
+  // schema migration after verifying that no legacy summaries remain.
   const countMatch = singleSummaryMatch(
     body,
-    /Observable coalesced failed attempts in this summary interval: ([^\n]*)\./g,
+    /(?:Observable coalesced failed attempts since this summary was created|Coalesced failed attempts): ([^\n]*)\./g,
     "coalesced failure count",
   );
   const identitiesMatch = singleSummaryMatch(
     body,
-    /Recent observable coalesced identities: ([^\n]*)\./g,
+    /(?:Recent observable coalesced identities|Recent coalesced identities): ([^\n]*)\./g,
     "coalesced identities",
   );
   const count = canonicalDecimalInteger(countMatch[1], "coalesced failure count", 0);
@@ -188,7 +196,7 @@ function parsedCoalesced(comment) {
   return { count, identities };
 }
 
-function occurrenceSummaryState(comment) {
+function parsedOccurrenceSummaryState(comment) {
   return { cursor: parsedCursor(comment), coalesced: parsedCoalesced(comment) };
 }
 
@@ -235,8 +243,19 @@ async function listAllPages(fetchPage) {
   }
 }
 
+function hasReporterCommentPrefix(body) {
+  return (
+    body.startsWith("<!-- cache-budget-audit-occurrence:") ||
+    body.startsWith(occurrenceSummaryMarker()) ||
+    body.startsWith(recoverySummaryMarker())
+  );
+}
+
 function isReporterComment(comment) {
-  return comment.user?.login === REPORTER_BOT_LOGIN;
+  return (
+    comment.user?.login === REPORTER_BOT_LOGIN &&
+    hasReporterCommentPrefix(comment.body ?? "")
+  );
 }
 
 async function reporterComments(client, issue) {
@@ -263,30 +282,46 @@ async function canonicalSummary(client, comments, marker) {
   return canonical;
 }
 
-async function canonicalOccurrenceSummary(client, comments) {
+function occurrenceSummaryPlan(comments) {
   const summaries = comments.filter((comment) =>
     (comment.body ?? "").includes(occurrenceSummaryMarker()),
   );
   if (summaries.length <= 1) {
     if (summaries[0]) {
-      occurrenceSummaryState(summaries[0]);
+      parsedOccurrenceSummaryState(summaries[0]);
     }
-    return summaries[0] ?? null;
+    return { canonical: summaries[0] ?? null, redundant: [] };
   }
 
   const canonical = summaries.at(-1);
-  const canonicalState = occurrenceSummaryState(canonical);
+  const canonicalState = parsedOccurrenceSummaryState(canonical);
   if (
     summaries
       .slice(0, -1)
-      .some((summary) => !sameOccurrenceSummaryState(occurrenceSummaryState(summary), canonicalState))
+      .some((summary) => !sameOccurrenceSummaryState(parsedOccurrenceSummaryState(summary), canonicalState))
   ) {
     throw invalidOccurrenceSummary("duplicate summaries disagree");
   }
+  return { canonical, redundant: summaries.slice(0, -1) };
+}
+
+async function consolidateOccurrenceSummary(client, plan) {
   await Promise.all(
-    summaries.slice(0, -1).map((summary) => client.deleteIssueComment(summary.id)),
+    plan.redundant.map((summary) => client.deleteIssueComment(summary.id)),
   );
-  return canonical;
+}
+
+function nextCoalescedState(coalesced, failures) {
+  if (coalesced.count > Number.MAX_SAFE_INTEGER - failures.length) {
+    throw invalidOccurrenceSummary("coalesced failure count would exceed the safe integer limit");
+  }
+  return {
+    count: coalesced.count + failures.length,
+    identities: [
+      ...coalesced.identities,
+      ...failures.map(runIdentity),
+    ].slice(-MAX_RECENT_COALESCED_IDENTITIES),
+  };
 }
 
 async function canonicalRecoverySummary(client, comments) {
@@ -363,7 +398,8 @@ export async function reconcileCacheBudgetAudit({
   let closed = 0;
 
   let comments = issue ? await reporterComments(client, issue) : [];
-  let summary = issue ? await canonicalOccurrenceSummary(client, comments) : null;
+  let summaryPlan = issue ? occurrenceSummaryPlan(comments) : { canonical: null, redundant: [] };
+  let summary = summaryPlan.canonical;
   let cursor = issue ? (summary ? parsedCursor(summary) : recordedCursor(issue, comments, trustedRuns)) : null;
   if (cursor && isNewerRun(cursor, workflowRun)) {
     throw invalidOccurrenceSummary("cursor must not be newer than observable trusted health");
@@ -375,6 +411,12 @@ export async function reconcileCacheBudgetAudit({
       (!cursor || isNewerRun(run, cursor)) &&
       runIdentity(run) !== runIdentity(workflowRun),
   );
+  nextCoalescedState(coalesced, coalescedFailures);
+  if (summaryPlan.redundant.length > 0) {
+    await consolidateOccurrenceSummary(client, summaryPlan);
+    comments = comments.filter((comment) => !summaryPlan.redundant.includes(comment));
+    summaryPlan = { canonical: summary, redundant: [] };
+  }
 
   // A queue may coalesce a failure behind a later successful reporter run.
   // Preserve that evidence by creating the canonical issue from the newest
@@ -401,7 +443,7 @@ export async function reconcileCacheBudgetAudit({
       const occurrence = occurrenceMarker(workflowRun.id, workflowRun.run_attempt);
       if (!(await issueContains(client, issue, occurrence))) {
         comments = await reporterComments(client, issue);
-        summary = await canonicalOccurrenceSummary(client, comments);
+        summary = occurrenceSummaryPlan(comments).canonical;
         const detailedOccurrences = comments.filter((comment) =>
           (comment.body ?? "").includes("<!-- cache-budget-audit-occurrence:") &&
           !(comment.body ?? "").includes(occurrenceSummaryMarker()),
@@ -462,15 +504,9 @@ export async function reconcileCacheBudgetAudit({
 
   if (issue) {
     comments = await reporterComments(client, issue);
-    summary = await canonicalOccurrenceSummary(client, comments);
+    summary = occurrenceSummaryPlan(comments).canonical;
     coalesced = summary ? parsedCoalesced(summary) : coalesced;
-    coalesced = {
-      count: coalesced.count + coalescedFailures.length,
-      identities: [
-        ...coalesced.identities,
-        ...coalescedFailures.map(runIdentity),
-      ].slice(-MAX_RECENT_COALESCED_IDENTITIES),
-    };
+    coalesced = nextCoalescedState(coalesced, coalescedFailures);
     if (summary || coalescedFailures.length > 0) {
       const occurrenceRun = failed
         ? workflowRun

--- a/.github/scripts/report-cache-budget-audit.mjs
+++ b/.github/scripts/report-cache-budget-audit.mjs
@@ -6,6 +6,8 @@ import { pathToFileURL } from "node:url";
 export const CACHE_BUDGET_AUDIT_LABEL = "ci/cache-budget-audit";
 export const REPORTER_BOT_LOGIN = "github-actions[bot]";
 export const MAX_DETAILED_OCCURRENCE_COMMENTS = 20;
+export const MAX_RECENT_COALESCED_IDENTITIES = 20;
+export const MAX_REPORTER_COMMENTS = MAX_DETAILED_OCCURRENCE_COMMENTS + 2;
 export const TRUSTED_AUDIT_EVENTS = new Set([
   "push",
   "schedule",
@@ -26,6 +28,10 @@ export function occurrenceMarker(runId, runAttempt) {
 
 function occurrenceSummaryMarker() {
   return "<!-- cache-budget-audit-occurrence-summary -->";
+}
+
+function coalescingCursorMarker(workflowRun) {
+  return `<!-- cache-budget-audit-cursor:${workflowRun.run_number}:${workflowRun.run_attempt ?? 1} -->`;
 }
 
 function recoverySummaryMarker() {
@@ -91,16 +97,57 @@ function occurrenceComment({ workflowRun }) {
   ].join("\n");
 }
 
-function occurrenceSummaryComment({ workflowRun }) {
+function occurrenceSummaryComment({ workflowRun, occurrenceRun = workflowRun, coalesced }) {
   return [
     occurrenceSummaryMarker(),
-    occurrenceMarker(workflowRun.id, workflowRun.run_attempt),
+    occurrenceMarker(occurrenceRun.id, occurrenceRun.run_attempt),
+    coalescingCursorMarker(workflowRun),
     "Detailed recurrence comments are capped at 20; this rolling summary records the latest recurrence.",
+    `Coalesced failed attempts: ${coalesced.count}.`,
+    `Recent coalesced identities: ${coalesced.identities.length ? coalesced.identities.join(", ") : "none"}.`,
     "",
     `- Workflow run: [${workflowRun.id}](${workflowRun.html_url})`,
     `- Trigger: \`${workflowRun.event}\``,
     `- Conclusion: \`${workflowRun.conclusion ?? "unknown"}\``,
   ].join("\n");
+}
+
+function runIdentity(workflowRun) {
+  return `${workflowRun.id}:${workflowRun.run_attempt ?? 1}`;
+}
+
+function parsedCursor(comment) {
+  const match = (comment.body ?? "").match(
+    /<!-- cache-budget-audit-cursor:(\d+):(\d+) -->/,
+  );
+  if (!match) {
+    return null;
+  }
+  return { run_number: Number(match[1]), run_attempt: Number(match[2]) };
+}
+
+function parsedCoalesced(comment) {
+  const count = Number(
+    (comment.body ?? "").match(/Coalesced failed attempts: (\d+)\./)?.[1] ?? 0,
+  );
+  const identities = (comment.body ?? "")
+    .match(/Recent coalesced identities: (.+)\./)?.[1]
+    ?.split(", ")
+    .filter((identity) => identity !== "none") ?? [];
+  return {
+    count: Number.isSafeInteger(count) && count >= 0 ? count : 0,
+    identities,
+  };
+}
+
+function recordedCursor(issue, comments, runs) {
+  const bodies = [issue.body ?? "", ...comments.map((comment) => comment.body ?? "")];
+  return runs
+    .filter((run) => bodies.some((body) => body.includes(occurrenceMarker(run.id, run.run_attempt))))
+    .reduce(
+      (latest, run) => (!latest || isNewerRun(run, latest) ? run : latest),
+      null,
+    );
 }
 
 function recoveryComment({ workflowRun, issue }) {
@@ -138,6 +185,37 @@ async function reporterComments(client, issue) {
   return comments.filter(isReporterComment);
 }
 
+async function canonicalSummary(client, comments, marker) {
+  const summaries = comments.filter((comment) =>
+    (comment.body ?? "").includes(marker),
+  );
+  if (summaries.length <= 1) {
+    return summaries[0] ?? null;
+  }
+  const canonical = summaries.at(-1);
+  await Promise.all(
+    summaries.slice(0, -1).map((summary) => client.deleteIssueComment(summary.id)),
+  );
+  return canonical;
+}
+
+async function canonicalOccurrenceSummary(client, comments) {
+  return canonicalSummary(client, comments, occurrenceSummaryMarker());
+}
+
+async function canonicalRecoverySummary(client, comments) {
+  return canonicalSummary(client, comments, recoverySummaryMarker());
+}
+
+async function enforceCommentBudget(client, comments, protectedCommentId = null) {
+  const removable = comments.filter((comment) => comment.id !== protectedCommentId);
+  while (comments.length > MAX_REPORTER_COMMENTS && removable.length > 0) {
+    const comment = removable.shift();
+    await client.deleteIssueComment(comment.id);
+    comments.splice(comments.indexOf(comment), 1);
+  }
+}
+
 async function issueContains(client, issue, marker) {
   if ((issue.body ?? "").includes(marker)) {
     return true;
@@ -165,8 +243,15 @@ export async function reconcileCacheBudgetAudit({
   const completedRuns = await listAllPages((page) =>
     client.listCompletedWorkflowRuns(workflowRun.workflow_id, defaultBranch, page),
   );
+  const trustedRuns = [...new Map(
+    [...completedRuns, workflowRun]
+      .filter((run) => isTrustedAuditRun(run, defaultBranch, repository))
+      .map((run) => [runIdentity(run), run]),
+  ).values()].sort((left, right) =>
+    isNewerRun(left, right) ? 1 : isNewerRun(right, left) ? -1 : 0,
+  );
   const latest = latestTrustedAuditRun(
-    [...completedRuns, workflowRun],
+    trustedRuns,
     defaultBranch,
     repository,
   );
@@ -179,7 +264,7 @@ export async function reconcileCacheBudgetAudit({
   const issues = await listAllPages((page) =>
     client.listIssues(CACHE_BUDGET_AUDIT_LABEL, page),
   );
-  const issue = issues.find(
+  let issue = issues.find(
     (candidate) =>
       !candidate.pull_request &&
       (candidate.body ?? "").includes(cacheBudgetAuditMarker()),
@@ -189,21 +274,45 @@ export async function reconcileCacheBudgetAudit({
   let updated = 0;
   let closed = 0;
 
+  let comments = issue ? await reporterComments(client, issue) : [];
+  let summary = issue ? await canonicalOccurrenceSummary(client, comments) : null;
+  let cursor = issue ? (summary ? parsedCursor(summary) : recordedCursor(issue, comments, trustedRuns)) : null;
+  let coalesced = summary ? parsedCoalesced(summary) : { count: 0, identities: [] };
+  let coalescedFailures = trustedRuns.filter(
+    (run) =>
+      run.conclusion !== "success" &&
+      (!cursor || isNewerRun(run, cursor)) &&
+      runIdentity(run) !== runIdentity(workflowRun),
+  );
+
+  // A queue may coalesce a failure behind a later successful reporter run.
+  // Preserve that evidence by creating the canonical issue from the newest
+  // unseen failure, then immediately reconciling its latest health below.
+  if (!issue && (failed || coalescedFailures.length > 0)) {
+    const directFailure = failed ? workflowRun : coalescedFailures.at(-1);
+    coalescedFailures = coalescedFailures.filter(
+      (run) => runIdentity(run) !== runIdentity(directFailure),
+    );
+    issue = await client.createIssue({
+      title: "[cache budget audit] Actions cache budget audit failed on main",
+      body: issueBody({ repository, workflowRun: directFailure }),
+      labels: [CACHE_BUDGET_AUDIT_LABEL],
+    });
+    created = 1;
+    comments = [];
+    cursor = directFailure;
+  }
+
   if (failed) {
-    if (!issue) {
-      await client.createIssue({
-        title: "[cache budget audit] Actions cache budget audit failed on main",
-        body: issueBody({ repository, workflowRun }),
-        labels: [CACHE_BUDGET_AUDIT_LABEL],
-      });
-      created = 1;
-    } else {
+    if (issue && created === 0) {
       let changed = false;
       const occurrence = occurrenceMarker(workflowRun.id, workflowRun.run_attempt);
       if (!(await issueContains(client, issue, occurrence))) {
-        const comments = await reporterComments(client, issue);
+        comments = await reporterComments(client, issue);
+        summary = await canonicalOccurrenceSummary(client, comments);
         const detailedOccurrences = comments.filter((comment) =>
-          (comment.body ?? "").includes("<!-- cache-budget-audit-occurrence:"),
+          (comment.body ?? "").includes("<!-- cache-budget-audit-occurrence:") &&
+          !(comment.body ?? "").includes(occurrenceSummaryMarker()),
         );
         if (detailedOccurrences.length < MAX_DETAILED_OCCURRENCE_COMMENTS) {
           await client.createIssueComment(
@@ -211,18 +320,15 @@ export async function reconcileCacheBudgetAudit({
             occurrenceComment({ workflowRun }),
           );
         } else {
-          const summary = comments.find((comment) =>
-            (comment.body ?? "").includes(occurrenceSummaryMarker()),
-          );
           if (summary) {
             await client.updateIssueComment(
               summary.id,
-              occurrenceSummaryComment({ workflowRun }),
+              occurrenceSummaryComment({ workflowRun, coalesced }),
             );
           } else {
             await client.createIssueComment(
               issue.number,
-              occurrenceSummaryComment({ workflowRun }),
+              occurrenceSummaryComment({ workflowRun, coalesced }),
             );
           }
         }
@@ -245,9 +351,7 @@ export async function reconcileCacheBudgetAudit({
     );
     if (!(await issueContains(client, issue, recovery))) {
       const comments = await reporterComments(client, issue);
-      const summary = comments.find((comment) =>
-        (comment.body ?? "").includes(recoverySummaryMarker()),
-      );
+      const summary = await canonicalRecoverySummary(client, comments);
       if (summary) {
         await client.updateIssueComment(
           summary.id,
@@ -262,6 +366,43 @@ export async function reconcileCacheBudgetAudit({
     }
     await client.updateIssue(issue.number, { state: "closed" });
     closed = 1;
+  }
+
+  if (issue) {
+    comments = await reporterComments(client, issue);
+    summary = await canonicalOccurrenceSummary(client, comments);
+    coalesced = summary ? parsedCoalesced(summary) : coalesced;
+    coalesced = {
+      count: coalesced.count + coalescedFailures.length,
+      identities: [
+        ...coalesced.identities,
+        ...coalescedFailures.map(runIdentity),
+      ].slice(-MAX_RECENT_COALESCED_IDENTITIES),
+    };
+    if (summary || coalescedFailures.length > 0) {
+      const occurrenceRun = failed
+        ? workflowRun
+        : coalescedFailures.at(-1) ?? workflowRun;
+      if (summary) {
+        await client.updateIssueComment(
+          summary.id,
+          occurrenceSummaryComment({ workflowRun, occurrenceRun, coalesced }),
+        );
+      } else if (comments.length >= MAX_REPORTER_COMMENTS) {
+        const replacement = comments.at(-1);
+        await client.updateIssueComment(
+          replacement.id,
+          occurrenceSummaryComment({ workflowRun, occurrenceRun, coalesced }),
+        );
+      } else {
+        await client.createIssueComment(
+          issue.number,
+          occurrenceSummaryComment({ workflowRun, occurrenceRun, coalesced }),
+        );
+      }
+    }
+    comments = await reporterComments(client, issue);
+    await enforceCommentBudget(client, comments);
   }
 
   const result = { created, updated, closed, failed };
@@ -372,6 +513,13 @@ export class GitHubRestClient {
       "PATCH",
       this.repoPath(`/issues/comments/${commentId}`),
       { body },
+    );
+  }
+
+  async deleteIssueComment(commentId) {
+    return this.request(
+      "DELETE",
+      this.repoPath(`/issues/comments/${commentId}`),
     );
   }
 

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   CACHE_BUDGET_AUDIT_LABEL,
@@ -17,6 +17,7 @@ import {
 } from "./report-cache-budget-audit.mjs";
 
 const REPORTER_PATH = fileURLToPath(new URL("./report-cache-budget-audit.mjs", import.meta.url));
+const INTERVAL_WRITER_COMMIT = "0237fb1";
 
 class FakeClient {
   constructor({ issues = [], comments = [], completedRuns = [] } = {}) {
@@ -138,6 +139,42 @@ function legacyOccurrenceSummaryBody(options = {}) {
       "Coalesced failed attempts",
     )
     .replace("Recent observable coalesced identities", "Recent coalesced identities");
+}
+
+async function directParentOccurrenceSummaryBody() {
+  // Commit 0237fb1 is the reviewed predecessor whose writer emitted the
+  // interval wording. Load and run that writer, rather than reconstruct
+  // its output in this test, so compatibility follows actual persisted state.
+  const source = execFileSync(
+    "git",
+    ["show", `${INTERVAL_WRITER_COMMIT}:.github/scripts/report-cache-budget-audit.mjs`],
+    { encoding: "utf8" },
+  );
+  const directory = await mkdtemp(join(tmpdir(), "fsl-cache-audit-parent-writer-"));
+  const parentReporterPath = join(directory, "report-cache-budget-audit.mjs");
+  await writeFile(parentReporterPath, source);
+
+  try {
+    const { reconcileCacheBudgetAudit: reconcileParent } = await import(
+      `${pathToFileURL(parentReporterPath).href}?parent=${INTERVAL_WRITER_COMMIT}`,
+    );
+    const parentClient = new FakeClient({
+      completedRuns: [workflowRun({ id: 41, run_number: 12 })],
+    });
+    await reconcileParent({
+      client: parentClient,
+      repository: "ymm-oss/fsl",
+      defaultBranch: "main",
+      workflowRun: workflowRun({ id: 42, run_number: 13 }),
+    });
+    const summary = parentClient.comments.find((comment) =>
+      comment.body.includes("cache-budget-audit-occurrence-summary"),
+    );
+    assert.ok(summary, "the parent writer must produce an occurrence summary");
+    return summary.body;
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
 }
 
 function clientWithOccurrenceSummary(bodies) {
@@ -437,7 +474,7 @@ test("replaying an already-summarised run does not PATCH identical content", asy
   assert.equal(client.updatedComments, updatesBeforeReplay);
 });
 
-test("a legacy summary migrates to the qualified format", async () => {
+test("an original unqualified summary migrates to the qualified format", async () => {
   const client = clientWithOccurrenceSummary([legacyOccurrenceSummaryBody()]);
 
   await reconcile(client, workflowRun({ id: 50, run_number: 13 }));
@@ -447,6 +484,26 @@ test("a legacy summary migrates to the qualified format", async () => {
     /Observable coalesced failed attempts since this summary was created: 7\./,
   );
   assert.doesNotMatch(client.comments[0].body, /Coalesced failed attempts: 7\./);
+});
+
+test("the direct-parent interval summary migrates to the current format", async () => {
+  const parentSummary = await directParentOccurrenceSummaryBody();
+  assert.match(
+    parentSummary,
+    /Observable coalesced failed attempts in this summary interval: 1\./,
+  );
+  const client = clientWithOccurrenceSummary([parentSummary]);
+
+  await reconcile(client, workflowRun({ id: 50, run_number: 14 }));
+
+  assert.match(
+    client.comments[0].body,
+    /Observable coalesced failed attempts since this summary was created: 1\./,
+  );
+  assert.doesNotMatch(
+    client.comments[0].body,
+    /Observable coalesced failed attempts in this summary interval/,
+  );
 });
 
 test("a bot quote of an occurrence marker cannot suppress a recurrence", async () => {
@@ -467,6 +524,40 @@ test("a bot quote of an occurrence marker cannot suppress a recurrence", async (
     client.comments.filter((comment) => comment.body.startsWith("<!-- cache-budget-audit-occurrence:")).length,
     1,
   );
+});
+
+test("a bot comment with a partial occurrence marker cannot suppress a recurrence", async () => {
+  const client = new FakeClient();
+  await reconcile(client, workflowRun());
+  const run = workflowRun({ id: 42, run_number: 13 });
+  client.comments.push({
+    id: 1,
+    issue: 100,
+    body: "<!-- cache-budget-audit-occurrence:42:",
+    user: { login: "github-actions[bot]" },
+  });
+
+  const result = await reconcile(client, run);
+
+  assert.equal(result.updated, 1);
+  assert.equal(
+    client.comments.filter((comment) => comment.body.startsWith(occurrenceMarker(42, 1))).length,
+    1,
+  );
+});
+
+test("write-side identity deduplication preserves parser round trips", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ cursor: "12:1", count: "1", identities: "42:1" }),
+  ]);
+  client.completedRuns = [workflowRun({ id: 42, run_number: 13 })];
+
+  await reconcile(client, workflowRun({ id: 43, run_number: 14, conclusion: "success" }));
+
+  const summary = client.comments[0];
+  assert.match(summary.body, /Observable coalesced failed attempts since this summary was created: 1\./);
+  assert.match(summary.body, /Recent observable coalesced identities: 42:1\./);
+  await reconcile(client, workflowRun({ id: 43, run_number: 14, conclusion: "success" }));
 });
 
 test("a safe-boundary count round-trips and overflow rejects before mutation", async () => {

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -63,6 +63,13 @@ class FakeClient {
     this.updatedComments += 1;
   }
 
+  async deleteIssueComment(commentId) {
+    this.comments.splice(
+      this.comments.findIndex((comment) => comment.id === commentId),
+      1,
+    );
+  }
+
   async updateIssue(number, update) {
     Object.assign(
       this.issues.find((issue) => issue.number === number),
@@ -206,7 +213,8 @@ test("a marker beyond the first comment page remains idempotent", async () => {
   const result = await reconcile(client, run);
 
   assert.deepEqual(result, { created: 0, updated: 0, closed: 0, failed: true });
-  assert.equal(client.comments.length, 101);
+  assert.equal(client.comments.length, MAX_DETAILED_OCCURRENCE_COMMENTS + 2);
+  assert.ok(client.comments.some((comment) => comment.id === 101));
 });
 
 test("a non-bot occurrence marker cannot suppress the reporter audit trail", async () => {
@@ -243,7 +251,7 @@ test("recurrence comments are bounded by a rolling summary", async () => {
   }
 
   assert.equal(client.comments.length, MAX_DETAILED_OCCURRENCE_COMMENTS + 1);
-  assert.equal(client.updatedComments, 7);
+  assert.ok(client.updatedComments >= 7);
   assert.match(
     client.comments.at(-1).body,
     /cache-budget-audit-occurrence-summary/,
@@ -277,6 +285,55 @@ test("recovery flapping cannot grow reporter comments without bound", async () =
   assert.equal(
     client.comments.filter((comment) =>
       comment.body.includes("cache-budget-audit-recovery-summary"),
+    ).length,
+    1,
+  );
+});
+
+test("coalesced intermediate failures retain a count and recent identities", async () => {
+  const client = new FakeClient({
+    completedRuns: [
+      workflowRun({ id: 41, run_number: 12 }),
+      workflowRun({ id: 42, run_number: 13 }),
+    ],
+  });
+
+  await reconcile(client, workflowRun({ id: 43, run_number: 14 }));
+
+  const summary = client.comments.find((comment) =>
+    comment.body.includes("cache-budget-audit-occurrence-summary"),
+  );
+  assert.match(summary.body, /Coalesced failed attempts: 2\./);
+  assert.match(summary.body, /41:1, 42:1/);
+  assert.match(client.issues[0].body, /cache-budget-audit-occurrence:43:1/);
+});
+
+test("duplicate or marker-edited summaries self-heal within the comment bound", async () => {
+  const client = new FakeClient();
+  await reconcile(client, workflowRun());
+  for (let offset = 1; offset <= MAX_DETAILED_OCCURRENCE_COMMENTS + 1; offset += 1) {
+    await reconcile(client, workflowRun({ id: 41 + offset, run_number: 12 + offset }));
+  }
+  const summary = client.comments.find((comment) =>
+    comment.body.includes("cache-budget-audit-occurrence-summary"),
+  );
+  summary.body = "<!-- cache-budget-audit-occurrence-summary --> edited";
+  client.comments.push({
+    id: 9999,
+    issue: 100,
+    body: "<!-- cache-budget-audit-occurrence-summary --> duplicate",
+    user: { login: "github-actions[bot]" },
+  });
+
+  await reconcile(
+    client,
+    workflowRun({ id: 99, run_number: 99, conclusion: "success" }),
+  );
+
+  assert.ok(client.comments.length <= MAX_DETAILED_OCCURRENCE_COMMENTS + 2);
+  assert.equal(
+    client.comments.filter((comment) =>
+      comment.body.includes("cache-budget-audit-occurrence-summary"),
     ).length,
     1,
   );

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -439,6 +439,7 @@ test("historical summary fixtures are provenance-bound and need no Git history",
       {
         writerCommit: "cbb00dca5acf99742743a22dd33affa29378d85e",
         writerSha256: "3dc17ad18cd035bb9ef197742e283d47e4d6d00169941255aef837cb673185e9",
+        outputSha256: "6ea77d6d6b95de9f6acbfec0a00cfd4d13aae0135d436969aa1de34d2937d649",
       },
     ],
     [
@@ -446,6 +447,7 @@ test("historical summary fixtures are provenance-bound and need no Git history",
       {
         writerCommit: "0237fb1fe2b30911ddd5cdf60de1020810e72164",
         writerSha256: "d8618cd5d2bf8d8c99c8b0093d7e55b34fd37240f71ee30cfed32a85bea90833",
+        outputSha256: "81b01087c076b23e2a804ff0398d62b84017780d73a07b0d72f113fbe12b1ddf",
       },
     ],
   ]);
@@ -458,6 +460,7 @@ test("historical summary fixtures are provenance-bound and need no Git history",
       {
         writerCommit: fixture.provenance.writerCommit,
         writerSha256: fixture.provenance.writerSha256,
+        outputSha256: fixture.provenance.outputSha256,
       },
       expectedProvenance.get(fixture.id),
     );

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -17,6 +17,7 @@ import {
 } from "./report-cache-budget-audit.mjs";
 
 const REPORTER_PATH = fileURLToPath(new URL("./report-cache-budget-audit.mjs", import.meta.url));
+const ORIGINAL_WRITER_COMMIT = "cbb00dc";
 const INTERVAL_WRITER_COMMIT = "0237fb1";
 
 class FakeClient {
@@ -128,26 +129,12 @@ function occurrenceSummaryBody({
   ].join("\n");
 }
 
-function legacyOccurrenceSummaryBody(options = {}) {
-  return occurrenceSummaryBody(options)
-    .replace(
-      "This rolling summary records coalesced failures and its displayed workflow run.",
-      "Detailed recurrence comments are capped at 20; this rolling summary records the latest recurrence.",
-    )
-    .replace(
-      "Observable coalesced failed attempts since this summary was created",
-      "Coalesced failed attempts",
-    )
-    .replace("Recent observable coalesced identities", "Recent coalesced identities");
-}
-
-async function directParentOccurrenceSummaryBody() {
-  // Commit 0237fb1 is the reviewed predecessor whose writer emitted the
-  // interval wording. Load and run that writer, rather than reconstruct
-  // its output in this test, so compatibility follows actual persisted state.
+async function historicalWriterOccurrenceSummaryBody(commit) {
+  // Run the historical writer rather than reconstruct its output in this test,
+  // so each compatibility control follows actual persisted state.
   const source = execFileSync(
     "git",
-    ["show", `${INTERVAL_WRITER_COMMIT}:.github/scripts/report-cache-budget-audit.mjs`],
+    ["show", `${commit}:.github/scripts/report-cache-budget-audit.mjs`],
     { encoding: "utf8" },
   );
   const directory = await mkdtemp(join(tmpdir(), "fsl-cache-audit-parent-writer-"));
@@ -156,7 +143,7 @@ async function directParentOccurrenceSummaryBody() {
 
   try {
     const { reconcileCacheBudgetAudit: reconcileParent } = await import(
-      `${pathToFileURL(parentReporterPath).href}?parent=${INTERVAL_WRITER_COMMIT}`,
+      `${pathToFileURL(parentReporterPath).href}?writer=${commit}`,
     );
     const parentClient = new FakeClient({
       completedRuns: [workflowRun({ id: 41, run_number: 12 })],
@@ -475,19 +462,21 @@ test("replaying an already-summarised run does not PATCH identical content", asy
 });
 
 test("an original unqualified summary migrates to the qualified format", async () => {
-  const client = clientWithOccurrenceSummary([legacyOccurrenceSummaryBody()]);
+  const originalSummary = await historicalWriterOccurrenceSummaryBody(ORIGINAL_WRITER_COMMIT);
+  assert.match(originalSummary, /Coalesced failed attempts: 1\./);
+  const client = clientWithOccurrenceSummary([originalSummary]);
 
   await reconcile(client, workflowRun({ id: 50, run_number: 13 }));
 
   assert.match(
     client.comments[0].body,
-    /Observable coalesced failed attempts since this summary was created: 7\./,
+    /Observable coalesced failed attempts since this summary was created: 1\./,
   );
-  assert.doesNotMatch(client.comments[0].body, /Coalesced failed attempts: 7\./);
+  assert.doesNotMatch(client.comments[0].body, /Coalesced failed attempts: 1\./);
 });
 
 test("the direct-parent interval summary migrates to the current format", async () => {
-  const parentSummary = await directParentOccurrenceSummaryBody();
+  const parentSummary = await historicalWriterOccurrenceSummaryBody(INTERVAL_WRITER_COMMIT);
   assert.match(
     parentSummary,
     /Observable coalesced failed attempts in this summary interval: 1\./,

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -103,6 +103,47 @@ async function reconcile(client, run) {
   });
 }
 
+function occurrenceSummaryBody({
+  cursor = "12:1",
+  count = "7",
+  identities = "41:1",
+} = {}) {
+  return [
+    "<!-- cache-budget-audit-occurrence-summary -->",
+    occurrenceMarker(41, 1),
+    ...(cursor === null ? [] : [`<!-- cache-budget-audit-cursor:${cursor} -->`]),
+    "Detailed recurrence comments are capped at 20; this rolling summary records the latest recurrence.",
+    `Coalesced failed attempts: ${count}.`,
+    `Recent coalesced identities: ${identities}.`,
+  ].join("\n");
+}
+
+function clientWithOccurrenceSummary(bodies) {
+  return new FakeClient({
+    issues: [{ number: 100, state: "open", body: cacheBudgetAuditMarker() }],
+    comments: bodies.map((body, index) => ({
+      id: index + 1,
+      issue: 100,
+      body,
+      user: { login: "github-actions[bot]" },
+    })),
+  });
+}
+
+async function assertOccurrenceSummaryRejected(client, expected) {
+  const issueBefore = structuredClone(client.issues);
+  const commentsBefore = structuredClone(client.comments);
+
+  await assert.rejects(
+    reconcile(client, workflowRun({ id: 50, run_number: 13 })),
+    expected,
+  );
+
+  assert.deepEqual(client.issues, issueBefore);
+  assert.deepEqual(client.comments, commentsBefore);
+  assert.equal(client.labels.size, 0);
+}
+
 test("first failure files one canonical issue", async () => {
   const client = new FakeClient();
 
@@ -308,7 +349,27 @@ test("coalesced intermediate failures retain a count and recent identities", asy
   assert.match(client.issues[0].body, /cache-budget-audit-occurrence:43:1/);
 });
 
-test("duplicate or marker-edited summaries self-heal within the comment bound", async () => {
+test("coalescing records only the latest same-run attempt exposed by the list API", async () => {
+  const supersededAttempt = workflowRun({ id: 42, run_number: 13, run_attempt: 1 });
+  const listedLatestAttempt = workflowRun({ id: 42, run_number: 13, run_attempt: 2 });
+  const client = new FakeClient({
+    completedRuns: [
+      workflowRun({ id: 41, run_number: 12 }),
+      listedLatestAttempt,
+    ],
+  });
+
+  await reconcile(client, workflowRun({ id: 43, run_number: 14 }));
+
+  const summary = client.comments.find((comment) =>
+    comment.body.includes("cache-budget-audit-occurrence-summary"),
+  );
+  assert.match(summary.body, /Coalesced failed attempts: 2\./);
+  assert.match(summary.body, /41:1, 42:2/);
+  assert.doesNotMatch(summary.body, new RegExp(`${supersededAttempt.id}:1`));
+});
+
+test("duplicate identical summaries self-heal within the comment bound", async () => {
   const client = new FakeClient();
   await reconcile(client, workflowRun());
   for (let offset = 1; offset <= MAX_DETAILED_OCCURRENCE_COMMENTS + 1; offset += 1) {
@@ -317,11 +378,10 @@ test("duplicate or marker-edited summaries self-heal within the comment bound", 
   const summary = client.comments.find((comment) =>
     comment.body.includes("cache-budget-audit-occurrence-summary"),
   );
-  summary.body = "<!-- cache-budget-audit-occurrence-summary --> edited";
   client.comments.push({
     id: 9999,
     issue: 100,
-    body: "<!-- cache-budget-audit-occurrence-summary --> duplicate",
+    body: summary.body,
     user: { login: "github-actions[bot]" },
   });
 
@@ -336,5 +396,73 @@ test("duplicate or marker-edited summaries self-heal within the comment bound", 
       comment.body.includes("cache-budget-audit-occurrence-summary"),
     ).length,
     1,
+  );
+});
+
+test("a non-numeric coalesced count fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: "not-a-number" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced failure count must be a non-negative safe integer/,
+  );
+});
+
+test("a negative coalesced count fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: "-1" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced failure count must be a non-negative safe integer/,
+  );
+});
+
+test("an unsafe coalesced count fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: "9007199254740992" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced failure count must be a non-negative safe integer/,
+  );
+});
+
+test("a valid and malformed duplicate summary fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody(),
+    occurrenceSummaryBody({ count: "not-a-number" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced failure count must be a non-negative safe integer/,
+  );
+});
+
+test("a missing cursor with a valid count fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ cursor: null, count: "7" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /cursor marker must appear exactly once/,
+  );
+});
+
+test("conflicting valid duplicate summaries fail closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: "7" }),
+    occurrenceSummaryBody({ count: "6" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /duplicate summaries disagree/,
   );
 });

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 import {
   CACHE_BUDGET_AUDIT_LABEL,
@@ -15,10 +16,9 @@ import {
   occurrenceMarker,
   reconcileCacheBudgetAudit,
 } from "./report-cache-budget-audit.mjs";
+import { HISTORICAL_SUMMARY_FIXTURES } from "./fixtures/cache-budget-audit-summary-fixtures.mjs";
 
 const REPORTER_PATH = fileURLToPath(new URL("./report-cache-budget-audit.mjs", import.meta.url));
-const ORIGINAL_WRITER_COMMIT = "cbb00dc";
-const INTERVAL_WRITER_COMMIT = "0237fb1";
 
 class FakeClient {
   constructor({ issues = [], comments = [], completedRuns = [] } = {}) {
@@ -129,39 +129,10 @@ function occurrenceSummaryBody({
   ].join("\n");
 }
 
-async function historicalWriterOccurrenceSummaryBody(commit) {
-  // Run the historical writer rather than reconstruct its output in this test,
-  // so each compatibility control follows actual persisted state.
-  const source = execFileSync(
-    "git",
-    ["show", `${commit}:.github/scripts/report-cache-budget-audit.mjs`],
-    { encoding: "utf8" },
-  );
-  const directory = await mkdtemp(join(tmpdir(), "fsl-cache-audit-parent-writer-"));
-  const parentReporterPath = join(directory, "report-cache-budget-audit.mjs");
-  await writeFile(parentReporterPath, source);
-
-  try {
-    const { reconcileCacheBudgetAudit: reconcileParent } = await import(
-      `${pathToFileURL(parentReporterPath).href}?writer=${commit}`,
-    );
-    const parentClient = new FakeClient({
-      completedRuns: [workflowRun({ id: 41, run_number: 12 })],
-    });
-    await reconcileParent({
-      client: parentClient,
-      repository: "ymm-oss/fsl",
-      defaultBranch: "main",
-      workflowRun: workflowRun({ id: 42, run_number: 13 }),
-    });
-    const summary = parentClient.comments.find((comment) =>
-      comment.body.includes("cache-budget-audit-occurrence-summary"),
-    );
-    assert.ok(summary, "the parent writer must produce an occurrence summary");
-    return summary.body;
-  } finally {
-    await rm(directory, { force: true, recursive: true });
-  }
+function historicalSummaryFixture(id) {
+  const fixture = HISTORICAL_SUMMARY_FIXTURES.find((candidate) => candidate.id === id);
+  assert.ok(fixture, `missing historical summary fixture '${id}'`);
+  return fixture;
 }
 
 function clientWithOccurrenceSummary(bodies) {
@@ -461,10 +432,61 @@ test("replaying an already-summarised run does not PATCH identical content", asy
   assert.equal(client.updatedComments, updatesBeforeReplay);
 });
 
+test("historical summary fixtures are provenance-bound and need no Git history", async () => {
+  const expectedProvenance = new Map([
+    [
+      "original-unqualified",
+      {
+        writerCommit: "cbb00dca5acf99742743a22dd33affa29378d85e",
+        writerSha256: "3dc17ad18cd035bb9ef197742e283d47e4d6d00169941255aef837cb673185e9",
+      },
+    ],
+    [
+      "interval-qualified",
+      {
+        writerCommit: "0237fb1fe2b30911ddd5cdf60de1020810e72164",
+        writerSha256: "d8618cd5d2bf8d8c99c8b0093d7e55b34fd37240f71ee30cfed32a85bea90833",
+      },
+    ],
+  ]);
+  assert.deepEqual(
+    HISTORICAL_SUMMARY_FIXTURES.map((fixture) => fixture.id),
+    [...expectedProvenance.keys()],
+  );
+  for (const fixture of HISTORICAL_SUMMARY_FIXTURES) {
+    assert.deepEqual(
+      {
+        writerCommit: fixture.provenance.writerCommit,
+        writerSha256: fixture.provenance.writerSha256,
+      },
+      expectedProvenance.get(fixture.id),
+    );
+    assert.equal(
+      fixture.provenance.captureCommand,
+      `node .github/scripts/capture-cache-budget-audit-summary-fixture.mjs ${fixture.provenance.writerCommit}`,
+    );
+    assert.equal(
+      createHash("sha256").update(fixture.body).digest("hex"),
+      fixture.provenance.outputSha256,
+    );
+  }
+
+  // merge-readiness.yml's automation-contracts checkout has fetch-depth: 0,
+  // but this control must also pass in a shallow local clone: tests consume
+  // committed outputs and never look up their historical writer commits.
+  const testSource = await readFile(fileURLToPath(import.meta.url), "utf8");
+  const forbiddenHistoryApi = `exec${"FileSync"}`;
+  const forbiddenGitLookup = new RegExp(
+    [String.raw`["']git["']`, String.raw`["']show["']`].join(String.raw`\s*,\s*\[\s*`),
+  );
+  assert.doesNotMatch(testSource, new RegExp(`\\b${forbiddenHistoryApi}\\b`));
+  assert.doesNotMatch(testSource, forbiddenGitLookup);
+});
+
 test("an original unqualified summary migrates to the qualified format", async () => {
-  const originalSummary = await historicalWriterOccurrenceSummaryBody(ORIGINAL_WRITER_COMMIT);
-  assert.match(originalSummary, /Coalesced failed attempts: 1\./);
-  const client = clientWithOccurrenceSummary([originalSummary]);
+  const originalFixture = historicalSummaryFixture("original-unqualified");
+  assert.match(originalFixture.body, /Coalesced failed attempts: 1\./);
+  const client = clientWithOccurrenceSummary([originalFixture.body]);
 
   await reconcile(client, workflowRun({ id: 50, run_number: 13 }));
 
@@ -476,7 +498,7 @@ test("an original unqualified summary migrates to the qualified format", async (
 });
 
 test("the direct-parent interval summary migrates to the current format", async () => {
-  const parentSummary = await historicalWriterOccurrenceSummaryBody(INTERVAL_WRITER_COMMIT);
+  const parentSummary = historicalSummaryFixture("interval-qualified").body;
   assert.match(
     parentSummary,
     /Observable coalesced failed attempts in this summary interval: 1\./,

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CACHE_BUDGET_AUDIT_LABEL,
+  cacheBudgetAuditMarker,
+  reconcileCacheBudgetAudit,
+} from "./report-cache-budget-audit.mjs";
+
+class FakeClient {
+  constructor({ issues = [], comments = [], completedRuns = [] } = {}) {
+    this.issues = issues;
+    this.comments = comments;
+    this.completedRuns = completedRuns;
+    this.labels = new Set();
+    this.nextIssue = 100;
+  }
+
+  async listCompletedWorkflowRuns() {
+    return this.completedRuns;
+  }
+
+  async ensureLabel(name) {
+    this.labels.add(name);
+  }
+
+  async listIssues() {
+    return this.issues;
+  }
+
+  async listIssueComments(number) {
+    return this.comments.filter((comment) => comment.issue === number);
+  }
+
+  async createIssue(issue) {
+    const created = { ...issue, number: this.nextIssue, state: "open" };
+    this.nextIssue += 1;
+    this.issues.push(created);
+    return created;
+  }
+
+  async createIssueComment(number, body) {
+    this.comments.push({ issue: number, body });
+  }
+
+  async updateIssue(number, update) {
+    Object.assign(
+      this.issues.find((issue) => issue.number === number),
+      update,
+    );
+  }
+}
+
+function workflowRun(overrides = {}) {
+  return {
+    id: 41,
+    workflow_id: 7,
+    run_number: 12,
+    run_attempt: 1,
+    conclusion: "failure",
+    event: "schedule",
+    head_branch: "main",
+    head_repository: { full_name: "ymm-oss/fsl" },
+    head_sha: "0123456789abcdef0123456789abcdef01234567",
+    html_url: "https://github.com/ymm-oss/fsl/actions/runs/41",
+    ...overrides,
+  };
+}
+
+async function reconcile(client, run) {
+  return reconcileCacheBudgetAudit({
+    client,
+    repository: "ymm-oss/fsl",
+    defaultBranch: "main",
+    workflowRun: run,
+  });
+}
+
+test("first failure files one canonical issue", async () => {
+  const client = new FakeClient();
+
+  const result = await reconcile(client, workflowRun());
+
+  assert.deepEqual(result, { created: 1, updated: 0, closed: 0, failed: true });
+  assert.equal(client.issues.length, 1);
+  assert.ok(client.issues[0].body.includes(cacheBudgetAuditMarker()));
+  assert.deepEqual(client.issues[0].labels, [CACHE_BUDGET_AUDIT_LABEL]);
+});
+
+test("the same run is idempotent", async () => {
+  const client = new FakeClient();
+  const run = workflowRun();
+
+  await reconcile(client, run);
+  const result = await reconcile(client, run);
+
+  assert.deepEqual(result, { created: 0, updated: 0, closed: 0, failed: true });
+  assert.equal(client.issues.length, 1);
+  assert.equal(client.comments.length, 0);
+});
+
+test("a distinct later failure comments on the canonical issue", async () => {
+  const client = new FakeClient();
+
+  await reconcile(client, workflowRun());
+  const result = await reconcile(
+    client,
+    workflowRun({ id: 42, run_number: 13, head_sha: "abcdef0123456789abcdef0123456789abcdef01" }),
+  );
+
+  assert.deepEqual(result, { created: 0, updated: 1, closed: 0, failed: true });
+  assert.equal(client.issues.length, 1);
+  assert.equal(client.comments.length, 1);
+  assert.match(client.comments[0].body, /failure recurred/);
+});
+
+test("a later success closes the canonical issue", async () => {
+  const client = new FakeClient();
+
+  await reconcile(client, workflowRun());
+  const result = await reconcile(
+    client,
+    workflowRun({ id: 42, run_number: 13, conclusion: "success" }),
+  );
+
+  assert.deepEqual(result, { created: 0, updated: 0, closed: 1, failed: false });
+  assert.equal(client.issues[0].state, "closed");
+  assert.match(client.comments[0].body, /Recovered on/);
+});
+
+test("a later failure reopens the canonical issue", async () => {
+  const client = new FakeClient();
+
+  await reconcile(client, workflowRun());
+  await reconcile(client, workflowRun({ id: 42, run_number: 13, conclusion: "success" }));
+  const result = await reconcile(client, workflowRun({ id: 43, run_number: 14 }));
+
+  assert.deepEqual(result, { created: 0, updated: 1, closed: 0, failed: true });
+  assert.equal(client.issues.length, 1);
+  assert.equal(client.issues[0].state, "open");
+  assert.equal(client.comments.length, 2);
+});
+
+test("a stale failure event reconciles newer recovered health instead", async () => {
+  const client = new FakeClient();
+
+  await reconcile(client, workflowRun());
+  client.completedRuns = [
+    workflowRun({ id: 42, run_number: 13, conclusion: "success" }),
+  ];
+  const result = await reconcile(client, workflowRun());
+
+  assert.deepEqual(result, {
+    created: 0,
+    updated: 0,
+    closed: 1,
+    failed: false,
+    redirectedFromRunId: 41,
+    reconciledRunId: 42,
+  });
+  assert.equal(client.issues.length, 1);
+  assert.equal(client.issues[0].state, "closed");
+});

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -5,7 +5,9 @@ import test from "node:test";
 
 import {
   CACHE_BUDGET_AUDIT_LABEL,
+  MAX_DETAILED_OCCURRENCE_COMMENTS,
   cacheBudgetAuditMarker,
+  occurrenceMarker,
   reconcileCacheBudgetAudit,
 } from "./report-cache-budget-audit.mjs";
 
@@ -16,22 +18,26 @@ class FakeClient {
     this.completedRuns = completedRuns;
     this.labels = new Set();
     this.nextIssue = 100;
+    this.nextComment = 1000;
+    this.updatedComments = 0;
   }
 
-  async listCompletedWorkflowRuns() {
-    return this.completedRuns;
+  async listCompletedWorkflowRuns(_workflowId, _branch, page) {
+    return this.completedRuns.slice((page - 1) * 100, page * 100);
   }
 
   async ensureLabel(name) {
     this.labels.add(name);
   }
 
-  async listIssues() {
-    return this.issues;
+  async listIssues(_label, page) {
+    return this.issues.slice((page - 1) * 100, page * 100);
   }
 
-  async listIssueComments(number) {
-    return this.comments.filter((comment) => comment.issue === number);
+  async listIssueComments(number, page) {
+    return this.comments
+      .filter((comment) => comment.issue === number)
+      .slice((page - 1) * 100, page * 100);
   }
 
   async createIssue(issue) {
@@ -42,7 +48,19 @@ class FakeClient {
   }
 
   async createIssueComment(number, body) {
-    this.comments.push({ issue: number, body });
+    this.comments.push({
+      id: this.nextComment,
+      issue: number,
+      body,
+      user: { login: "github-actions[bot]" },
+    });
+    this.nextComment += 1;
+  }
+
+  async updateIssueComment(commentId, body) {
+    const comment = this.comments.find((candidate) => candidate.id === commentId);
+    comment.body = body;
+    this.updatedComments += 1;
   }
 
   async updateIssue(number, update) {
@@ -162,4 +180,104 @@ test("a stale failure event reconciles newer recovered health instead", async ()
   });
   assert.equal(client.issues.length, 1);
   assert.equal(client.issues[0].state, "closed");
+});
+
+test("a marker beyond the first comment page remains idempotent", async () => {
+  const run = workflowRun({ id: 42, run_number: 13 });
+  const issue = {
+    number: 100,
+    state: "open",
+    body: cacheBudgetAuditMarker(),
+  };
+  const comments = Array.from({ length: 100 }, (_value, index) => ({
+    id: index + 1,
+    issue: 100,
+    body: `filler ${index}`,
+    user: { login: "github-actions[bot]" },
+  }));
+  comments.push({
+    id: 101,
+    issue: 100,
+    body: occurrenceMarker(run.id, run.run_attempt),
+    user: { login: "github-actions[bot]" },
+  });
+  const client = new FakeClient({ issues: [issue], comments });
+
+  const result = await reconcile(client, run);
+
+  assert.deepEqual(result, { created: 0, updated: 0, closed: 0, failed: true });
+  assert.equal(client.comments.length, 101);
+});
+
+test("a non-bot occurrence marker cannot suppress the reporter audit trail", async () => {
+  const client = new FakeClient();
+  await reconcile(client, workflowRun());
+  const run = workflowRun({ id: 42, run_number: 13 });
+  client.comments.push({
+    id: 1,
+    issue: 100,
+    body: occurrenceMarker(run.id, run.run_attempt),
+    user: { login: "human-reviewer" },
+  });
+
+  const result = await reconcile(client, run);
+
+  assert.equal(result.updated, 1);
+  assert.equal(client.comments.length, 2);
+  assert.equal(client.comments[1].user.login, "github-actions[bot]");
+});
+
+test("recurrence comments are bounded by a rolling summary", async () => {
+  const client = new FakeClient();
+  await reconcile(client, workflowRun());
+
+  for (let offset = 1; offset <= MAX_DETAILED_OCCURRENCE_COMMENTS + 8; offset += 1) {
+    await reconcile(
+      client,
+      workflowRun({
+        id: 41 + offset,
+        run_number: 12 + offset,
+        head_sha: `${offset}`.padStart(40, "0"),
+      }),
+    );
+  }
+
+  assert.equal(client.comments.length, MAX_DETAILED_OCCURRENCE_COMMENTS + 1);
+  assert.equal(client.updatedComments, 7);
+  assert.match(
+    client.comments.at(-1).body,
+    /cache-budget-audit-occurrence-summary/,
+  );
+  assert.ok(
+    client.comments.at(-1).body.includes(
+      occurrenceMarker(41 + MAX_DETAILED_OCCURRENCE_COMMENTS + 8, 1),
+    ),
+  );
+});
+
+test("recovery flapping cannot grow reporter comments without bound", async () => {
+  const client = new FakeClient();
+  await reconcile(client, workflowRun());
+  let runId = 41;
+  let runNumber = 12;
+
+  for (let iteration = 0; iteration < MAX_DETAILED_OCCURRENCE_COMMENTS + 5; iteration += 1) {
+    runId += 1;
+    runNumber += 1;
+    await reconcile(
+      client,
+      workflowRun({ id: runId, run_number: runNumber, conclusion: "success" }),
+    );
+    runId += 1;
+    runNumber += 1;
+    await reconcile(client, workflowRun({ id: runId, run_number: runNumber }));
+  }
+
+  assert.equal(client.comments.length, MAX_DETAILED_OCCURRENCE_COMMENTS + 2);
+  assert.equal(
+    client.comments.filter((comment) =>
+      comment.body.includes("cache-budget-audit-recovery-summary"),
+    ).length,
+    1,
+  );
 });

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -3,7 +3,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -19,6 +19,7 @@ import {
 import { HISTORICAL_SUMMARY_FIXTURES } from "./fixtures/cache-budget-audit-summary-fixtures.mjs";
 
 const REPORTER_PATH = fileURLToPath(new URL("./report-cache-budget-audit.mjs", import.meta.url));
+const TEST_PATH = fileURLToPath(import.meta.url);
 
 class FakeClient {
   constructor({ issues = [], comments = [], completedRuns = [] } = {}) {
@@ -475,15 +476,26 @@ test("historical summary fixtures have fixed provenance labels and need no Git h
   }
 
   // merge-readiness.yml's automation-contracts checkout has fetch-depth: 0,
-  // but this control must also pass in a shallow local clone: tests consume
-  // committed outputs and never look up their historical writer commits.
-  const testSource = await readFile(fileURLToPath(import.meta.url), "utf8");
-  const forbiddenHistoryApi = `exec${"FileSync"}`;
-  const forbiddenGitLookup = new RegExp(
-    [String.raw`["']git["']`, String.raw`["']show["']`].join(String.raw`\s*,\s*\[\s*`),
-  );
-  assert.doesNotMatch(testSource, new RegExp(`\\b${forbiddenHistoryApi}\\b`));
-  assert.doesNotMatch(testSource, forbiddenGitLookup);
+  // but this control must also pass in a shallow local clone. Run every
+  // imported fixture path from a non-Git directory with no Git executable.
+  if (process.env.CACHE_BUDGET_AUDIT_NO_GIT_CHILD === "1") {
+    return;
+  }
+  const noGitDirectory = await mkdtemp(join(tmpdir(), "fsl-cache-audit-no-git-"));
+  try {
+    const result = spawnSync(process.execPath, ["--test", TEST_PATH], {
+      cwd: noGitDirectory,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: noGitDirectory,
+        CACHE_BUDGET_AUDIT_NO_GIT_CHILD: "1",
+      },
+    });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  } finally {
+    await rm(noGitDirectory, { force: true, recursive: true });
+  }
 });
 
 test("an original unqualified summary migrates to the qualified format", async () => {

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   CACHE_BUDGET_AUDIT_LABEL,
@@ -10,6 +15,8 @@ import {
   occurrenceMarker,
   reconcileCacheBudgetAudit,
 } from "./report-cache-budget-audit.mjs";
+
+const REPORTER_PATH = fileURLToPath(new URL("./report-cache-budget-audit.mjs", import.meta.url));
 
 class FakeClient {
   constructor({ issues = [], comments = [], completedRuns = [] } = {}) {
@@ -114,10 +121,23 @@ function occurrenceSummaryBody({
     occurrenceMarker(41, 1),
     ...(cursor === null ? [] : [`<!-- cache-budget-audit-cursor:${cursor} -->`]),
     ...extraLines,
-    "This rolling summary records coalesced failures and the latest recurrence.",
-    `Observable coalesced failed attempts in this summary interval: ${count}.`,
+    "This rolling summary records coalesced failures and its displayed workflow run.",
+    `Observable coalesced failed attempts since this summary was created: ${count}.`,
     `Recent observable coalesced identities: ${identities}.`,
   ].join("\n");
+}
+
+function legacyOccurrenceSummaryBody(options = {}) {
+  return occurrenceSummaryBody(options)
+    .replace(
+      "This rolling summary records coalesced failures and its displayed workflow run.",
+      "Detailed recurrence comments are capped at 20; this rolling summary records the latest recurrence.",
+    )
+    .replace(
+      "Observable coalesced failed attempts since this summary was created",
+      "Coalesced failed attempts",
+    )
+    .replace("Recent observable coalesced identities", "Recent coalesced identities");
 }
 
 function clientWithOccurrenceSummary(bodies) {
@@ -132,12 +152,16 @@ function clientWithOccurrenceSummary(bodies) {
   });
 }
 
-async function assertOccurrenceSummaryRejected(client, expected) {
+async function assertOccurrenceSummaryRejected(
+  client,
+  expected,
+  run = workflowRun({ id: 50, run_number: 13 }),
+) {
   const issueBefore = structuredClone(client.issues);
   const commentsBefore = structuredClone(client.comments);
 
   await assert.rejects(
-    reconcile(client, workflowRun({ id: 50, run_number: 13 })),
+    reconcile(client, run),
     expected,
   );
 
@@ -256,7 +280,7 @@ test("a marker beyond the first comment page remains idempotent", async () => {
   const result = await reconcile(client, run);
 
   assert.deepEqual(result, { created: 0, updated: 0, closed: 0, failed: true });
-  assert.equal(client.comments.length, MAX_DETAILED_OCCURRENCE_COMMENTS + 2);
+  assert.equal(client.comments.length, 101);
   assert.ok(client.comments.some((comment) => comment.id === 101));
 });
 
@@ -346,7 +370,7 @@ test("coalesced intermediate failures retain a count and recent identities", asy
   const summary = client.comments.find((comment) =>
     comment.body.includes("cache-budget-audit-occurrence-summary"),
   );
-  assert.match(summary.body, /Observable coalesced failed attempts in this summary interval: 2\./);
+  assert.match(summary.body, /Observable coalesced failed attempts since this summary was created: 2\./);
   assert.match(summary.body, /41:1, 42:1/);
   assert.match(client.issues[0].body, /cache-budget-audit-occurrence:43:1/);
 });
@@ -366,7 +390,7 @@ test("coalescing records only the latest same-run attempt exposed by the list AP
   const summary = client.comments.find((comment) =>
     comment.body.includes("cache-budget-audit-occurrence-summary"),
   );
-  assert.match(summary.body, /Observable coalesced failed attempts in this summary interval: 2\./);
+  assert.match(summary.body, /Observable coalesced failed attempts since this summary was created: 2\./);
   assert.match(summary.body, /41:1, 42:2/);
   assert.doesNotMatch(summary.body, new RegExp(`${supersededAttempt.id}:1`));
 });
@@ -394,7 +418,7 @@ test("coalescing retains an earlier triggering attempt absent from the list API"
   const summary = client.comments.find((comment) =>
     comment.body.includes("cache-budget-audit-occurrence-summary"),
   );
-  assert.match(summary.body, /Observable coalesced failed attempts in this summary interval: 1\./);
+  assert.match(summary.body, /Observable coalesced failed attempts since this summary was created: 1\./);
   assert.match(summary.body, /42:1/);
   assert.doesNotMatch(summary.body, /42:2/);
 });
@@ -411,6 +435,73 @@ test("replaying an already-summarised run does not PATCH identical content", asy
 
   assert.deepEqual(result, { created: 0, updated: 0, closed: 0, failed: true });
   assert.equal(client.updatedComments, updatesBeforeReplay);
+});
+
+test("a legacy summary migrates to the qualified format", async () => {
+  const client = clientWithOccurrenceSummary([legacyOccurrenceSummaryBody()]);
+
+  await reconcile(client, workflowRun({ id: 50, run_number: 13 }));
+
+  assert.match(
+    client.comments[0].body,
+    /Observable coalesced failed attempts since this summary was created: 7\./,
+  );
+  assert.doesNotMatch(client.comments[0].body, /Coalesced failed attempts: 7\./);
+});
+
+test("a bot quote of an occurrence marker cannot suppress a recurrence", async () => {
+  const client = new FakeClient();
+  await reconcile(client, workflowRun());
+  const run = workflowRun({ id: 42, run_number: 13 });
+  client.comments.push({
+    id: 1,
+    issue: 100,
+    body: `Quoted reporter marker: ${occurrenceMarker(run.id, run.run_attempt)}`,
+    user: { login: "github-actions[bot]" },
+  });
+
+  const result = await reconcile(client, run);
+
+  assert.equal(result.updated, 1);
+  assert.equal(
+    client.comments.filter((comment) => comment.body.startsWith("<!-- cache-budget-audit-occurrence:")).length,
+    1,
+  );
+});
+
+test("a safe-boundary count round-trips and overflow rejects before mutation", async () => {
+  const boundaryClient = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: `${Number.MAX_SAFE_INTEGER - 1}`, identities: "none" }),
+  ]);
+  boundaryClient.completedRuns = [workflowRun({ id: 42, run_number: 13 })];
+
+  await reconcile(boundaryClient, workflowRun({ id: 43, run_number: 14 }));
+  assert.match(
+    boundaryClient.comments[0].body,
+    new RegExp(`since this summary was created: ${Number.MAX_SAFE_INTEGER}\\.`),
+  );
+  await reconcile(boundaryClient, workflowRun({ id: 43, run_number: 14 }));
+
+  const overflowClient = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: `${Number.MAX_SAFE_INTEGER}`, identities: "none" }),
+  ]);
+  overflowClient.completedRuns = [workflowRun({ id: 42, run_number: 13 })];
+  await assertOccurrenceSummaryRejected(
+    overflowClient,
+    /coalesced failure count would exceed the safe integer limit/,
+    workflowRun({ id: 43, run_number: 14 }),
+  );
+});
+
+test("duplicate future summaries are validated before consolidation", async () => {
+  const futureSummary = occurrenceSummaryBody({ cursor: "999:1" });
+  const client = clientWithOccurrenceSummary([futureSummary, futureSummary]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /cursor must not be newer than observable trusted health/,
+  );
+  assert.equal(client.comments.length, 2);
 });
 
 test("duplicate identical summaries self-heal within the comment bound", async () => {
@@ -565,12 +656,55 @@ test("duplicate coalesced identities fail closed", async () => {
   );
 });
 
+test("a coalesced identity with extra colons fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: "1", identities: "41:1:2" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced identities must be a bounded run_id:run_attempt list/,
+  );
+});
+
+test("more than twenty persisted coalesced identities fails closed", async () => {
+  const identities = Array.from({ length: 21 }, (_value, index) => `${index + 1}:1`).join(", ");
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: "21", identities }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced identities must be a unique bounded run_id:run_attempt list/,
+  );
+});
+
+test("a missing coalesced identities line fails closed", async () => {
+  const body = occurrenceSummaryBody().replace(
+    "\nRecent observable coalesced identities: 41:1.",
+    "",
+  );
+  const client = clientWithOccurrenceSummary([body]);
+
+  await assertOccurrenceSummaryRejected(client, /coalesced identities must appear exactly once/);
+});
+
+test("a repeated coalesced identities line fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({
+      extraLines: ["Recent observable coalesced identities: 41:1."],
+    }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(client, /coalesced identities must appear exactly once/);
+});
+
 test("extra cursor and count lines fail closed", async () => {
   const client = clientWithOccurrenceSummary([
     occurrenceSummaryBody({
       extraLines: [
         "<!-- cache-budget-audit-cursor:999:1 -->",
-        "Observable coalesced failed attempts in this summary interval: not-a-number.",
+        "Observable coalesced failed attempts since this summary was created: not-a-number.",
       ],
     }),
   ]);
@@ -582,7 +716,7 @@ test("an extra coalesced count line fails closed", async () => {
   const client = clientWithOccurrenceSummary([
     occurrenceSummaryBody({
       extraLines: [
-        "Observable coalesced failed attempts in this summary interval: not-a-number.",
+        "Observable coalesced failed attempts since this summary was created: not-a-number.",
       ],
     }),
   ]);
@@ -612,7 +746,7 @@ test("whole-summary deletion deliberately starts a new cumulative interval", asy
   const summary = client.comments.find((comment) =>
     comment.body.includes("cache-budget-audit-occurrence-summary"),
   );
-  assert.match(summary.body, /Observable coalesced failed attempts in this summary interval: 1\./);
+  assert.match(summary.body, /Observable coalesced failed attempts since this summary was created: 1\./);
   assert.match(summary.body, /41:1/);
 });
 
@@ -649,4 +783,32 @@ test("conflicting valid duplicate summaries fail closed", async () => {
     client,
     /duplicate summaries disagree/,
   );
+});
+
+test("the executable wrapper reports an untrusted event on stdout and exits zero", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "fsl-cache-audit-reporter-"));
+  const eventPath = join(directory, "event.json");
+  await writeFile(
+    eventPath,
+    JSON.stringify({
+      repository: { default_branch: "main" },
+      workflow_run: workflowRun({ event: "pull_request" }),
+    }),
+  );
+
+  try {
+    const result = spawnSync(process.execPath, [REPORTER_PATH], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_REPOSITORY: "ymm-oss/fsl",
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "Skipping untrusted cache-budget audit run.\n");
+    assert.equal(result.stderr, "");
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
 });

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -432,7 +432,7 @@ test("replaying an already-summarised run does not PATCH identical content", asy
   assert.equal(client.updatedComments, updatesBeforeReplay);
 });
 
-test("historical summary fixtures are provenance-bound and need no Git history", async () => {
+test("historical summary fixtures have fixed provenance labels and need no Git history", async () => {
   const expectedProvenance = new Map([
     [
       "original-unqualified",

--- a/.github/scripts/report-cache-budget-audit.test.mjs
+++ b/.github/scripts/report-cache-budget-audit.test.mjs
@@ -107,14 +107,16 @@ function occurrenceSummaryBody({
   cursor = "12:1",
   count = "7",
   identities = "41:1",
+  extraLines = [],
 } = {}) {
   return [
     "<!-- cache-budget-audit-occurrence-summary -->",
     occurrenceMarker(41, 1),
     ...(cursor === null ? [] : [`<!-- cache-budget-audit-cursor:${cursor} -->`]),
-    "Detailed recurrence comments are capped at 20; this rolling summary records the latest recurrence.",
-    `Coalesced failed attempts: ${count}.`,
-    `Recent coalesced identities: ${identities}.`,
+    ...extraLines,
+    "This rolling summary records coalesced failures and the latest recurrence.",
+    `Observable coalesced failed attempts in this summary interval: ${count}.`,
+    `Recent observable coalesced identities: ${identities}.`,
   ].join("\n");
 }
 
@@ -344,7 +346,7 @@ test("coalesced intermediate failures retain a count and recent identities", asy
   const summary = client.comments.find((comment) =>
     comment.body.includes("cache-budget-audit-occurrence-summary"),
   );
-  assert.match(summary.body, /Coalesced failed attempts: 2\./);
+  assert.match(summary.body, /Observable coalesced failed attempts in this summary interval: 2\./);
   assert.match(summary.body, /41:1, 42:1/);
   assert.match(client.issues[0].body, /cache-budget-audit-occurrence:43:1/);
 });
@@ -364,9 +366,51 @@ test("coalescing records only the latest same-run attempt exposed by the list AP
   const summary = client.comments.find((comment) =>
     comment.body.includes("cache-budget-audit-occurrence-summary"),
   );
-  assert.match(summary.body, /Coalesced failed attempts: 2\./);
+  assert.match(summary.body, /Observable coalesced failed attempts in this summary interval: 2\./);
   assert.match(summary.body, /41:1, 42:2/);
   assert.doesNotMatch(summary.body, new RegExp(`${supersededAttempt.id}:1`));
+});
+
+test("coalescing retains an earlier triggering attempt absent from the list API", async () => {
+  const issue = {
+    number: 100,
+    state: "open",
+    body: cacheBudgetAuditMarker(),
+  };
+  const triggeringAttempt = workflowRun({ id: 42, run_number: 13, run_attempt: 1 });
+  const listedLatestAttempt = workflowRun({
+    id: 42,
+    run_number: 13,
+    run_attempt: 2,
+    conclusion: "success",
+  });
+  const client = new FakeClient({
+    issues: [issue],
+    completedRuns: [listedLatestAttempt],
+  });
+
+  await reconcile(client, triggeringAttempt);
+
+  const summary = client.comments.find((comment) =>
+    comment.body.includes("cache-budget-audit-occurrence-summary"),
+  );
+  assert.match(summary.body, /Observable coalesced failed attempts in this summary interval: 1\./);
+  assert.match(summary.body, /42:1/);
+  assert.doesNotMatch(summary.body, /42:2/);
+});
+
+test("replaying an already-summarised run does not PATCH identical content", async () => {
+  const client = new FakeClient({
+    completedRuns: [workflowRun({ id: 41, run_number: 12 })],
+  });
+  const run = workflowRun({ id: 42, run_number: 13 });
+
+  await reconcile(client, run);
+  const updatesBeforeReplay = client.updatedComments;
+  const result = await reconcile(client, run);
+
+  assert.deepEqual(result, { created: 0, updated: 0, closed: 0, failed: true });
+  assert.equal(client.updatedComments, updatesBeforeReplay);
 });
 
 test("duplicate identical summaries self-heal within the comment bound", async () => {
@@ -406,7 +450,7 @@ test("a non-numeric coalesced count fails closed", async () => {
 
   await assertOccurrenceSummaryRejected(
     client,
-    /coalesced failure count must be a non-negative safe integer/,
+    /coalesced failure count must be a canonical decimal safe integer/,
   );
 });
 
@@ -417,7 +461,7 @@ test("a negative coalesced count fails closed", async () => {
 
   await assertOccurrenceSummaryRejected(
     client,
-    /coalesced failure count must be a non-negative safe integer/,
+    /coalesced failure count must be a canonical decimal safe integer/,
   );
 });
 
@@ -428,8 +472,148 @@ test("an unsafe coalesced count fails closed", async () => {
 
   await assertOccurrenceSummaryRejected(
     client,
-    /coalesced failure count must be a non-negative safe integer/,
+    /coalesced failure count must be a canonical decimal safe integer/,
   );
+});
+
+test("an empty coalesced count fails closed", async () => {
+  const client = clientWithOccurrenceSummary([occurrenceSummaryBody({ count: "" })]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced failure count must be a canonical decimal safe integer/,
+  );
+});
+
+test("an exponent-form coalesced count fails closed", async () => {
+  const client = clientWithOccurrenceSummary([occurrenceSummaryBody({ count: "1e2" })]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced failure count must be a canonical decimal safe integer/,
+  );
+});
+
+test("a hexadecimal coalesced count fails closed", async () => {
+  const client = clientWithOccurrenceSummary([occurrenceSummaryBody({ count: "0x10" })]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced failure count must be a canonical decimal safe integer/,
+  );
+});
+
+test("a whitespace-padded coalesced count fails closed", async () => {
+  const client = clientWithOccurrenceSummary([occurrenceSummaryBody({ count: " 1" })]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced failure count must be a canonical decimal safe integer/,
+  );
+});
+
+test("an exponent-form cursor fails closed", async () => {
+  const client = clientWithOccurrenceSummary([occurrenceSummaryBody({ cursor: "1e2:1" })]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /cursor run number must be a canonical decimal safe integer/,
+  );
+});
+
+test("an unsafe coalesced identity fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: "1", identities: "9007199254740992:1" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced identity run ID must be a canonical decimal safe integer/,
+  );
+});
+
+test("a zero coalesced identity fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: "0", identities: "0:0" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced identity run ID must be a canonical decimal safe integer/,
+  );
+});
+
+test("a coalesced count smaller than its identities fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: "1", identities: "41:1, 42:1" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced failure count must cover every recorded identity/,
+  );
+});
+
+test("duplicate coalesced identities fail closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({ count: "2", identities: "41:1, 41:1" }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced identities must be a unique bounded run_id:run_attempt list/,
+  );
+});
+
+test("extra cursor and count lines fail closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({
+      extraLines: [
+        "<!-- cache-budget-audit-cursor:999:1 -->",
+        "Observable coalesced failed attempts in this summary interval: not-a-number.",
+      ],
+    }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(client, /cursor marker must appear exactly once/);
+});
+
+test("an extra coalesced count line fails closed", async () => {
+  const client = clientWithOccurrenceSummary([
+    occurrenceSummaryBody({
+      extraLines: [
+        "Observable coalesced failed attempts in this summary interval: not-a-number.",
+      ],
+    }),
+  ]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /coalesced failure count must appear exactly once/,
+  );
+});
+
+test("a future cursor fails closed rather than moving backward", async () => {
+  const client = clientWithOccurrenceSummary([occurrenceSummaryBody({ cursor: "999:1" })]);
+
+  await assertOccurrenceSummaryRejected(
+    client,
+    /cursor must not be newer than observable trusted health/,
+  );
+});
+
+test("whole-summary deletion deliberately starts a new cumulative interval", async () => {
+  const client = clientWithOccurrenceSummary([occurrenceSummaryBody({ count: "7" })]);
+  client.comments = [];
+  client.completedRuns = [workflowRun({ id: 41, run_number: 12 })];
+
+  await reconcile(client, workflowRun({ id: 50, run_number: 13 }));
+
+  const summary = client.comments.find((comment) =>
+    comment.body.includes("cache-budget-audit-occurrence-summary"),
+  );
+  assert.match(summary.body, /Observable coalesced failed attempts in this summary interval: 1\./);
+  assert.match(summary.body, /41:1/);
 });
 
 test("a valid and malformed duplicate summary fails closed", async () => {
@@ -440,7 +624,7 @@ test("a valid and malformed duplicate summary fails closed", async () => {
 
   await assertOccurrenceSummaryRejected(
     client,
-    /coalesced failure count must be a non-negative safe integer/,
+    /coalesced failure count must be a canonical decimal safe integer/,
   );
 });
 

--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -512,7 +512,17 @@ def validate_audit_workflow_name_uniqueness(workflows_directory: Path) -> list[s
     for path in sorted(workflows_directory.iterdir()):
         if not path.is_file() or path.suffix not in {".yaml", ".yml"}:
             continue
-        document = load_workflow(path)
+        try:
+            document = load_workflow(path)
+        except FileNotFoundError:
+            errors.append(f"workflow file '{path}' does not exist")
+            continue
+        except OSError as error:
+            errors.append(f"workflow file '{path}' could not be read: {error.strerror}")
+            continue
+        except yaml.YAMLError as error:
+            errors.append(f"workflow YAML is invalid: sibling workflow file '{path}': {error}")
+            continue
         if isinstance(document, Mapping) and document.get("name") == AUDIT_WORKFLOW_NAME:
             matching_workflows.append(path.name)
 

--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -25,6 +25,7 @@ DEFAULT_REPORTER_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "cache-budget-audit-reporter.yml"
 )
 AUDIT_JOB_ID = "audit"
+AUDIT_WORKFLOW_NAME = "cache budget audit"
 AUDIT_CONCURRENCY_GROUP = "cache-budget-audit"
 AUDIT_JOB_NAME = "audit Actions cache budget"
 AUDIT_RUNS_ON = "ubuntu-latest"
@@ -40,7 +41,6 @@ AUDIT_TOKEN = "${{ secrets.GITHUB_TOKEN }}"
 REQUIRED_PERMISSIONS = {"actions": "read", "contents": "read"}
 REPORTER_JOB_ID = "reconcile"
 REPORTER_PERMISSIONS = {"actions": "read", "contents": "read", "issues": "write"}
-REPORTER_WORKFLOW_RUN_SOURCE = "cache budget audit"
 REPORTER_WORKFLOW_RUN_TYPES = ["completed"]
 REPORTER_CONCURRENCY_GROUP = "cache-budget-audit-reporter"
 REPORTER_CHECKOUT_ACTION = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
@@ -178,6 +178,8 @@ def validate_workflow(document: Any) -> list[str]:
         "workflow",
         errors,
     )
+    if workflow.get("name") != AUDIT_WORKFLOW_NAME:
+        errors.append("audit workflow name must be exactly 'cache budget audit'")
 
     triggers = _mapping(workflow.get("on"), "workflow 'on'", errors)
     if triggers is not None:
@@ -379,9 +381,9 @@ def validate_reporter_workflow(document: Any) -> list[str]:
                 "reporter trigger 'workflow_run'",
                 errors,
             )
-            if workflow_run.get("workflows") != [REPORTER_WORKFLOW_RUN_SOURCE]:
+            if workflow_run.get("workflows") != [AUDIT_WORKFLOW_NAME]:
                 errors.append(
-                    "reporter workflow_run.workflows must be exactly ['cache budget audit']"
+                    f"reporter workflow_run.workflows must be exactly ['{AUDIT_WORKFLOW_NAME}']"
                 )
             if workflow_run.get("types") != REPORTER_WORKFLOW_RUN_TYPES:
                 errors.append("reporter workflow_run.types must be exactly ['completed']")

--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -25,9 +25,18 @@ DEFAULT_REPORTER_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "cache-budget-audit-reporter.yml"
 )
 AUDIT_JOB_ID = "audit"
+AUDIT_CONCURRENCY_GROUP = "cache-budget-audit"
+AUDIT_JOB_NAME = "audit Actions cache budget"
+AUDIT_RUNS_ON = "ubuntu-latest"
+AUDIT_TIMEOUT_MINUTES = 5
+AUDIT_CHECKOUT_ACTION = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+AUDIT_SETUP_NODE_ACTION = "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020"
+AUDIT_NODE_VERSION = "22"
 CALIBRATION_STEP_NAME = "Calibrate the audit"
+CALIBRATION_COMMAND = ["node", "--test", ".github/scripts/audit-cache-budget.test.mjs"]
 LIVE_AUDIT_STEP_NAME = "Audit the live cache budget"
 LIVE_AUDIT_COMMAND = ["node", ".github/scripts/run-cache-budget-audit.mjs"]
+AUDIT_TOKEN = "${{ secrets.GITHUB_TOKEN }}"
 REQUIRED_PERMISSIONS = {"actions": "read", "contents": "read"}
 REPORTER_JOB_ID = "reconcile"
 REPORTER_PERMISSIONS = {"actions": "read", "contents": "read", "issues": "write"}
@@ -172,6 +181,7 @@ def validate_workflow(document: Any) -> list[str]:
 
     triggers = _mapping(workflow.get("on"), "workflow 'on'", errors)
     if triggers is not None:
+        _reject_unapproved_keys(triggers, set(REQUIRED_TRIGGERS), "workflow 'on'", errors)
         for trigger in REQUIRED_TRIGGERS:
             if trigger not in triggers:
                 errors.append(f"required trigger '{trigger}' is absent")
@@ -195,6 +205,7 @@ def validate_workflow(document: Any) -> list[str]:
         if "push" in triggers:
             push_mapping = _mapping(push, "trigger 'push'", errors)
             if push_mapping is not None:
+                _reject_unapproved_keys(push_mapping, {"branches", "paths"}, "trigger 'push'", errors)
                 branches = push_mapping.get("branches")
                 if not isinstance(branches, list) or "main" not in branches:
                     errors.append("trigger 'push.branches' must contain 'main'")
@@ -208,6 +219,19 @@ def validate_workflow(document: Any) -> list[str]:
 
     if workflow.get("permissions") != REQUIRED_PERMISSIONS:
         errors.append("top-level permissions must be exactly actions: read and contents: read")
+
+    concurrency = _mapping(workflow.get("concurrency"), "audit concurrency", errors)
+    if concurrency is not None:
+        _reject_unapproved_keys(
+            concurrency,
+            {"group", "cancel-in-progress"},
+            "audit concurrency",
+            errors,
+        )
+        if concurrency.get("group") != AUDIT_CONCURRENCY_GROUP:
+            errors.append("audit concurrency group must be 'cache-budget-audit'")
+        if concurrency.get("cancel-in-progress") is not False:
+            errors.append("audit concurrency cancel-in-progress must be false")
 
     jobs = _mapping(workflow.get("jobs"), "workflow jobs", errors)
     if jobs is None:
@@ -229,6 +253,12 @@ def validate_workflow(document: Any) -> list[str]:
         "audit job",
         errors,
     )
+    if job.get("name") != AUDIT_JOB_NAME:
+        errors.append("audit job name must be exactly 'audit Actions cache budget'")
+    if job.get("runs-on") != AUDIT_RUNS_ON:
+        errors.append("audit job runs-on must be exactly 'ubuntu-latest'")
+    if job.get("timeout-minutes") != AUDIT_TIMEOUT_MINUTES:
+        errors.append("audit job timeout-minutes must be exactly 5")
     steps_value = job.get("steps")
     if not isinstance(steps_value, list):
         errors.append("audit job steps must be a list")
@@ -239,6 +269,7 @@ def validate_workflow(document: Any) -> list[str]:
     live_audit_indices = _named_step_indices(steps, LIVE_AUDIT_STEP_NAME)
     if len(calibration_indices) != 1:
         errors.append("audit job must contain exactly one named calibration step")
+        return errors
     if len(live_audit_indices) != 1:
         errors.append("audit job must contain exactly one named live-audit step")
         return errors
@@ -246,15 +277,67 @@ def validate_workflow(document: Any) -> list[str]:
     live_audit_index = live_audit_indices[0]
     if calibration_indices and calibration_indices[0] >= live_audit_index:
         errors.append("calibration step must precede the live-audit step")
+        return errors
+
+    if not (
+        len(steps) == 4
+        and all(isinstance(step, Mapping) for step in steps)
+        and isinstance(steps[0].get("uses"), str)
+        and steps[0]["uses"].startswith("actions/checkout@")
+        and isinstance(steps[1].get("uses"), str)
+        and steps[1]["uses"].startswith("actions/setup-node@")
+        and steps[2].get("name") == CALIBRATION_STEP_NAME
+        and steps[3].get("name") == LIVE_AUDIT_STEP_NAME
+    ):
+        errors.append(
+            "audit job steps must be exactly checkout, setup-node, calibration, and live-audit runner in that order"
+        )
+        return errors
+
+    checkout = steps[0]
+    _reject_unapproved_keys(checkout, {"uses", "with"}, "audit checkout step", errors)
+    if checkout.get("uses") != AUDIT_CHECKOUT_ACTION:
+        errors.append("audit checkout action must be pinned to the approved commit")
+    else:
+        checkout_with = checkout.get("with")
+        if isinstance(checkout_with, Mapping):
+            _reject_unapproved_keys(
+                checkout_with,
+                {"persist-credentials"},
+                "audit checkout configuration",
+                errors,
+            )
+        if not isinstance(checkout_with, Mapping) or checkout_with.get("persist-credentials") is not False:
+            errors.append("audit checkout must disable persisted credentials")
+
+    setup_node = steps[1]
+    _reject_unapproved_keys(setup_node, {"uses", "with"}, "audit setup-node step", errors)
+    if setup_node.get("uses") != AUDIT_SETUP_NODE_ACTION:
+        errors.append("audit setup-node action must be pinned to the approved commit")
+    if setup_node.get("with") != {"node-version": AUDIT_NODE_VERSION}:
+        errors.append("audit setup-node step must use exactly node-version 22")
+
+    calibration = steps[2]
+    _reject_unapproved_keys(calibration, {"name", "run"}, "audit calibration step", errors)
+    if _normalized_argv(calibration.get("run")) != CALIBRATION_COMMAND:
+        errors.append(
+            "audit calibration command must be exactly "
+            "'node --test .github/scripts/audit-cache-budget.test.mjs'"
+        )
 
     # _named_step_indices selects only Mapping instances, so the unique live
     # step above is necessarily a mapping.  Keeping a defensive non-mapping
     # branch here would create an unreachable, uncalibrated diagnostic.
-    live_step = steps[live_audit_index]
+    live_step = steps[3]
     if "if" in live_step:
         errors.append("live-audit step must not declare 'if'")
+        return errors
     if "continue-on-error" in live_step:
         errors.append("live-audit step must not declare 'continue-on-error'")
+        return errors
+    _reject_unapproved_keys(live_step, {"name", "env", "run"}, "live-audit step", errors)
+    if live_step.get("env") != {"GITHUB_TOKEN": AUDIT_TOKEN}:
+        errors.append("live-audit step must bind GITHUB_TOKEN to secrets.GITHUB_TOKEN")
     if _normalized_argv(live_step.get("run")) != LIVE_AUDIT_COMMAND:
         errors.append(
             "live-audit command must be exactly "

--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -41,6 +41,9 @@ REPORTER_NODE_VERSION = "22"
 REPORTER_TOKEN = "${{ secrets.GITHUB_TOKEN }}"
 REPORTER_RUNNER_STEP_NAME = "Create, update, or resolve cache budget audit issue"
 REPORTER_COMMAND = ["node", ".github/scripts/report-cache-budget-audit.mjs"]
+REPORTER_JOB_NAME = "reconcile cache-budget audit issue"
+REPORTER_RUNS_ON = "ubuntu-latest"
+REPORTER_TIMEOUT_MINUTES = 5
 REPORTER_TRUSTED_CONDITION = " ".join(
     [
         "github.event.workflow_run.head_repository.full_name == github.repository &&",
@@ -93,6 +96,14 @@ def _mapping(value: Any, label: str, errors: list[str]) -> Optional[Mapping[str,
         errors.append(f"{label} must be a mapping")
         return None
     return value
+
+
+def _reject_unapproved_keys(
+    mapping: Mapping[str, Any], allowed: set[str], label: str, errors: list[str]
+) -> None:
+    unexpected = sorted(set(mapping).difference(allowed))
+    if unexpected:
+        errors.append(f"{label} must not declare unapproved keys: {', '.join(unexpected)}")
 
 
 def _named_step_indices(steps: list[Any], name: str) -> list[int]:
@@ -221,13 +232,26 @@ def validate_reporter_workflow(document: Any) -> list[str]:
     workflow = _mapping(document, "reporter workflow", errors)
     if workflow is None:
         return errors
+    _reject_unapproved_keys(
+        workflow,
+        {"name", "on", "permissions", "concurrency", "jobs"},
+        "reporter workflow",
+        errors,
+    )
 
     triggers = _mapping(workflow.get("on"), "reporter workflow 'on'", errors)
     if triggers is not None:
+        _reject_unapproved_keys(triggers, {"workflow_run"}, "reporter workflow 'on'", errors)
         workflow_run = _mapping(
             triggers.get("workflow_run"), "reporter trigger 'workflow_run'", errors
         )
         if workflow_run is not None:
+            _reject_unapproved_keys(
+                workflow_run,
+                {"workflows", "types"},
+                "reporter trigger 'workflow_run'",
+                errors,
+            )
             if workflow_run.get("workflows") != [REPORTER_WORKFLOW_RUN_SOURCE]:
                 errors.append(
                     "reporter workflow_run.workflows must be exactly ['cache budget audit']"
@@ -242,6 +266,12 @@ def validate_reporter_workflow(document: Any) -> list[str]:
 
     concurrency = _mapping(workflow.get("concurrency"), "reporter concurrency", errors)
     if concurrency is not None:
+        _reject_unapproved_keys(
+            concurrency,
+            {"group", "cancel-in-progress"},
+            "reporter concurrency",
+            errors,
+        )
         if concurrency.get("group") != REPORTER_CONCURRENCY_GROUP:
             errors.append("reporter concurrency group must be 'cache-budget-audit-reporter'")
         if concurrency.get("cancel-in-progress") is not False:
@@ -250,14 +280,29 @@ def validate_reporter_workflow(document: Any) -> list[str]:
     jobs = _mapping(workflow.get("jobs"), "reporter workflow jobs", errors)
     if jobs is None:
         return errors
+    _reject_unapproved_keys(jobs, {REPORTER_JOB_ID}, "reporter workflow jobs", errors)
     job = _mapping(jobs.get(REPORTER_JOB_ID), f"reporter job '{REPORTER_JOB_ID}'", errors)
     if job is None:
         return errors
 
     if "permissions" in job:
         errors.append("reporter job must not declare a permissions override")
+        return errors
     if "continue-on-error" in job:
         errors.append("reporter job must not declare 'continue-on-error'")
+        return errors
+    _reject_unapproved_keys(
+        job,
+        {"name", "if", "runs-on", "timeout-minutes", "steps"},
+        "reporter job",
+        errors,
+    )
+    if job.get("name") != REPORTER_JOB_NAME:
+        errors.append("reporter job name must be exactly 'reconcile cache-budget audit issue'")
+    if job.get("runs-on") != REPORTER_RUNS_ON:
+        errors.append("reporter job runs-on must be exactly 'ubuntu-latest'")
+    if job.get("timeout-minutes") != REPORTER_TIMEOUT_MINUTES:
+        errors.append("reporter job timeout-minutes must be exactly 5")
     if _normalized_text(job.get("if")) != REPORTER_TRUSTED_CONDITION:
         errors.append(
             "reporter job must restrict to trusted default-branch schedule, push, or workflow_dispatch audits"
@@ -283,28 +328,45 @@ def validate_reporter_workflow(document: Any) -> list[str]:
         return errors
 
     checkout = steps[0]
+    _reject_unapproved_keys(checkout, {"uses", "with"}, "reporter checkout step", errors)
     if checkout.get("uses") != REPORTER_CHECKOUT_ACTION:
         errors.append("reporter checkout action must be pinned to the approved commit")
     else:
         checkout_with = checkout.get("with")
+        if isinstance(checkout_with, Mapping):
+            _reject_unapproved_keys(
+                checkout_with,
+                {"ref", "persist-credentials"},
+                "reporter checkout configuration",
+                errors,
+            )
         if not isinstance(checkout_with, Mapping) or checkout_with.get("ref") != REPORTER_CHECKOUT_REF:
             errors.append("reporter checkout must use the repository default branch ref")
         if not isinstance(checkout_with, Mapping) or checkout_with.get("persist-credentials") is not False:
             errors.append("reporter checkout must disable persisted credentials")
 
     setup_node = steps[1]
+    _reject_unapproved_keys(setup_node, {"uses", "with"}, "reporter setup-node step", errors)
     if setup_node.get("uses") != REPORTER_SETUP_NODE_ACTION:
         errors.append("reporter setup-node action must be pinned to the approved commit")
     if setup_node.get("with") != {"node-version": REPORTER_NODE_VERSION}:
         errors.append("reporter setup-node step must use exactly node-version 22")
 
     runner = steps[2]
-    if runner.get("env") != {"GITHUB_TOKEN": REPORTER_TOKEN}:
-        errors.append("reporter reconciliation runner must bind GITHUB_TOKEN to secrets.GITHUB_TOKEN")
     if "if" in runner:
         errors.append("reporter reconciliation runner must not declare 'if'")
+        return errors
     if "continue-on-error" in runner:
         errors.append("reporter reconciliation runner must not declare 'continue-on-error'")
+        return errors
+    _reject_unapproved_keys(
+        runner,
+        {"name", "env", "run"},
+        "reporter reconciliation runner",
+        errors,
+    )
+    if runner.get("env") != {"GITHUB_TOKEN": REPORTER_TOKEN}:
+        errors.append("reporter reconciliation runner must bind GITHUB_TOKEN to secrets.GITHUB_TOKEN")
     if _normalized_argv(runner.get("run")) != REPORTER_COMMAND:
         errors.append(
             "reporter reconciliation command must be exactly "

--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -34,7 +34,12 @@ REPORTER_PERMISSIONS = {"actions": "read", "contents": "read", "issues": "write"
 REPORTER_WORKFLOW_RUN_SOURCE = "cache budget audit"
 REPORTER_WORKFLOW_RUN_TYPES = ["completed"]
 REPORTER_CONCURRENCY_GROUP = "cache-budget-audit-reporter"
+REPORTER_CHECKOUT_ACTION = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
 REPORTER_CHECKOUT_REF = "${{ github.event.repository.default_branch }}"
+REPORTER_SETUP_NODE_ACTION = "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020"
+REPORTER_NODE_VERSION = "22"
+REPORTER_TOKEN = "${{ secrets.GITHUB_TOKEN }}"
+REPORTER_RUNNER_STEP_NAME = "Create, update, or resolve cache budget audit issue"
 REPORTER_COMMAND = ["node", ".github/scripts/report-cache-budget-audit.mjs"]
 REPORTER_TRUSTED_CONDITION = " ".join(
     [
@@ -50,7 +55,10 @@ REQUIRED_WATCHED_PATHS = {
     ".github/scripts/audit-cache-budget.mjs",
     ".github/scripts/audit-cache-budget.test.mjs",
     ".github/scripts/run-cache-budget-audit.mjs",
+    ".github/scripts/report-cache-budget-audit.mjs",
+    ".github/scripts/report-cache-budget-audit.test.mjs",
     ".github/workflows/cache-budget-audit.yml",
+    ".github/workflows/cache-budget-audit-reporter.yml",
     ".github/workflows/ci.yml",
     ".github/workflows/merge-readiness.yml",
 }
@@ -246,6 +254,8 @@ def validate_reporter_workflow(document: Any) -> list[str]:
     if job is None:
         return errors
 
+    if "permissions" in job:
+        errors.append("reporter job must not declare a permissions override")
     if "continue-on-error" in job:
         errors.append("reporter job must not declare 'continue-on-error'")
     if _normalized_text(job.get("if")) != REPORTER_TRUSTED_CONDITION:
@@ -258,30 +268,39 @@ def validate_reporter_workflow(document: Any) -> list[str]:
         errors.append("reporter job steps must be a list")
         return errors
     steps = steps_value
-    checkout_indices = [
-        index
-        for index, step in enumerate(steps)
-        if isinstance(step, Mapping)
-        and isinstance(step.get("uses"), str)
-        and step["uses"].startswith("actions/checkout@")
-    ]
-    if len(checkout_indices) != 1:
-        errors.append("reporter job must contain exactly one checkout step")
+    if not (
+        len(steps) == 3
+        and all(isinstance(step, Mapping) for step in steps)
+        and isinstance(steps[0].get("uses"), str)
+        and steps[0]["uses"].startswith("actions/checkout@")
+        and isinstance(steps[1].get("uses"), str)
+        and steps[1]["uses"].startswith("actions/setup-node@")
+        and steps[2].get("name") == REPORTER_RUNNER_STEP_NAME
+    ):
+        errors.append(
+            "reporter job steps must be exactly checkout, setup-node, and reconciliation runner in that order"
+        )
+        return errors
+
+    checkout = steps[0]
+    if checkout.get("uses") != REPORTER_CHECKOUT_ACTION:
+        errors.append("reporter checkout action must be pinned to the approved commit")
     else:
-        checkout = steps[checkout_indices[0]]
         checkout_with = checkout.get("with")
         if not isinstance(checkout_with, Mapping) or checkout_with.get("ref") != REPORTER_CHECKOUT_REF:
             errors.append("reporter checkout must use the repository default branch ref")
         if not isinstance(checkout_with, Mapping) or checkout_with.get("persist-credentials") is not False:
             errors.append("reporter checkout must disable persisted credentials")
 
-    runner_indices = _named_step_indices(
-        steps, "Create, update, or resolve cache budget audit issue"
-    )
-    if len(runner_indices) != 1:
-        errors.append("reporter job must contain exactly one named reconciliation runner step")
-        return errors
-    runner = steps[runner_indices[0]]
+    setup_node = steps[1]
+    if setup_node.get("uses") != REPORTER_SETUP_NODE_ACTION:
+        errors.append("reporter setup-node action must be pinned to the approved commit")
+    if setup_node.get("with") != {"node-version": REPORTER_NODE_VERSION}:
+        errors.append("reporter setup-node step must use exactly node-version 22")
+
+    runner = steps[2]
+    if runner.get("env") != {"GITHUB_TOKEN": REPORTER_TOKEN}:
+        errors.append("reporter reconciliation runner must bind GITHUB_TOKEN to secrets.GITHUB_TOKEN")
     if "if" in runner:
         errors.append("reporter reconciliation runner must not declare 'if'")
     if "continue-on-error" in runner:

--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -505,12 +505,32 @@ def validate_reporter_workflow(document: Any) -> list[str]:
     return errors
 
 
+def validate_audit_workflow_name_uniqueness(workflows_directory: Path) -> list[str]:
+    """Reject another workflow that could match the reporter's source name."""
+    errors: list[str] = []
+    matching_workflows = []
+    for path in sorted(workflows_directory.iterdir()):
+        if not path.is_file() or path.suffix not in {".yaml", ".yml"}:
+            continue
+        document = load_workflow(path)
+        if isinstance(document, Mapping) and document.get("name") == AUDIT_WORKFLOW_NAME:
+            matching_workflows.append(path.name)
+
+    if len(matching_workflows) > 1:
+        errors.append(
+            "audit workflow name "
+            f"'{AUDIT_WORKFLOW_NAME}' must be unique; found in: {', '.join(matching_workflows)}"
+        )
+    return errors
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--workflow", type=Path, default=DEFAULT_WORKFLOW)
     parser.add_argument("--reporter-workflow", type=Path, default=DEFAULT_REPORTER_WORKFLOW)
     args = parser.parse_args()
 
+    audit_workflow_loaded = False
     try:
         document = load_workflow(args.workflow)
     except FileNotFoundError:
@@ -520,6 +540,7 @@ def main() -> int:
     except yaml.YAMLError as error:
         errors = [f"workflow YAML is invalid: {error}"]
     else:
+        audit_workflow_loaded = True
         errors = validate_workflow(document)
     try:
         reporter_document = load_workflow(args.reporter_workflow)
@@ -533,6 +554,8 @@ def main() -> int:
         errors.append(f"reporter workflow YAML is invalid: {error}")
     else:
         errors.extend(validate_reporter_workflow(reporter_document))
+    if audit_workflow_loaded:
+        errors.extend(validate_audit_workflow_name_uniqueness(args.workflow.parent))
     if errors:
         for error in errors:
             print(f"cache-budget-audit workflow wiring: FAIL -- {error}")

--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -21,11 +21,30 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "cache-budget-audit.yml"
+DEFAULT_REPORTER_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "cache-budget-audit-reporter.yml"
+)
 AUDIT_JOB_ID = "audit"
 CALIBRATION_STEP_NAME = "Calibrate the audit"
 LIVE_AUDIT_STEP_NAME = "Audit the live cache budget"
 LIVE_AUDIT_COMMAND = ["node", ".github/scripts/run-cache-budget-audit.mjs"]
 REQUIRED_PERMISSIONS = {"actions": "read", "contents": "read"}
+REPORTER_JOB_ID = "reconcile"
+REPORTER_PERMISSIONS = {"actions": "read", "contents": "read", "issues": "write"}
+REPORTER_WORKFLOW_RUN_SOURCE = "cache budget audit"
+REPORTER_WORKFLOW_RUN_TYPES = ["completed"]
+REPORTER_CONCURRENCY_GROUP = "cache-budget-audit-reporter"
+REPORTER_CHECKOUT_REF = "${{ github.event.repository.default_branch }}"
+REPORTER_COMMAND = ["node", ".github/scripts/report-cache-budget-audit.mjs"]
+REPORTER_TRUSTED_CONDITION = " ".join(
+    [
+        "github.event.workflow_run.head_repository.full_name == github.repository &&",
+        "github.event.workflow_run.head_branch == github.event.repository.default_branch &&",
+        "(github.event.workflow_run.event == 'push' ||",
+        "github.event.workflow_run.event == 'schedule' ||",
+        "github.event.workflow_run.event == 'workflow_dispatch')",
+    ]
+)
 REQUIRED_TRIGGERS = ("schedule", "workflow_dispatch", "push")
 REQUIRED_WATCHED_PATHS = {
     ".github/scripts/audit-cache-budget.mjs",
@@ -182,9 +201,104 @@ def validate_workflow(document: Any) -> list[str]:
     return errors
 
 
+def _normalized_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return " ".join(value.split())
+
+
+def validate_reporter_workflow(document: Any) -> list[str]:
+    """Return every violated cache-budget-audit reporter wiring contract."""
+    errors: list[str] = []
+    workflow = _mapping(document, "reporter workflow", errors)
+    if workflow is None:
+        return errors
+
+    triggers = _mapping(workflow.get("on"), "reporter workflow 'on'", errors)
+    if triggers is not None:
+        workflow_run = _mapping(
+            triggers.get("workflow_run"), "reporter trigger 'workflow_run'", errors
+        )
+        if workflow_run is not None:
+            if workflow_run.get("workflows") != [REPORTER_WORKFLOW_RUN_SOURCE]:
+                errors.append(
+                    "reporter workflow_run.workflows must be exactly ['cache budget audit']"
+                )
+            if workflow_run.get("types") != REPORTER_WORKFLOW_RUN_TYPES:
+                errors.append("reporter workflow_run.types must be exactly ['completed']")
+
+    if workflow.get("permissions") != REPORTER_PERMISSIONS:
+        errors.append(
+            "reporter permissions must be exactly actions: read, contents: read, and issues: write"
+        )
+
+    concurrency = _mapping(workflow.get("concurrency"), "reporter concurrency", errors)
+    if concurrency is not None:
+        if concurrency.get("group") != REPORTER_CONCURRENCY_GROUP:
+            errors.append("reporter concurrency group must be 'cache-budget-audit-reporter'")
+        if concurrency.get("cancel-in-progress") is not False:
+            errors.append("reporter concurrency cancel-in-progress must be false")
+
+    jobs = _mapping(workflow.get("jobs"), "reporter workflow jobs", errors)
+    if jobs is None:
+        return errors
+    job = _mapping(jobs.get(REPORTER_JOB_ID), f"reporter job '{REPORTER_JOB_ID}'", errors)
+    if job is None:
+        return errors
+
+    if "continue-on-error" in job:
+        errors.append("reporter job must not declare 'continue-on-error'")
+    if _normalized_text(job.get("if")) != REPORTER_TRUSTED_CONDITION:
+        errors.append(
+            "reporter job must restrict to trusted default-branch schedule, push, or workflow_dispatch audits"
+        )
+
+    steps_value = job.get("steps")
+    if not isinstance(steps_value, list):
+        errors.append("reporter job steps must be a list")
+        return errors
+    steps = steps_value
+    checkout_indices = [
+        index
+        for index, step in enumerate(steps)
+        if isinstance(step, Mapping)
+        and isinstance(step.get("uses"), str)
+        and step["uses"].startswith("actions/checkout@")
+    ]
+    if len(checkout_indices) != 1:
+        errors.append("reporter job must contain exactly one checkout step")
+    else:
+        checkout = steps[checkout_indices[0]]
+        checkout_with = checkout.get("with")
+        if not isinstance(checkout_with, Mapping) or checkout_with.get("ref") != REPORTER_CHECKOUT_REF:
+            errors.append("reporter checkout must use the repository default branch ref")
+        if not isinstance(checkout_with, Mapping) or checkout_with.get("persist-credentials") is not False:
+            errors.append("reporter checkout must disable persisted credentials")
+
+    runner_indices = _named_step_indices(
+        steps, "Create, update, or resolve cache budget audit issue"
+    )
+    if len(runner_indices) != 1:
+        errors.append("reporter job must contain exactly one named reconciliation runner step")
+        return errors
+    runner = steps[runner_indices[0]]
+    if "if" in runner:
+        errors.append("reporter reconciliation runner must not declare 'if'")
+    if "continue-on-error" in runner:
+        errors.append("reporter reconciliation runner must not declare 'continue-on-error'")
+    if _normalized_argv(runner.get("run")) != REPORTER_COMMAND:
+        errors.append(
+            "reporter reconciliation command must be exactly "
+            "'node .github/scripts/report-cache-budget-audit.mjs'"
+        )
+
+    return errors
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--workflow", type=Path, default=DEFAULT_WORKFLOW)
+    parser.add_argument("--reporter-workflow", type=Path, default=DEFAULT_REPORTER_WORKFLOW)
     args = parser.parse_args()
 
     try:
@@ -197,6 +311,18 @@ def main() -> int:
         errors = [f"workflow YAML is invalid: {error}"]
     else:
         errors = validate_workflow(document)
+    try:
+        reporter_document = load_workflow(args.reporter_workflow)
+    except FileNotFoundError:
+        errors.append(f"reporter workflow file '{args.reporter_workflow}' does not exist")
+    except OSError as error:
+        errors.append(
+            f"reporter workflow file '{args.reporter_workflow}' could not be read: {error.strerror}"
+        )
+    except yaml.YAMLError as error:
+        errors.append(f"reporter workflow YAML is invalid: {error}")
+    else:
+        errors.extend(validate_reporter_workflow(reporter_document))
     if errors:
         for error in errors:
             print(f"cache-budget-audit workflow wiring: FAIL -- {error}")

--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -70,10 +70,37 @@ REQUIRED_WATCHED_PATHS = {
 class WorkflowLoader(yaml.SafeLoader):
     """SafeLoader with YAML 1.2 boolean spelling for GitHub Actions keys."""
 
+    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> dict[Any, Any]:
+        """Construct every mapping while rejecting duplicate keys at parse time."""
+        mapping: dict[Any, Any] = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                duplicate = key in mapping
+            except TypeError as error:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found an unhashable key",
+                    key_node.start_mark,
+                ) from error
+            if duplicate:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r}",
+                    key_node.start_mark,
+                )
+            mapping[key] = self.construct_object(value_node, deep=deep)
+        return mapping
+
 
 # PyYAML's YAML 1.1 resolver turns the Actions key ``on`` into ``True``.  GitHub
 # Actions uses YAML 1.2 spelling, where only true/false are booleans, so retain
 # those values while treating ``on`` as the string key it is in the workflow.
+# The constructor above covers every mapping the loader touches, including nested
+# step configuration, so a duplicate cannot disappear before a fail-closed
+# approved-mapping check sees the workflow structure.
 WorkflowLoader.yaml_implicit_resolvers = copy.deepcopy(yaml.SafeLoader.yaml_implicit_resolvers)
 for first_character, resolvers in WorkflowLoader.yaml_implicit_resolvers.items():
     WorkflowLoader.yaml_implicit_resolvers[first_character] = [

--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -163,6 +163,12 @@ def validate_workflow(document: Any) -> list[str]:
     workflow = _mapping(document, "workflow", errors)
     if workflow is None:
         return errors
+    _reject_unapproved_keys(
+        workflow,
+        {"name", "on", "permissions", "concurrency", "jobs"},
+        "workflow",
+        errors,
+    )
 
     triggers = _mapping(workflow.get("on"), "workflow 'on'", errors)
     if triggers is not None:
@@ -206,12 +212,23 @@ def validate_workflow(document: Any) -> list[str]:
     jobs = _mapping(workflow.get("jobs"), "workflow jobs", errors)
     if jobs is None:
         return errors
+    _reject_unapproved_keys(jobs, {AUDIT_JOB_ID}, "workflow jobs", errors)
     job = _mapping(jobs.get(AUDIT_JOB_ID), f"job '{AUDIT_JOB_ID}'", errors)
     if job is None:
         return errors
+    if "permissions" in job:
+        errors.append("audit job must not declare a permissions override")
+        return errors
     if "continue-on-error" in job:
         errors.append("audit job must not declare 'continue-on-error'")
+        return errors
 
+    _reject_unapproved_keys(
+        job,
+        {"name", "runs-on", "timeout-minutes", "steps"},
+        "audit job",
+        errors,
+    )
     steps_value = job.get("steps")
     if not isinstance(steps_value, list):
         errors.append("audit job steps must be a list")

--- a/.github/workflows/cache-budget-audit-reporter.yml
+++ b/.github/workflows/cache-budget-audit-reporter.yml
@@ -12,8 +12,10 @@ permissions:
   contents: read
   issues: write
 
-# Do not cancel a pending reconciliation: each runner observes the latest
-# completed trusted audit before it mutates the canonical issue.
+# Do not cancel an in-progress reconciliation. GitHub retains at most one
+# pending concurrency-group run and may replace an older pending run, so the
+# reporter coalesces intermediate failures into its bounded audit summary
+# before it reconciles the latest completed trusted health.
 concurrency:
   group: cache-budget-audit-reporter
   cancel-in-progress: false

--- a/.github/workflows/cache-budget-audit-reporter.yml
+++ b/.github/workflows/cache-budget-audit-reporter.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: cache budget audit reporter
+
+on:
+  workflow_run:
+    workflows: ["cache budget audit"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+# Do not cancel a pending reconciliation: each runner observes the latest
+# completed trusted audit before it mutates the canonical issue.
+concurrency:
+  group: cache-budget-audit-reporter
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: reconcile cache-budget audit issue
+    if: >-
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+      (github.event.workflow_run.event == 'push' ||
+      github.event.workflow_run.event == 'schedule' ||
+      github.event.workflow_run.event == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Create, update, or resolve cache budget audit issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/report-cache-budget-audit.mjs

--- a/.github/workflows/cache-budget-audit-wiring.yml
+++ b/.github/workflows/cache-budget-audit-wiring.yml
@@ -16,7 +16,7 @@ name: cache budget audit wiring
 # This context is intentionally not required yet.  Making it required needs a
 # coordinated, separate rollout through the ruleset contract, fixtures, design
 # record, and live ruleset; this workflow is unfiltered so that future rollout
-# can be evaluated without a path-filter reporting gap.  See issue #802.
+# can be evaluated without a path-filter reporting gap.  See issue #845.
 
 on:
   pull_request:

--- a/.github/workflows/cache-budget-audit.yml
+++ b/.github/workflows/cache-budget-audit.yml
@@ -31,7 +31,10 @@ on:
       - .github/scripts/audit-cache-budget.mjs
       - .github/scripts/audit-cache-budget.test.mjs
       - .github/scripts/run-cache-budget-audit.mjs
+      - .github/scripts/report-cache-budget-audit.mjs
+      - .github/scripts/report-cache-budget-audit.test.mjs
       - .github/workflows/cache-budget-audit.yml
+      - .github/workflows/cache-budget-audit-reporter.yml
       - .github/workflows/ci.yml
       - .github/workflows/merge-readiness.yml
 

--- a/changelog.d/795-cache-budget-audit-reporter.fixed.md
+++ b/changelog.d/795-cache-budget-audit-reporter.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#795): failed trusted Actions cache-budget audits now maintain one deduplicated issue and close it after recovery.

--- a/changelog.d/840-cache-budget-audit-validator-sibling-load.fixed.md
+++ b/changelog.d/840-cache-budget-audit-validator-sibling-load.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#840): Cache-budget audit wiring validation now reports malformed sibling workflows without a traceback.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -901,14 +901,18 @@ reporter invocation steps, so a mutable action, alternate checkout source/path, 
 job, or inserted pre-run shell step cannot alter the checked-out reporter before it receives the
 write token. Its YAML loader also rejects duplicate keys while constructing every mapping, before a
 last-key-wins parser could hide an unapproved value from those mapping checks.
+The same validator constrains the read-only audit workflow: it rejects unknown top-level and audit-job
+keys, jobs other than `audit`, and any audit job-level permission override, so no job can override the
+read-only top-level permission set.
 
 The reporter maintains one canonical issue, identified by the stable hidden marker
 `<!-- cache-budget-audit -->`. The currently reconciled failure has an occurrence marker keyed by
 `run_id:run_attempt`; the initial failure creates the issue, a later failure records a recurrence,
 a successful trusted audit closes the issue with a recovery comment, and a later failure reopens the
 same issue. A human close does not change identity: the next distinct failure reopens the canonical
-issue. Comment markers count only when authored by `github-actions[bot]`, so a user cannot suppress
-the reporter's audit trail by posting a predictable marker.
+issue. A comment counts as reporter-authored only when it is authored by `github-actions[bot]` and an
+exact cache-budget reporter marker begins its body; a quoted marker or unrelated Actions comment does
+not suppress the reporter's audit trail.
 
 Before mutation the reporter lists completed default-branch audit runs and chooses the greatest
 `(run_number, run_attempt)` among trusted runs. It intentionally does not use completion timestamps:
@@ -936,12 +940,16 @@ are consolidated. A missing, malformed, or unsafe cursor/count/identity field, o
 that disagree, instead fails reconciliation without mutation; it is not silently repaired or reset.
 Summary integers must be canonical decimal safe integers; cursor and identity parts are positive,
 identities are unique, and the count covers every retained identity. A cursor newer than currently
-observable trusted health is rejected rather than moved backward. The visible count is cumulative
-only for its summary interval: deleting the complete summary intentionally resets that interval, and
-the next summary starts a new count rather than claiming to reconstruct deleted evidence. These rules
-preserve the meaning of a retained cumulative count instead of presenting a false repaired value. The
-audit's `push` paths include the reporter workflow, script, and tests, so a merged reporter change
-runs the live audit immediately instead of waiting for the next schedule or manual dispatch.
+observable trusted health is rejected rather than moved backward, and the writer rejects an addition
+that would exceed the safe-integer limit. The visible count is cumulative since its summary was
+created: deleting the complete summary intentionally resets that history, and the next summary starts
+a new count rather than claiming to reconstruct deleted evidence. The reader accepts the immediately
+preceding unqualified count and identity phrases only to migrate them on the next write; the writer
+emits qualified phrases exclusively. That compatibility may be removed only in an explicit comment
+schema migration after remaining legacy summaries have been verified absent. These rules preserve the
+meaning of a retained cumulative count instead of presenting a false repaired value. The audit's
+`push` paths include the reporter workflow, script, and tests, so a merged reporter change runs the
+live audit immediately instead of waiting for the next schedule or manual dispatch.
 
 ## Required pre-merge contexts, and why the merge queue was rejected
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -894,12 +894,15 @@ cache observation into repository mutation. `.github/workflows/cache-budget-audi
 the separate, least-privilege writer. It has exactly Actions/contents read plus issues write and
 listens only for completed `cache budget audit` runs. Its job additionally requires the same
 repository, the default branch, and one of `push`, `schedule`, or `workflow_dispatch`; it checks out
-the default branch rather than the triggering SHA. The job has no permission override and exactly
-the pinned checkout, pinned Node setup, and reporter invocation steps, so a mutable action or an
-inserted pre-run shell step cannot alter the checked-out reporter before it receives the write token.
+the default branch rather than the triggering SHA. The reporter workflow, trigger, job set, job, and
+each step are checked as approved mappings: unknown keys fail closed, not merely known dangerous
+fields. The job has no permission override and exactly the pinned checkout, pinned Node setup, and
+reporter invocation steps, so a mutable action, alternate checkout source/path, runner shell, extra
+job, or inserted pre-run shell step cannot alter the checked-out reporter before it receives the
+write token.
 
 The reporter maintains one canonical issue, identified by the stable hidden marker
-`<!-- cache-budget-audit -->`. Each run attempt has an occurrence marker keyed by
+`<!-- cache-budget-audit -->`. The currently reconciled failure has an occurrence marker keyed by
 `run_id:run_attempt`; the initial failure creates the issue, a later failure records a recurrence,
 a successful trusted audit closes the issue with a recovery comment, and a later failure reopens the
 same issue. A human close does not change identity: the next distinct failure reopens the canonical
@@ -910,18 +913,25 @@ Before mutation the reporter lists completed default-branch audit runs and choos
 `(run_number, run_attempt)` among trusted runs. It intentionally does not use completion timestamps:
 run numbers establish workflow order and attempts establish re-run order, while completion delivery
 can arrive out of order. A delayed event therefore reconciles current completed health rather than
-reopening an issue for stale failure. Reporter runs serialize with `cancel-in-progress: false` to
-avoid duplicate-creation races.
+reopening an issue for stale failure. This is deliberately **latest-health coalescing**, not a claim
+that every completed attempt receives a durable individual comment: the reporter stores a cursor,
+the cumulative number of skipped failing attempts, and up to 20 recent skipped `run_id:run_attempt`
+identities in its rolling recurrence summary. Thus a queued reporter that observes failures 41, 42,
+and 43 records 43 directly and preserves 41/42 as coalesced evidence. `cancel-in-progress: false`
+does not promise that every pending run executes—GitHub retains one pending concurrency-group run
+and may replace an older pending run—so this coalescing record is required independently of the
+concurrency setting.
 
 The reporter paginates issues, runs, and comments rather than assuming page one is complete. This is
 a scheduled operational path rather than a merge hot path, so the potentially unbounded API scan is
 acceptable to preserve complete idempotency and recovery evidence. Comment volume is nevertheless
 bounded: it keeps at most 20 detailed recurrence comments, then creates and updates one rolling
-recurrence summary; it also updates one rolling recovery summary. Thus it retains at most 22
-reporter-authored comments and a persistent incident cannot turn one canonical issue into an
-unbounded comment log. The audit's `push` paths include the reporter workflow, script, and tests, so
-a merged reporter change runs the live audit immediately instead of waiting for the next schedule or
-manual dispatch.
+recurrence/coalescing summary; it also updates one rolling recovery summary. The reporter
+self-heals duplicate summaries and enforces a maximum of 22 reporter-authored comments, including
+when a marker-intact summary was edited. A persistent incident therefore cannot turn one canonical
+issue into an unbounded comment log. The audit's `push` paths include the reporter workflow, script,
+and tests, so a merged reporter change runs the live audit immediately instead of waiting for the
+next schedule or manual dispatch.
 
 ## Required pre-merge contexts, and why the merge queue was rejected
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -899,7 +899,8 @@ each step are checked as approved mappings: unknown keys fail closed, not merely
 fields. The job has no permission override and exactly the pinned checkout, pinned Node setup, and
 reporter invocation steps, so a mutable action, alternate checkout source/path, runner shell, extra
 job, or inserted pre-run shell step cannot alter the checked-out reporter before it receives the
-write token.
+write token. Its YAML loader also rejects duplicate keys while constructing every mapping, before a
+last-key-wins parser could hide an unapproved value from those mapping checks.
 
 The reporter maintains one canonical issue, identified by the stable hidden marker
 `<!-- cache-budget-audit -->`. The currently reconciled failure has an occurrence marker keyed by
@@ -915,23 +916,26 @@ run numbers establish workflow order and attempts establish re-run order, while 
 can arrive out of order. A delayed event therefore reconciles current completed health rather than
 reopening an issue for stale failure. This is deliberately **latest-health coalescing**, not a claim
 that every completed attempt receives a durable individual comment: the reporter stores a cursor,
-the cumulative number of skipped failing attempts, and up to 20 recent skipped `run_id:run_attempt`
-identities in its rolling recurrence summary. Thus a queued reporter that observes failures 41, 42,
-and 43 records 43 directly and preserves 41/42 as coalesced evidence. `cancel-in-progress: false`
-does not promise that every pending run executes—GitHub retains one pending concurrency-group run
-and may replace an older pending run—so this coalescing record is required independently of the
-concurrency setting.
+the cumulative number of skipped failing latest attempts returned by the workflow-runs list endpoint,
+and up to 20 recent `run_id:run_attempt` identities from that same endpoint in its rolling recurrence
+summary. That endpoint does not expose an earlier superseded attempt of the same run ID, so the
+summary cannot recover or count such an attempt when no reporter ran for it. Thus a queued reporter
+that observes list-returned failures 41, 42, and 43 records 43 directly and preserves 41/42 as
+coalesced evidence. `cancel-in-progress: false` does not promise that every pending run
+executes—GitHub retains one pending concurrency-group run and may replace an older pending run—so
+this bounded, available evidence is required independently of the concurrency setting.
 
 The reporter paginates issues, runs, and comments rather than assuming page one is complete. This is
 a scheduled operational path rather than a merge hot path, so the potentially unbounded API scan is
-acceptable to preserve complete idempotency and recovery evidence. Comment volume is nevertheless
-bounded: it keeps at most 20 detailed recurrence comments, then creates and updates one rolling
-recurrence/coalescing summary; it also updates one rolling recovery summary. The reporter
-self-heals duplicate summaries and enforces a maximum of 22 reporter-authored comments, including
-when a marker-intact summary was edited. A persistent incident therefore cannot turn one canonical
-issue into an unbounded comment log. The audit's `push` paths include the reporter workflow, script,
-and tests, so a merged reporter change runs the live audit immediately instead of waiting for the
-next schedule or manual dispatch.
+acceptable to preserve marker idempotency and all evidence the endpoint makes available. For valid
+reporter-authored state, comment volume is bounded: it keeps at most 20 detailed recurrence comments,
+then creates and updates one rolling recurrence/coalescing summary; it also updates one rolling
+recovery summary, for at most 22 reporter-authored comments. Identical occurrence-summary duplicates
+are consolidated. A missing, malformed, or unsafe cursor/count/identity field, or duplicate summaries
+that disagree, instead fails reconciliation without mutation; it is not silently repaired or reset.
+This preserves the meaning of the cumulative count instead of presenting a false repaired value. The
+audit's `push` paths include the reporter workflow, script, and tests, so a merged reporter change
+runs the live audit immediately instead of waiting for the next schedule or manual dispatch.
 
 ## Required pre-merge contexts, and why the merge queue was rejected
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -886,6 +886,43 @@ gating a merge on it would gate on something outside the change under review.
 Issue #747 records the incident. Issue #720's Finding 2 — warming the fault-operator scratch build —
 **adds** a cache and therefore depends on this budget holding first.
 
+### Cache-budget audit failure reporting
+
+`.github/workflows/cache-budget-audit.yml` deliberately remains an observer: it has only
+`actions: read` and `contents: read`, including on `workflow_dispatch`, so it cannot turn a live
+cache observation into repository mutation. `.github/workflows/cache-budget-audit-reporter.yml` is
+the separate, least-privilege writer. It has exactly Actions/contents read plus issues write and
+listens only for completed `cache budget audit` runs. Its job additionally requires the same
+repository, the default branch, and one of `push`, `schedule`, or `workflow_dispatch`; it checks out
+the default branch rather than the triggering SHA. The job has no permission override and exactly
+the pinned checkout, pinned Node setup, and reporter invocation steps, so a mutable action or an
+inserted pre-run shell step cannot alter the checked-out reporter before it receives the write token.
+
+The reporter maintains one canonical issue, identified by the stable hidden marker
+`<!-- cache-budget-audit -->`. Each run attempt has an occurrence marker keyed by
+`run_id:run_attempt`; the initial failure creates the issue, a later failure records a recurrence,
+a successful trusted audit closes the issue with a recovery comment, and a later failure reopens the
+same issue. A human close does not change identity: the next distinct failure reopens the canonical
+issue. Comment markers count only when authored by `github-actions[bot]`, so a user cannot suppress
+the reporter's audit trail by posting a predictable marker.
+
+Before mutation the reporter lists completed default-branch audit runs and chooses the greatest
+`(run_number, run_attempt)` among trusted runs. It intentionally does not use completion timestamps:
+run numbers establish workflow order and attempts establish re-run order, while completion delivery
+can arrive out of order. A delayed event therefore reconciles current completed health rather than
+reopening an issue for stale failure. Reporter runs serialize with `cancel-in-progress: false` to
+avoid duplicate-creation races.
+
+The reporter paginates issues, runs, and comments rather than assuming page one is complete. This is
+a scheduled operational path rather than a merge hot path, so the potentially unbounded API scan is
+acceptable to preserve complete idempotency and recovery evidence. Comment volume is nevertheless
+bounded: it keeps at most 20 detailed recurrence comments, then creates and updates one rolling
+recurrence summary; it also updates one rolling recovery summary. Thus it retains at most 22
+reporter-authored comments and a persistent incident cannot turn one canonical issue into an
+unbounded comment log. The audit's `push` paths include the reporter workflow, script, and tests, so
+a merged reporter change runs the live audit immediately instead of waiting for the next schedule or
+manual dispatch.
+
 ## Required pre-merge contexts, and why the merge queue was rejected
 
 The `main` ruleset (`main safety and CI`, id `19090811`) requires six contexts: `merge readiness`,

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -906,6 +906,9 @@ unknown workflow, trigger, concurrency, job, and step keys; jobs other than `aud
 permission overrides; unpinned actions; and any reordered, inserted, or altered calibration/live-audit
 step. It fixes the read-only token binding and command of the live audit, so no job can override the
 read-only top-level permission set or alter the checked-out audit before that command runs.
+The validator also enumerates every `.yml`/`.yaml` workflow in `.github/workflows/` and requires
+`cache budget audit` to be unique, preventing another default-branch workflow from impersonating the
+name that GitHub uses to select `workflow_run` subscribers.
 
 The reporter maintains one canonical issue, identified by the stable hidden marker
 `<!-- cache-budget-audit -->`. The currently reconciled failure has an occurrence marker keyed by
@@ -959,10 +962,11 @@ writer commits at test time: this repository squash-merges pull requests, so tho
 not survive on `main`. Each fixture records its writer commit, writer/output SHA-256 digests, and its
 capture command; regeneration is a deliberate operation that first makes the original writer commit
 available and then refreshes the recorded digests. The test locks each committed body to its recorded
-output digest and fixed writer commit/digest labels while rejecting Git-history lookup; it cannot
-rehash an original writer that squash merge has removed, so the writer digest is an auditable review
-record rather than a run-time source verification. Both the full-history automation checkout and a
-shallow developer clone therefore exercise the same persisted output.
+output digest and fixed writer commit/digest labels, then runs the full reporter test file from a
+non-Git directory with no Git executable; imported modules therefore cannot hide a Git-history
+lookup. It cannot rehash an original writer that squash merge has removed, so the writer digest is an
+auditable review record rather than a run-time source verification. Both the full-history automation
+checkout and a shallow developer clone therefore exercise the same persisted output.
 
 ## Required pre-merge contexts, and why the merge queue was rejected
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -958,9 +958,11 @@ Historical-summary compatibility tests consume committed output fixtures rather 
 writer commits at test time: this repository squash-merges pull requests, so those source commits do
 not survive on `main`. Each fixture records its writer commit, writer/output SHA-256 digests, and its
 capture command; regeneration is a deliberate operation that first makes the original writer commit
-available and then refreshes the recorded digests. The test asserts that provenance and fixture
-integrity while rejecting Git-history lookup, so both the full-history automation checkout and a
-shallow developer clone exercise the same persisted output.
+available and then refreshes the recorded digests. The test locks each committed body to its recorded
+output digest and fixed writer commit/digest labels while rejecting Git-history lookup; it cannot
+rehash an original writer that squash merge has removed, so the writer digest is an auditable review
+record rather than a run-time source verification. Both the full-history automation checkout and a
+shallow developer clone therefore exercise the same persisted output.
 
 ## Required pre-merge contexts, and why the merge queue was rejected
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -916,14 +916,15 @@ run numbers establish workflow order and attempts establish re-run order, while 
 can arrive out of order. A delayed event therefore reconciles current completed health rather than
 reopening an issue for stale failure. This is deliberately **latest-health coalescing**, not a claim
 that every completed attempt receives a durable individual comment: the reporter stores a cursor,
-the cumulative number of skipped failing latest attempts returned by the workflow-runs list endpoint,
-and up to 20 recent `run_id:run_attempt` identities from that same endpoint in its rolling recurrence
-summary. That endpoint does not expose an earlier superseded attempt of the same run ID, so the
-summary cannot recover or count such an attempt when no reporter ran for it. Thus a queued reporter
-that observes list-returned failures 41, 42, and 43 records 43 directly and preserves 41/42 as
-coalesced evidence. `cancel-in-progress: false` does not promise that every pending run
-executes—GitHub retains one pending concurrency-group run and may replace an older pending run—so
-this bounded, available evidence is required independently of the concurrency setting.
+the cumulative number of skipped failing attempts observable through either the triggering
+`workflow_run` event or the workflow-runs list endpoint, and up to 20 recent
+`run_id:run_attempt` identities from those sources in its rolling recurrence summary. An earlier
+superseded attempt is not recoverable when it is absent from the list endpoint and did not trigger a
+reporter run. Thus a queued reporter that observes failures 41, 42, and 43 records 43 directly and
+preserves 41/42 as coalesced evidence. `cancel-in-progress: false` does not promise that every
+pending run executes—GitHub retains one pending concurrency-group run and may replace an older
+pending run—so this bounded, observable evidence is required independently of the concurrency
+setting.
 
 The reporter paginates issues, runs, and comments rather than assuming page one is complete. This is
 a scheduled operational path rather than a merge hot path, so the potentially unbounded API scan is
@@ -933,7 +934,12 @@ then creates and updates one rolling recurrence/coalescing summary; it also upda
 recovery summary, for at most 22 reporter-authored comments. Identical occurrence-summary duplicates
 are consolidated. A missing, malformed, or unsafe cursor/count/identity field, or duplicate summaries
 that disagree, instead fails reconciliation without mutation; it is not silently repaired or reset.
-This preserves the meaning of the cumulative count instead of presenting a false repaired value. The
+Summary integers must be canonical decimal safe integers; cursor and identity parts are positive,
+identities are unique, and the count covers every retained identity. A cursor newer than currently
+observable trusted health is rejected rather than moved backward. The visible count is cumulative
+only for its summary interval: deleting the complete summary intentionally resets that interval, and
+the next summary starts a new count rather than claiming to reconstruct deleted evidence. These rules
+preserve the meaning of a retained cumulative count instead of presenting a false repaired value. The
 audit's `push` paths include the reporter workflow, script, and tests, so a merged reporter change
 runs the live audit immediately instead of waiting for the next schedule or manual dispatch.
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -901,9 +901,11 @@ reporter invocation steps, so a mutable action, alternate checkout source/path, 
 job, or inserted pre-run shell step cannot alter the checked-out reporter before it receives the
 write token. Its YAML loader also rejects duplicate keys while constructing every mapping, before a
 last-key-wins parser could hide an unapproved value from those mapping checks.
-The same validator constrains the read-only audit workflow: it rejects unknown top-level and audit-job
-keys, jobs other than `audit`, and any audit job-level permission override, so no job can override the
-read-only top-level permission set.
+The same validator constrains the read-only audit workflow as a complete approved mapping: it rejects
+unknown workflow, trigger, concurrency, job, and step keys; jobs other than `audit`; job-level
+permission overrides; unpinned actions; and any reordered, inserted, or altered calibration/live-audit
+step. It fixes the read-only token binding and command of the live audit, so no job can override the
+read-only top-level permission set or alter the checked-out audit before that command runs.
 
 The reporter maintains one canonical issue, identified by the stable hidden marker
 `<!-- cache-budget-audit -->`. The currently reconciled failure has an occurrence marker keyed by
@@ -943,10 +945,11 @@ identities are unique, and the count covers every retained identity. A cursor ne
 observable trusted health is rejected rather than moved backward, and the writer rejects an addition
 that would exceed the safe-integer limit. The visible count is cumulative since its summary was
 created: deleting the complete summary intentionally resets that history, and the next summary starts
-a new count rather than claiming to reconstruct deleted evidence. The reader accepts the immediately
-preceding unqualified count and identity phrases only to migrate them on the next write; the writer
-emits qualified phrases exclusively. That compatibility may be removed only in an explicit comment
-schema migration after remaining legacy summaries have been verified absent. These rules preserve the
+a new count rather than claiming to reconstruct deleted evidence. The reader accepts the original
+unqualified count/identity phrases and the preceding `in this summary interval` count phrase only to
+migrate them on the next write; the writer emits the current qualified phrases exclusively. That
+compatibility may be removed only in an explicit comment schema migration after remaining legacy
+summaries have been verified absent. These rules preserve the
 meaning of a retained cumulative count instead of presenting a false repaired value. The audit's
 `push` paths include the reporter workflow, script, and tests, so a merged reporter change runs the
 live audit immediately instead of waiting for the next schedule or manual dispatch.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -954,6 +954,14 @@ meaning of a retained cumulative count instead of presenting a false repaired va
 `push` paths include the reporter workflow, script, and tests, so a merged reporter change runs the
 live audit immediately instead of waiting for the next schedule or manual dispatch.
 
+Historical-summary compatibility tests consume committed output fixtures rather than resolving their
+writer commits at test time: this repository squash-merges pull requests, so those source commits do
+not survive on `main`. Each fixture records its writer commit, writer/output SHA-256 digests, and its
+capture command; regeneration is a deliberate operation that first makes the original writer commit
+available and then refreshes the recorded digests. The test asserts that provenance and fixture
+integrity while rejecting Git-history lookup, so both the full-history automation checkout and a
+shallow developer clone exercise the same persisted output.
+
 ## Required pre-merge contexts, and why the merge queue was rejected
 
 The `main` ruleset (`main safety and CI`, id `19090811`) requires six contexts: `merge readiness`,

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -759,6 +759,14 @@ def _run_cli(
     )
 
 
+def _copy_validator_workflows(tmp_path: Path) -> tuple[Path, Path]:
+    audit_path = tmp_path / WORKFLOW_PATH.name
+    reporter_path = tmp_path / REPORTER_WORKFLOW_PATH.name
+    audit_path.write_text(WORKFLOW_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+    reporter_path.write_text(REPORTER_WORKFLOW_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+    return audit_path, reporter_path
+
+
 def _assert_cli_failure(path: Path, expected: str) -> None:
     result = _run_cli(path)
     output = result.stdout + result.stderr
@@ -836,6 +844,30 @@ def test_cli_reports_unreadable_reporter_workflow_file(tmp_path: Path):
         f"cache-budget-audit workflow wiring: FAIL -- reporter workflow file '{path}' could not be read:"
     )
     assert "Traceback" not in output
+
+
+def test_cli_rejects_malformed_sibling_workflow_yaml_without_traceback(tmp_path: Path):
+    audit_path, reporter_path = _copy_validator_workflows(tmp_path)
+    sibling_path = tmp_path / "malformed-sibling.yml"
+    sibling_path.write_text("name: malformed sibling\n  invalid: [\n", encoding="utf-8")
+
+    result = _run_cli(audit_path, reporter_path)
+    output = result.stdout + result.stderr
+    expected = f"workflow YAML is invalid: sibling workflow file '{sibling_path}':"
+
+    assert result.returncode == 1, output
+    assert result.stdout.startswith(f"cache-budget-audit workflow wiring: FAIL -- {expected}")
+    assert "Traceback" not in output
+
+
+def test_cli_accepts_well_formed_unrelated_sibling_workflow(tmp_path: Path):
+    audit_path, reporter_path = _copy_validator_workflows(tmp_path)
+    (tmp_path / "unrelated.yml").write_text("name: unrelated workflow\n", encoding="utf-8")
+
+    result = _run_cli(audit_path, reporter_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout == "cache-budget-audit workflow wiring: PASS\n"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -55,7 +55,7 @@ def _reporter_checkout_step(document: dict[str, Any]) -> dict[str, Any]:
     return next(
         step
         for step in _reporter_job(document)["steps"]
-        if isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@")
+        if step.get("uses") == validator.REPORTER_CHECKOUT_ACTION
     )
 
 
@@ -63,7 +63,7 @@ def _reporter_runner_step(document: dict[str, Any]) -> dict[str, Any]:
     return next(
         step
         for step in _reporter_job(document)["steps"]
-        if step.get("name") == "Create, update, or resolve cache budget audit issue"
+        if step.get("name") == validator.REPORTER_RUNNER_STEP_NAME
     )
 
 
@@ -198,12 +198,24 @@ def _replace_reporter_with_list(_document: dict[str, Any]) -> list[str]:
     return ["not a reporter workflow mapping"]
 
 
+def _add_reporter_workflow_key(document: dict[str, Any]) -> None:
+    document["defaults"] = {}
+
+
 def _set_reporter_on_to_list(document: dict[str, Any]) -> None:
     document["on"] = []
 
 
 def _set_reporter_workflow_run_to_list(document: dict[str, Any]) -> None:
     document["on"]["workflow_run"] = []
+
+
+def _add_reporter_trigger(document: dict[str, Any]) -> None:
+    document["on"]["push"] = {"branches": ["main"]}
+
+
+def _add_reporter_workflow_run_key(document: dict[str, Any]) -> None:
+    document["on"]["workflow_run"]["branches"] = ["main"]
 
 
 def _replace_reporter_source(document: dict[str, Any]) -> None:
@@ -229,6 +241,10 @@ def _set_reporter_concurrency_to_list(document: dict[str, Any]) -> None:
     document["concurrency"] = []
 
 
+def _add_reporter_concurrency_key(document: dict[str, Any]) -> None:
+    document["concurrency"]["extra"] = True
+
+
 def _replace_reporter_concurrency_group(document: dict[str, Any]) -> None:
     document["concurrency"]["group"] = "wrong-group"
 
@@ -239,6 +255,10 @@ def _enable_reporter_cancel_in_progress(document: dict[str, Any]) -> None:
 
 def _remove_reporter_jobs(document: dict[str, Any]) -> None:
     del document["jobs"]
+
+
+def _add_reporter_job(document: dict[str, Any]) -> None:
+    document["jobs"]["attacker"] = {"runs-on": "ubuntu-latest", "steps": []}
 
 
 def _set_reporter_job_to_list(document: dict[str, Any]) -> None:
@@ -257,6 +277,10 @@ def _reporter_job_permissions_override(document: dict[str, Any]) -> None:
     _reporter_job(document)["permissions"] = validator.REPORTER_PERMISSIONS.copy()
 
 
+def _add_reporter_job_key(document: dict[str, Any]) -> None:
+    _reporter_job(document)["defaults"] = {"run": {"shell": "bash"}}
+
+
 def _remove_reporter_steps(document: dict[str, Any]) -> None:
     del _reporter_job(document)["steps"]
 
@@ -265,11 +289,25 @@ def _insert_reporter_shell_step(document: dict[str, Any]) -> None:
     _reporter_job(document)["steps"].insert(2, {"run": "printf compromised"})
 
 
+def _add_checkout_key(key: str, value: Any) -> Callable[[dict[str, Any]], None]:
+    def mutate(document: dict[str, Any]) -> None:
+        _reporter_checkout_step(document)["with"][key] = value
+
+    return mutate
+
+
+def _add_checkout_step_key(key: str, value: Any) -> Callable[[dict[str, Any]], None]:
+    def mutate(document: dict[str, Any]) -> None:
+        _reporter_checkout_step(document)[key] = value
+
+    return mutate
+
+
 def _remove_reporter_checkout(document: dict[str, Any]) -> None:
     _reporter_job(document)["steps"] = [
         step
         for step in _reporter_job(document)["steps"]
-        if not (isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@"))
+        if step.get("uses") != validator.REPORTER_CHECKOUT_ACTION
     ]
 
 
@@ -297,7 +335,7 @@ def _remove_reporter_runner(document: dict[str, Any]) -> None:
     _reporter_job(document)["steps"] = [
         step
         for step in _reporter_job(document)["steps"]
-        if step.get("name") != "Create, update, or resolve cache budget audit issue"
+        if step.get("name") != validator.REPORTER_RUNNER_STEP_NAME
     ]
 
 
@@ -315,6 +353,13 @@ def _append_true_to_reporter_runner(document: dict[str, Any]) -> None:
 
 def _replace_reporter_runner_token(document: dict[str, Any]) -> None:
     _reporter_runner_step(document)["env"]["GITHUB_TOKEN"] = "${{ github.token }}"
+
+
+def _add_runner_key(key: str, value: Any) -> Callable[[dict[str, Any]], None]:
+    def mutate(document: dict[str, Any]) -> None:
+        _reporter_runner_step(document)[key] = value
+
+    return mutate
 
 
 Mutation = tuple[str, Callable[[dict[str, Any]], Any], str]
@@ -365,8 +410,11 @@ MUTATIONS: list[Mutation] = [
 ReporterMutation = tuple[str, Callable[[dict[str, Any]], Any], str]
 REPORTER_MUTATIONS: list[ReporterMutation] = [
     ("replace reporter with a YAML list", _replace_reporter_with_list, "reporter workflow must be a mapping"),
+    ("add reporter workflow key", _add_reporter_workflow_key, "reporter workflow must not declare unapproved keys: defaults"),
     ("set reporter on to a list", _set_reporter_on_to_list, "reporter workflow 'on' must be a mapping"),
     ("set reporter workflow_run to a list", _set_reporter_workflow_run_to_list, "reporter trigger 'workflow_run' must be a mapping"),
+    ("add reporter trigger", _add_reporter_trigger, "reporter workflow 'on' must not declare unapproved keys: push"),
+    ("add reporter workflow_run key", _add_reporter_workflow_run_key, "reporter trigger 'workflow_run' must not declare unapproved keys: branches"),
     ("replace reporter workflow source", _replace_reporter_source, "reporter workflow_run.workflows must be exactly ['cache budget audit']"),
     ("replace reporter workflow types", _replace_reporter_types, "reporter workflow_run.types must be exactly ['completed']"),
     *[
@@ -383,16 +431,47 @@ REPORTER_MUTATIONS: list[ReporterMutation] = [
         "reporter permissions must be exactly actions: read, contents: read, and issues: write",
     ),
     ("set reporter concurrency to a list", _set_reporter_concurrency_to_list, "reporter concurrency must be a mapping"),
+    ("add reporter concurrency key", _add_reporter_concurrency_key, "reporter concurrency must not declare unapproved keys: extra"),
     ("replace reporter concurrency group", _replace_reporter_concurrency_group, "reporter concurrency group must be 'cache-budget-audit-reporter'"),
     ("enable reporter cancellation", _enable_reporter_cancel_in_progress, "reporter concurrency cancel-in-progress must be false"),
     ("remove reporter jobs", _remove_reporter_jobs, "reporter workflow jobs must be a mapping"),
+    ("add reporter job", _add_reporter_job, "reporter workflow jobs must not declare unapproved keys: attacker"),
     ("set reporter job to a list", _set_reporter_job_to_list, "reporter job 'reconcile' must be a mapping"),
     ("set reporter job permissions", _reporter_job_permissions_override, "reporter job must not declare a permissions override"),
+    ("add reporter job key", _add_reporter_job_key, "reporter job must not declare unapproved keys: defaults"),
     ("set reporter job continue-on-error", _reporter_job_continue_on_error, "reporter job must not declare 'continue-on-error'"),
     ("replace trusted reporter condition", _replace_reporter_condition, "reporter job must restrict to trusted default-branch schedule, push, or workflow_dispatch audits"),
     ("remove reporter steps", _remove_reporter_steps, "reporter job steps must be a list"),
     ("remove reporter checkout", _remove_reporter_checkout, "reporter job steps must be exactly checkout, setup-node, and reconciliation runner in that order"),
     ("insert arbitrary reporter shell step", _insert_reporter_shell_step, "reporter job steps must be exactly checkout, setup-node, and reconciliation runner in that order"),
+    *[
+        (
+            f"add checkout configuration {key}",
+            _add_checkout_key(key, value),
+            f"reporter checkout configuration must not declare unapproved keys: {key}",
+        )
+        for key, value in [
+            ("repository", "attacker/public-repo"),
+            ("path", "attacker"),
+            ("token", "${{ secrets.GITHUB_TOKEN }}"),
+            ("fetch-depth", 0),
+            ("submodules", True),
+        ]
+    ],
+    *[
+        (
+            f"add checkout step {key}",
+            _add_checkout_step_key(key, value),
+            f"reporter checkout step must not declare unapproved keys: {key}",
+        )
+        for key, value in [
+            ("if", "always()"),
+            ("env", {"X": "1"}),
+            ("id", "checkout"),
+            ("timeout-minutes", 1),
+            ("continue-on-error", True),
+        ]
+    ],
     ("checkout triggering SHA", _checkout_triggering_sha, "reporter checkout must use the repository default branch ref"),
     ("checkout mutable action ref", _checkout_mutable_action_ref, "reporter checkout action must be pinned to the approved commit"),
     ("persist checkout credentials", _checkout_persists_credentials, "reporter checkout must disable persisted credentials"),
@@ -400,6 +479,14 @@ REPORTER_MUTATIONS: list[ReporterMutation] = [
     ("setup-node unexpected config", _setup_node_unexpected_config, "reporter setup-node step must use exactly node-version 22"),
     ("remove reporter runner", _remove_reporter_runner, "reporter job steps must be exactly checkout, setup-node, and reconciliation runner in that order"),
     ("replace reporter runner token", _replace_reporter_runner_token, "reporter reconciliation runner must bind GITHUB_TOKEN to secrets.GITHUB_TOKEN"),
+    *[
+        (
+            f"add reporter runner {key}",
+            _add_runner_key(key, value),
+            f"reporter reconciliation runner must not declare unapproved keys: {key}",
+        )
+        for key, value in [("shell", "bash"), ("working-directory", "attacker"), ("id", "report")]
+    ],
     ("add an if to reporter runner", _reporter_runner_if, "reporter reconciliation runner must not declare 'if'"),
     ("set reporter runner continue-on-error", _reporter_runner_continue_on_error, "reporter reconciliation runner must not declare 'continue-on-error'"),
     ("append || true to reporter runner", _append_true_to_reporter_runner, "reporter reconciliation command must be exactly 'node .github/scripts/report-cache-budget-audit.mjs'"),

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -194,6 +194,26 @@ def _add_audit_issue_write_permission(document: dict[str, Any]) -> None:
     document["permissions"]["issues"] = "write"
 
 
+def _add_audit_workflow_key(document: dict[str, Any]) -> None:
+    document["defaults"] = {}
+
+
+def _add_audit_job(document: dict[str, Any]) -> None:
+    document["jobs"]["attacker"] = {
+        "permissions": {"issues": "write"},
+        "runs-on": "ubuntu-latest",
+        "steps": [{"run": "printf compromised"}],
+    }
+
+
+def _audit_job_permissions_override(document: dict[str, Any]) -> None:
+    _audit_job(document)["permissions"] = {"issues": "write"}
+
+
+def _add_audit_job_key(document: dict[str, Any]) -> None:
+    _audit_job(document)["defaults"] = {"run": {"shell": "bash"}}
+
+
 def _replace_reporter_with_list(_document: dict[str, Any]) -> list[str]:
     return ["not a reporter workflow mapping"]
 
@@ -365,6 +385,7 @@ def _add_runner_key(key: str, value: Any) -> Callable[[dict[str, Any]], None]:
 Mutation = tuple[str, Callable[[dict[str, Any]], Any], str]
 MUTATIONS: list[Mutation] = [
     ("replace workflow with a YAML list", _replace_workflow_with_list, "workflow must be a mapping"),
+    ("add audit workflow key", _add_audit_workflow_key, "workflow must not declare unapproved keys: defaults"),
     ("set on to a list", _set_on_to_list, "workflow 'on' must be a mapping"),
     ("empty schedule", _empty_schedule, "trigger 'schedule' must be a non-empty list"),
     ("disable workflow_dispatch", _disable_workflow_dispatch, "trigger 'workflow_dispatch' must be enabled"),
@@ -372,7 +393,10 @@ MUTATIONS: list[Mutation] = [
     ("set push to a list", _set_push_to_list, "trigger 'push' must be a mapping"),
     ("set push paths to a mapping", _set_push_paths_to_mapping, "trigger 'push.paths' must be a list"),
     ("remove jobs", _remove_jobs, "workflow jobs must be a mapping"),
+    ("add audit job", _add_audit_job, "workflow jobs must not declare unapproved keys: attacker"),
     ("set audit job to a list", _set_audit_job_to_list, "job 'audit' must be a mapping"),
+    ("set audit job permissions", _audit_job_permissions_override, "audit job must not declare a permissions override"),
+    ("add audit job key", _add_audit_job_key, "audit job must not declare unapproved keys: defaults"),
     ("remove steps", _remove_steps, "audit job steps must be a list"),
     ("remove calibration step", _remove_calibration_step, "audit job must contain exactly one named calibration step"),
     ("remove live-audit step", _remove_live_audit_step, "audit job must contain exactly one named live-audit step"),

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -67,6 +67,10 @@ def _reporter_runner_step(document: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _reporter_setup_node_step(document: dict[str, Any]) -> dict[str, Any]:
+    return _reporter_job(document)["steps"][1]
+
+
 def _live_audit_step(document: dict[str, Any]) -> dict[str, Any]:
     return next(
         step
@@ -249,8 +253,16 @@ def _reporter_job_continue_on_error(document: dict[str, Any]) -> None:
     _reporter_job(document)["continue-on-error"] = True
 
 
+def _reporter_job_permissions_override(document: dict[str, Any]) -> None:
+    _reporter_job(document)["permissions"] = validator.REPORTER_PERMISSIONS.copy()
+
+
 def _remove_reporter_steps(document: dict[str, Any]) -> None:
     del _reporter_job(document)["steps"]
+
+
+def _insert_reporter_shell_step(document: dict[str, Any]) -> None:
+    _reporter_job(document)["steps"].insert(2, {"run": "printf compromised"})
 
 
 def _remove_reporter_checkout(document: dict[str, Any]) -> None:
@@ -265,8 +277,20 @@ def _checkout_triggering_sha(document: dict[str, Any]) -> None:
     _reporter_checkout_step(document)["with"]["ref"] = "${{ github.event.workflow_run.head_sha }}"
 
 
+def _checkout_mutable_action_ref(document: dict[str, Any]) -> None:
+    _reporter_checkout_step(document)["uses"] = "actions/checkout@main"
+
+
 def _checkout_persists_credentials(document: dict[str, Any]) -> None:
     _reporter_checkout_step(document)["with"]["persist-credentials"] = True
+
+
+def _setup_node_mutable_action_ref(document: dict[str, Any]) -> None:
+    _reporter_setup_node_step(document)["uses"] = "actions/setup-node@main"
+
+
+def _setup_node_unexpected_config(document: dict[str, Any]) -> None:
+    _reporter_setup_node_step(document)["with"]["cache"] = "npm"
 
 
 def _remove_reporter_runner(document: dict[str, Any]) -> None:
@@ -287,6 +311,10 @@ def _reporter_runner_continue_on_error(document: dict[str, Any]) -> None:
 
 def _append_true_to_reporter_runner(document: dict[str, Any]) -> None:
     _reporter_runner_step(document)["run"] += " || true"
+
+
+def _replace_reporter_runner_token(document: dict[str, Any]) -> None:
+    _reporter_runner_step(document)["env"]["GITHUB_TOKEN"] = "${{ github.token }}"
 
 
 Mutation = tuple[str, Callable[[dict[str, Any]], Any], str]
@@ -359,13 +387,19 @@ REPORTER_MUTATIONS: list[ReporterMutation] = [
     ("enable reporter cancellation", _enable_reporter_cancel_in_progress, "reporter concurrency cancel-in-progress must be false"),
     ("remove reporter jobs", _remove_reporter_jobs, "reporter workflow jobs must be a mapping"),
     ("set reporter job to a list", _set_reporter_job_to_list, "reporter job 'reconcile' must be a mapping"),
+    ("set reporter job permissions", _reporter_job_permissions_override, "reporter job must not declare a permissions override"),
     ("set reporter job continue-on-error", _reporter_job_continue_on_error, "reporter job must not declare 'continue-on-error'"),
     ("replace trusted reporter condition", _replace_reporter_condition, "reporter job must restrict to trusted default-branch schedule, push, or workflow_dispatch audits"),
     ("remove reporter steps", _remove_reporter_steps, "reporter job steps must be a list"),
-    ("remove reporter checkout", _remove_reporter_checkout, "reporter job must contain exactly one checkout step"),
+    ("remove reporter checkout", _remove_reporter_checkout, "reporter job steps must be exactly checkout, setup-node, and reconciliation runner in that order"),
+    ("insert arbitrary reporter shell step", _insert_reporter_shell_step, "reporter job steps must be exactly checkout, setup-node, and reconciliation runner in that order"),
     ("checkout triggering SHA", _checkout_triggering_sha, "reporter checkout must use the repository default branch ref"),
+    ("checkout mutable action ref", _checkout_mutable_action_ref, "reporter checkout action must be pinned to the approved commit"),
     ("persist checkout credentials", _checkout_persists_credentials, "reporter checkout must disable persisted credentials"),
-    ("remove reporter runner", _remove_reporter_runner, "reporter job must contain exactly one named reconciliation runner step"),
+    ("setup-node mutable action ref", _setup_node_mutable_action_ref, "reporter setup-node action must be pinned to the approved commit"),
+    ("setup-node unexpected config", _setup_node_unexpected_config, "reporter setup-node step must use exactly node-version 22"),
+    ("remove reporter runner", _remove_reporter_runner, "reporter job steps must be exactly checkout, setup-node, and reconciliation runner in that order"),
+    ("replace reporter runner token", _replace_reporter_runner_token, "reporter reconciliation runner must bind GITHUB_TOKEN to secrets.GITHUB_TOKEN"),
     ("add an if to reporter runner", _reporter_runner_if, "reporter reconciliation runner must not declare 'if'"),
     ("set reporter runner continue-on-error", _reporter_runner_continue_on_error, "reporter reconciliation runner must not declare 'continue-on-error'"),
     ("append || true to reporter runner", _append_true_to_reporter_runner, "reporter reconciliation command must be exactly 'node .github/scripts/report-cache-budget-audit.mjs'"),

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -41,6 +41,18 @@ def _audit_job(document: dict[str, Any]) -> dict[str, Any]:
     return document["jobs"][validator.AUDIT_JOB_ID]
 
 
+def _audit_checkout_step(document: dict[str, Any]) -> dict[str, Any]:
+    return _audit_job(document)["steps"][0]
+
+
+def _audit_setup_node_step(document: dict[str, Any]) -> dict[str, Any]:
+    return _audit_job(document)["steps"][1]
+
+
+def _audit_calibration_step(document: dict[str, Any]) -> dict[str, Any]:
+    return _audit_job(document)["steps"][2]
+
+
 def _real_reporter_workflow() -> dict[str, Any]:
     document = validator.load_workflow(REPORTER_WORKFLOW_PATH)
     assert isinstance(document, dict)
@@ -214,6 +226,96 @@ def _add_audit_job_key(document: dict[str, Any]) -> None:
     _audit_job(document)["defaults"] = {"run": {"shell": "bash"}}
 
 
+def _add_audit_trigger(document: dict[str, Any]) -> None:
+    document["on"]["pull_request"] = {}
+
+
+def _add_audit_push_key(document: dict[str, Any]) -> None:
+    document["on"]["push"]["tags"] = ["v*"]
+
+
+def _set_audit_concurrency_to_list(document: dict[str, Any]) -> None:
+    document["concurrency"] = []
+
+
+def _add_audit_concurrency_key(document: dict[str, Any]) -> None:
+    document["concurrency"]["extra"] = True
+
+
+def _replace_audit_concurrency_group(document: dict[str, Any]) -> None:
+    document["concurrency"]["group"] = "wrong-group"
+
+
+def _enable_audit_cancel_in_progress(document: dict[str, Any]) -> None:
+    document["concurrency"]["cancel-in-progress"] = True
+
+
+def _replace_audit_job_name(document: dict[str, Any]) -> None:
+    _audit_job(document)["name"] = "wrong name"
+
+
+def _replace_audit_runs_on(document: dict[str, Any]) -> None:
+    _audit_job(document)["runs-on"] = "macos-latest"
+
+
+def _replace_audit_timeout(document: dict[str, Any]) -> None:
+    _audit_job(document)["timeout-minutes"] = 6
+
+
+def _insert_audit_shell_step(document: dict[str, Any]) -> None:
+    _audit_job(document)["steps"].insert(3, {"run": "printf compromised"})
+
+
+def _add_audit_checkout_config(key: str, value: Any) -> Callable[[dict[str, Any]], None]:
+    def mutate(document: dict[str, Any]) -> None:
+        _audit_checkout_step(document)["with"][key] = value
+
+    return mutate
+
+
+def _add_audit_checkout_step_key(key: str, value: Any) -> Callable[[dict[str, Any]], None]:
+    def mutate(document: dict[str, Any]) -> None:
+        _audit_checkout_step(document)[key] = value
+
+    return mutate
+
+
+def _checkout_audit_mutable_action_ref(document: dict[str, Any]) -> None:
+    _audit_checkout_step(document)["uses"] = "actions/checkout@main"
+
+
+def _checkout_audit_persists_credentials(document: dict[str, Any]) -> None:
+    _audit_checkout_step(document)["with"]["persist-credentials"] = True
+
+
+def _add_audit_setup_node_step_key(document: dict[str, Any]) -> None:
+    _audit_setup_node_step(document)["id"] = "setup-node"
+
+
+def _setup_node_audit_mutable_action_ref(document: dict[str, Any]) -> None:
+    _audit_setup_node_step(document)["uses"] = "actions/setup-node@main"
+
+
+def _setup_node_audit_unexpected_config(document: dict[str, Any]) -> None:
+    _audit_setup_node_step(document)["with"]["cache"] = "npm"
+
+
+def _add_calibration_step_key(document: dict[str, Any]) -> None:
+    _audit_calibration_step(document)["shell"] = "bash"
+
+
+def _append_true_to_calibration_command(document: dict[str, Any]) -> None:
+    _audit_calibration_step(document)["run"] += " || true"
+
+
+def _replace_audit_live_token(document: dict[str, Any]) -> None:
+    _live_audit_step(document)["env"]["GITHUB_TOKEN"] = "${{ github.token }}"
+
+
+def _add_audit_live_step_key(document: dict[str, Any]) -> None:
+    _live_audit_step(document)["shell"] = "bash"
+
+
 def _replace_reporter_with_list(_document: dict[str, Any]) -> list[str]:
     return ["not a reporter workflow mapping"]
 
@@ -289,6 +391,18 @@ def _replace_reporter_condition(document: dict[str, Any]) -> None:
     _reporter_job(document)["if"] = "github.event.workflow_run.event == 'push'"
 
 
+def _replace_reporter_job_name(document: dict[str, Any]) -> None:
+    _reporter_job(document)["name"] = "wrong name"
+
+
+def _replace_reporter_runs_on(document: dict[str, Any]) -> None:
+    _reporter_job(document)["runs-on"] = "macos-latest"
+
+
+def _replace_reporter_timeout(document: dict[str, Any]) -> None:
+    _reporter_job(document)["timeout-minutes"] = 6
+
+
 def _reporter_job_continue_on_error(document: dict[str, Any]) -> None:
     _reporter_job(document)["continue-on-error"] = True
 
@@ -351,6 +465,10 @@ def _setup_node_unexpected_config(document: dict[str, Any]) -> None:
     _reporter_setup_node_step(document)["with"]["cache"] = "npm"
 
 
+def _add_reporter_setup_node_step_key(document: dict[str, Any]) -> None:
+    _reporter_setup_node_step(document)["id"] = "setup-node"
+
+
 def _remove_reporter_runner(document: dict[str, Any]) -> None:
     _reporter_job(document)["steps"] = [
         step
@@ -391,21 +509,68 @@ MUTATIONS: list[Mutation] = [
     ("disable workflow_dispatch", _disable_workflow_dispatch, "trigger 'workflow_dispatch' must be enabled"),
     ("set workflow_dispatch to a list", _set_workflow_dispatch_to_list, "trigger 'workflow_dispatch' must be an event mapping"),
     ("set push to a list", _set_push_to_list, "trigger 'push' must be a mapping"),
+    ("add audit trigger", _add_audit_trigger, "workflow 'on' must not declare unapproved keys: pull_request"),
+    ("add audit push key", _add_audit_push_key, "trigger 'push' must not declare unapproved keys: tags"),
     ("set push paths to a mapping", _set_push_paths_to_mapping, "trigger 'push.paths' must be a list"),
     ("remove jobs", _remove_jobs, "workflow jobs must be a mapping"),
     ("add audit job", _add_audit_job, "workflow jobs must not declare unapproved keys: attacker"),
     ("set audit job to a list", _set_audit_job_to_list, "job 'audit' must be a mapping"),
     ("set audit job permissions", _audit_job_permissions_override, "audit job must not declare a permissions override"),
     ("add audit job key", _add_audit_job_key, "audit job must not declare unapproved keys: defaults"),
+    ("set audit concurrency to a list", _set_audit_concurrency_to_list, "audit concurrency must be a mapping"),
+    ("add audit concurrency key", _add_audit_concurrency_key, "audit concurrency must not declare unapproved keys: extra"),
+    ("replace audit concurrency group", _replace_audit_concurrency_group, "audit concurrency group must be 'cache-budget-audit'"),
+    ("enable audit cancellation", _enable_audit_cancel_in_progress, "audit concurrency cancel-in-progress must be false"),
+    ("replace audit job name", _replace_audit_job_name, "audit job name must be exactly 'audit Actions cache budget'"),
+    ("replace audit runs-on", _replace_audit_runs_on, "audit job runs-on must be exactly 'ubuntu-latest'"),
+    ("replace audit timeout", _replace_audit_timeout, "audit job timeout-minutes must be exactly 5"),
     ("remove steps", _remove_steps, "audit job steps must be a list"),
     ("remove calibration step", _remove_calibration_step, "audit job must contain exactly one named calibration step"),
     ("remove live-audit step", _remove_live_audit_step, "audit job must contain exactly one named live-audit step"),
     ("move calibration after live audit", _move_calibration_after_live_audit, "calibration step must precede the live-audit step"),
+    ("insert arbitrary audit shell step", _insert_audit_shell_step, "audit job steps must be exactly checkout, setup-node, calibration, and live-audit runner in that order"),
+    *[
+        (
+            f"add audit checkout configuration {key}",
+            _add_audit_checkout_config(key, value),
+            f"audit checkout configuration must not declare unapproved keys: {key}",
+        )
+        for key, value in [
+            ("repository", "attacker/public-repo"),
+            ("path", "attacker"),
+            ("token", "${{ secrets.GITHUB_TOKEN }}"),
+            ("fetch-depth", 0),
+            ("submodules", True),
+        ]
+    ],
+    *[
+        (
+            f"add audit checkout step {key}",
+            _add_audit_checkout_step_key(key, value),
+            f"audit checkout step must not declare unapproved keys: {key}",
+        )
+        for key, value in [
+            ("if", "always()"),
+            ("env", {"X": "1"}),
+            ("id", "checkout"),
+            ("timeout-minutes", 1),
+            ("continue-on-error", True),
+        ]
+    ],
+    ("checkout audit mutable action ref", _checkout_audit_mutable_action_ref, "audit checkout action must be pinned to the approved commit"),
+    ("persist audit checkout credentials", _checkout_audit_persists_credentials, "audit checkout must disable persisted credentials"),
+    ("add audit setup-node step key", _add_audit_setup_node_step_key, "audit setup-node step must not declare unapproved keys: id"),
+    ("setup-node audit mutable action ref", _setup_node_audit_mutable_action_ref, "audit setup-node action must be pinned to the approved commit"),
+    ("setup-node audit unexpected config", _setup_node_audit_unexpected_config, "audit setup-node step must use exactly node-version 22"),
+    ("add audit calibration step key", _add_calibration_step_key, "audit calibration step must not declare unapproved keys: shell"),
+    ("append || true to calibration command", _append_true_to_calibration_command, "audit calibration command must be exactly 'node --test .github/scripts/audit-cache-budget.test.mjs'"),
     ("remove live-audit run", _remove_live_audit_run, "live-audit command must be exactly 'node .github/scripts/run-cache-budget-audit.mjs'"),
     ("append || true to the live command", _append_true, "live-audit command must be exactly 'node .github/scripts/run-cache-budget-audit.mjs'"),
     ("set live-step continue-on-error", _step_continue_on_error, "live-audit step must not declare 'continue-on-error'"),
     ("set audit-job continue-on-error", _job_continue_on_error, "audit job must not declare 'continue-on-error'"),
     ("add an if to the live step", _step_if, "live-audit step must not declare 'if'"),
+    ("replace audit live token", _replace_audit_live_token, "live-audit step must bind GITHUB_TOKEN to secrets.GITHUB_TOKEN"),
+    ("add audit live step key", _add_audit_live_step_key, "live-audit step must not declare unapproved keys: shell"),
     (
         "add issues write to the audit",
         _add_audit_issue_write_permission,
@@ -464,6 +629,9 @@ REPORTER_MUTATIONS: list[ReporterMutation] = [
     ("set reporter job permissions", _reporter_job_permissions_override, "reporter job must not declare a permissions override"),
     ("add reporter job key", _add_reporter_job_key, "reporter job must not declare unapproved keys: defaults"),
     ("set reporter job continue-on-error", _reporter_job_continue_on_error, "reporter job must not declare 'continue-on-error'"),
+    ("replace reporter job name", _replace_reporter_job_name, "reporter job name must be exactly 'reconcile cache-budget audit issue'"),
+    ("replace reporter runs-on", _replace_reporter_runs_on, "reporter job runs-on must be exactly 'ubuntu-latest'"),
+    ("replace reporter timeout", _replace_reporter_timeout, "reporter job timeout-minutes must be exactly 5"),
     ("replace trusted reporter condition", _replace_reporter_condition, "reporter job must restrict to trusted default-branch schedule, push, or workflow_dispatch audits"),
     ("remove reporter steps", _remove_reporter_steps, "reporter job steps must be a list"),
     ("remove reporter checkout", _remove_reporter_checkout, "reporter job steps must be exactly checkout, setup-node, and reconciliation runner in that order"),
@@ -500,6 +668,7 @@ REPORTER_MUTATIONS: list[ReporterMutation] = [
     ("checkout mutable action ref", _checkout_mutable_action_ref, "reporter checkout action must be pinned to the approved commit"),
     ("persist checkout credentials", _checkout_persists_credentials, "reporter checkout must disable persisted credentials"),
     ("setup-node mutable action ref", _setup_node_mutable_action_ref, "reporter setup-node action must be pinned to the approved commit"),
+    ("add reporter setup-node step key", _add_reporter_setup_node_step_key, "reporter setup-node step must not declare unapproved keys: id"),
     ("setup-node unexpected config", _setup_node_unexpected_config, "reporter setup-node step must use exactly node-version 22"),
     ("remove reporter runner", _remove_reporter_runner, "reporter job steps must be exactly checkout, setup-node, and reconciliation runner in that order"),
     ("replace reporter runner token", _replace_reporter_runner_token, "reporter reconciliation runner must bind GITHUB_TOKEN to secrets.GITHUB_TOKEN"),

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -562,6 +562,29 @@ def test_cli_reports_unparseable_yaml(tmp_path: Path):
     assert "Traceback" not in output
 
 
+def test_cli_rejects_a_duplicate_yaml_key_before_wiring_validation(tmp_path: Path):
+    path = tmp_path / "duplicate-key.yml"
+    source = WORKFLOW_PATH.read_text(encoding="utf-8")
+    path.write_text(
+        source.replace(
+            "          persist-credentials: false",
+            "          persist-credentials: true\n          persist-credentials: false",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_cli(path)
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 1, output
+    assert result.stdout.startswith(
+        "cache-budget-audit workflow wiring: FAIL -- workflow YAML is invalid:"
+    )
+    assert "found duplicate key 'persist-credentials'" in result.stdout
+    assert "Traceback" not in output
+
+
 def test_cli_reports_missing_reporter_workflow_file(tmp_path: Path):
     path = tmp_path / "missing-reporter.yml"
     result = _run_cli(WORKFLOW_PATH, path)

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -704,6 +704,23 @@ def test_real_cache_budget_audit_reporter_workflow_is_accepted():
     assert validator.validate_reporter_workflow(_real_reporter_workflow()) == []
 
 
+def test_audit_workflow_name_rejects_a_third_same_named_workflow(tmp_path: Path):
+    (tmp_path / WORKFLOW_PATH.name).write_text(WORKFLOW_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / REPORTER_WORKFLOW_PATH.name).write_text(
+        REPORTER_WORKFLOW_PATH.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (tmp_path / "unrelated-cache-audit.yml").write_text(
+        f"name: {validator.AUDIT_WORKFLOW_NAME}\n",
+        encoding="utf-8",
+    )
+
+    assert validator.validate_audit_workflow_name_uniqueness(tmp_path) == [
+        "audit workflow name 'cache budget audit' must be unique; found in: "
+        "cache-budget-audit.yml, unrelated-cache-audit.yml"
+    ]
+
+
 @pytest.mark.parametrize(("description", "mutate", "expected"), MUTATIONS, ids=[item[0] for item in MUTATIONS])
 def test_each_single_wiring_mutation_is_rejected(
     description: str, mutate: Callable[[dict[str, Any]], Any], expected: str

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -210,6 +210,10 @@ def _add_audit_workflow_key(document: dict[str, Any]) -> None:
     document["defaults"] = {}
 
 
+def _rename_audit_workflow(document: dict[str, Any]) -> None:
+    document["name"] = "renamed cache audit"
+
+
 def _add_audit_job(document: dict[str, Any]) -> None:
     document["jobs"]["attacker"] = {
         "permissions": {"issues": "write"},
@@ -342,6 +346,10 @@ def _add_reporter_workflow_run_key(document: dict[str, Any]) -> None:
 
 def _replace_reporter_source(document: dict[str, Any]) -> None:
     document["on"]["workflow_run"]["workflows"] = ["wrong audit"]
+
+
+def _rename_reporter_subscription(document: dict[str, Any]) -> None:
+    document["on"]["workflow_run"]["workflows"] = ["renamed cache audit"]
 
 
 def _replace_reporter_types(document: dict[str, Any]) -> None:
@@ -504,6 +512,7 @@ Mutation = tuple[str, Callable[[dict[str, Any]], Any], str]
 MUTATIONS: list[Mutation] = [
     ("replace workflow with a YAML list", _replace_workflow_with_list, "workflow must be a mapping"),
     ("add audit workflow key", _add_audit_workflow_key, "workflow must not declare unapproved keys: defaults"),
+    ("rename audit workflow", _rename_audit_workflow, "audit workflow name must be exactly 'cache budget audit'"),
     ("set on to a list", _set_on_to_list, "workflow 'on' must be a mapping"),
     ("empty schedule", _empty_schedule, "trigger 'schedule' must be a non-empty list"),
     ("disable workflow_dispatch", _disable_workflow_dispatch, "trigger 'workflow_dispatch' must be enabled"),
@@ -604,7 +613,8 @@ REPORTER_MUTATIONS: list[ReporterMutation] = [
     ("set reporter workflow_run to a list", _set_reporter_workflow_run_to_list, "reporter trigger 'workflow_run' must be a mapping"),
     ("add reporter trigger", _add_reporter_trigger, "reporter workflow 'on' must not declare unapproved keys: push"),
     ("add reporter workflow_run key", _add_reporter_workflow_run_key, "reporter trigger 'workflow_run' must not declare unapproved keys: branches"),
-    ("replace reporter workflow source", _replace_reporter_source, "reporter workflow_run.workflows must be exactly ['cache budget audit']"),
+    ("replace reporter workflow source", _replace_reporter_source, f"reporter workflow_run.workflows must be exactly ['{validator.AUDIT_WORKFLOW_NAME}']"),
+    ("rename reporter subscription", _rename_reporter_subscription, f"reporter workflow_run.workflows must be exactly ['{validator.AUDIT_WORKFLOW_NAME}']"),
     ("replace reporter workflow types", _replace_reporter_types, "reporter workflow_run.types must be exactly ['completed']"),
     *[
         (

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -15,6 +15,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "cache-budget-audit.yml"
+REPORTER_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "cache-budget-audit-reporter.yml"
 VALIDATOR_PATH = REPO_ROOT / ".github" / "scripts" / "validate-cache-budget-audit-workflow.py"
 
 
@@ -38,6 +39,32 @@ def _real_workflow() -> dict[str, Any]:
 
 def _audit_job(document: dict[str, Any]) -> dict[str, Any]:
     return document["jobs"][validator.AUDIT_JOB_ID]
+
+
+def _real_reporter_workflow() -> dict[str, Any]:
+    document = validator.load_workflow(REPORTER_WORKFLOW_PATH)
+    assert isinstance(document, dict)
+    return document
+
+
+def _reporter_job(document: dict[str, Any]) -> dict[str, Any]:
+    return document["jobs"][validator.REPORTER_JOB_ID]
+
+
+def _reporter_checkout_step(document: dict[str, Any]) -> dict[str, Any]:
+    return next(
+        step
+        for step in _reporter_job(document)["steps"]
+        if isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@")
+    )
+
+
+def _reporter_runner_step(document: dict[str, Any]) -> dict[str, Any]:
+    return next(
+        step
+        for step in _reporter_job(document)["steps"]
+        if step.get("name") == "Create, update, or resolve cache budget audit issue"
+    )
 
 
 def _live_audit_step(document: dict[str, Any]) -> dict[str, Any]:
@@ -159,6 +186,109 @@ def _remove_live_audit_run(document: dict[str, Any]) -> None:
     del _live_audit_step(document)["run"]
 
 
+def _add_audit_issue_write_permission(document: dict[str, Any]) -> None:
+    document["permissions"]["issues"] = "write"
+
+
+def _replace_reporter_with_list(_document: dict[str, Any]) -> list[str]:
+    return ["not a reporter workflow mapping"]
+
+
+def _set_reporter_on_to_list(document: dict[str, Any]) -> None:
+    document["on"] = []
+
+
+def _set_reporter_workflow_run_to_list(document: dict[str, Any]) -> None:
+    document["on"]["workflow_run"] = []
+
+
+def _replace_reporter_source(document: dict[str, Any]) -> None:
+    document["on"]["workflow_run"]["workflows"] = ["wrong audit"]
+
+
+def _replace_reporter_types(document: dict[str, Any]) -> None:
+    document["on"]["workflow_run"]["types"] = ["requested"]
+
+
+def _remove_reporter_permission(permission: str) -> Callable[[dict[str, Any]], None]:
+    def mutate(document: dict[str, Any]) -> None:
+        del document["permissions"][permission]
+
+    return mutate
+
+
+def _add_reporter_permission(document: dict[str, Any]) -> None:
+    document["permissions"]["pull-requests"] = "read"
+
+
+def _set_reporter_concurrency_to_list(document: dict[str, Any]) -> None:
+    document["concurrency"] = []
+
+
+def _replace_reporter_concurrency_group(document: dict[str, Any]) -> None:
+    document["concurrency"]["group"] = "wrong-group"
+
+
+def _enable_reporter_cancel_in_progress(document: dict[str, Any]) -> None:
+    document["concurrency"]["cancel-in-progress"] = True
+
+
+def _remove_reporter_jobs(document: dict[str, Any]) -> None:
+    del document["jobs"]
+
+
+def _set_reporter_job_to_list(document: dict[str, Any]) -> None:
+    document["jobs"][validator.REPORTER_JOB_ID] = []
+
+
+def _replace_reporter_condition(document: dict[str, Any]) -> None:
+    _reporter_job(document)["if"] = "github.event.workflow_run.event == 'push'"
+
+
+def _reporter_job_continue_on_error(document: dict[str, Any]) -> None:
+    _reporter_job(document)["continue-on-error"] = True
+
+
+def _remove_reporter_steps(document: dict[str, Any]) -> None:
+    del _reporter_job(document)["steps"]
+
+
+def _remove_reporter_checkout(document: dict[str, Any]) -> None:
+    _reporter_job(document)["steps"] = [
+        step
+        for step in _reporter_job(document)["steps"]
+        if not (isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@"))
+    ]
+
+
+def _checkout_triggering_sha(document: dict[str, Any]) -> None:
+    _reporter_checkout_step(document)["with"]["ref"] = "${{ github.event.workflow_run.head_sha }}"
+
+
+def _checkout_persists_credentials(document: dict[str, Any]) -> None:
+    _reporter_checkout_step(document)["with"]["persist-credentials"] = True
+
+
+def _remove_reporter_runner(document: dict[str, Any]) -> None:
+    _reporter_job(document)["steps"] = [
+        step
+        for step in _reporter_job(document)["steps"]
+        if step.get("name") != "Create, update, or resolve cache budget audit issue"
+    ]
+
+
+def _reporter_runner_if(document: dict[str, Any]) -> None:
+    _reporter_runner_step(document)["if"] = "always()"
+
+
+def _reporter_runner_continue_on_error(document: dict[str, Any]) -> None:
+    _reporter_runner_step(document)["continue-on-error"] = True
+
+
+def _append_true_to_reporter_runner(document: dict[str, Any]) -> None:
+    _reporter_runner_step(document)["run"] += " || true"
+
+
 Mutation = tuple[str, Callable[[dict[str, Any]], Any], str]
 MUTATIONS: list[Mutation] = [
     ("replace workflow with a YAML list", _replace_workflow_with_list, "workflow must be a mapping"),
@@ -179,6 +309,11 @@ MUTATIONS: list[Mutation] = [
     ("set live-step continue-on-error", _step_continue_on_error, "live-audit step must not declare 'continue-on-error'"),
     ("set audit-job continue-on-error", _job_continue_on_error, "audit job must not declare 'continue-on-error'"),
     ("add an if to the live step", _step_if, "live-audit step must not declare 'if'"),
+    (
+        "add issues write to the audit",
+        _add_audit_issue_write_permission,
+        "top-level permissions must be exactly actions: read and contents: read",
+    ),
     *[
         (
             f"remove permission {permission}",
@@ -199,8 +334,50 @@ MUTATIONS: list[Mutation] = [
 ]
 
 
+ReporterMutation = tuple[str, Callable[[dict[str, Any]], Any], str]
+REPORTER_MUTATIONS: list[ReporterMutation] = [
+    ("replace reporter with a YAML list", _replace_reporter_with_list, "reporter workflow must be a mapping"),
+    ("set reporter on to a list", _set_reporter_on_to_list, "reporter workflow 'on' must be a mapping"),
+    ("set reporter workflow_run to a list", _set_reporter_workflow_run_to_list, "reporter trigger 'workflow_run' must be a mapping"),
+    ("replace reporter workflow source", _replace_reporter_source, "reporter workflow_run.workflows must be exactly ['cache budget audit']"),
+    ("replace reporter workflow types", _replace_reporter_types, "reporter workflow_run.types must be exactly ['completed']"),
+    *[
+        (
+            f"remove reporter permission {permission}",
+            _remove_reporter_permission(permission),
+            "reporter permissions must be exactly actions: read, contents: read, and issues: write",
+        )
+        for permission in sorted(validator.REPORTER_PERMISSIONS)
+    ],
+    (
+        "add reporter permission pull-requests",
+        _add_reporter_permission,
+        "reporter permissions must be exactly actions: read, contents: read, and issues: write",
+    ),
+    ("set reporter concurrency to a list", _set_reporter_concurrency_to_list, "reporter concurrency must be a mapping"),
+    ("replace reporter concurrency group", _replace_reporter_concurrency_group, "reporter concurrency group must be 'cache-budget-audit-reporter'"),
+    ("enable reporter cancellation", _enable_reporter_cancel_in_progress, "reporter concurrency cancel-in-progress must be false"),
+    ("remove reporter jobs", _remove_reporter_jobs, "reporter workflow jobs must be a mapping"),
+    ("set reporter job to a list", _set_reporter_job_to_list, "reporter job 'reconcile' must be a mapping"),
+    ("set reporter job continue-on-error", _reporter_job_continue_on_error, "reporter job must not declare 'continue-on-error'"),
+    ("replace trusted reporter condition", _replace_reporter_condition, "reporter job must restrict to trusted default-branch schedule, push, or workflow_dispatch audits"),
+    ("remove reporter steps", _remove_reporter_steps, "reporter job steps must be a list"),
+    ("remove reporter checkout", _remove_reporter_checkout, "reporter job must contain exactly one checkout step"),
+    ("checkout triggering SHA", _checkout_triggering_sha, "reporter checkout must use the repository default branch ref"),
+    ("persist checkout credentials", _checkout_persists_credentials, "reporter checkout must disable persisted credentials"),
+    ("remove reporter runner", _remove_reporter_runner, "reporter job must contain exactly one named reconciliation runner step"),
+    ("add an if to reporter runner", _reporter_runner_if, "reporter reconciliation runner must not declare 'if'"),
+    ("set reporter runner continue-on-error", _reporter_runner_continue_on_error, "reporter reconciliation runner must not declare 'continue-on-error'"),
+    ("append || true to reporter runner", _append_true_to_reporter_runner, "reporter reconciliation command must be exactly 'node .github/scripts/report-cache-budget-audit.mjs'"),
+]
+
+
 def test_real_cache_budget_audit_workflow_is_accepted():
     assert validator.validate_workflow(_real_workflow()) == []
+
+
+def test_real_cache_budget_audit_reporter_workflow_is_accepted():
+    assert validator.validate_reporter_workflow(_real_reporter_workflow()) == []
 
 
 @pytest.mark.parametrize(("description", "mutate", "expected"), MUTATIONS, ids=[item[0] for item in MUTATIONS])
@@ -213,9 +390,28 @@ def test_each_single_wiring_mutation_is_rejected(
     assert errors == [expected], f"{description}: expected {expected!r}, got {errors!r}"
 
 
-def _run_cli(path: Path) -> subprocess.CompletedProcess[str]:
+@pytest.mark.parametrize(
+    ("description", "mutate", "expected"),
+    REPORTER_MUTATIONS,
+    ids=[item[0] for item in REPORTER_MUTATIONS],
+)
+def test_each_single_reporter_wiring_mutation_is_rejected(
+    description: str, mutate: Callable[[dict[str, Any]], Any], expected: str
+):
+    document = copy.deepcopy(_real_reporter_workflow())
+    mutated = mutate(document)
+    errors = validator.validate_reporter_workflow(document if mutated is None else mutated)
+    assert errors == [expected], f"{description}: expected {expected!r}, got {errors!r}"
+
+
+def _run_cli(
+    path: Path, reporter_path: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    command = [sys.executable, str(VALIDATOR_PATH), "--workflow", str(path)]
+    if reporter_path is not None:
+        command.extend(["--reporter-workflow", str(reporter_path)])
     return subprocess.run(
-        [sys.executable, str(VALIDATOR_PATH), "--workflow", str(path)],
+        command,
         check=False,
         capture_output=True,
         text=True,
@@ -242,6 +438,39 @@ def test_cli_reports_unparseable_yaml(tmp_path: Path):
     output = result.stdout + result.stderr
     assert result.returncode == 1, output
     assert result.stdout.startswith("cache-budget-audit workflow wiring: FAIL -- workflow YAML is invalid:")
+    assert "Traceback" not in output
+
+
+def test_cli_reports_missing_reporter_workflow_file(tmp_path: Path):
+    path = tmp_path / "missing-reporter.yml"
+    result = _run_cli(WORKFLOW_PATH, path)
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert result.stdout == f"cache-budget-audit workflow wiring: FAIL -- reporter workflow file '{path}' does not exist\n"
+    assert "Traceback" not in output
+
+
+def test_cli_reports_unparseable_reporter_workflow_yaml(tmp_path: Path):
+    path = tmp_path / "invalid-reporter.yml"
+    path.write_text("on: [\n", encoding="utf-8")
+    result = _run_cli(WORKFLOW_PATH, path)
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert result.stdout.startswith(
+        "cache-budget-audit workflow wiring: FAIL -- reporter workflow YAML is invalid:"
+    )
+    assert "Traceback" not in output
+
+
+def test_cli_reports_unreadable_reporter_workflow_file(tmp_path: Path):
+    path = tmp_path / "reporter-directory"
+    path.mkdir()
+    result = _run_cli(WORKFLOW_PATH, path)
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert result.stdout.startswith(
+        f"cache-budget-audit workflow wiring: FAIL -- reporter workflow file '{path}' could not be read:"
+    )
     assert "Traceback" not in output
 
 

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -35,6 +35,10 @@ check_core_contracts() {
 
 check_automation() {
   node --test .github/scripts/report-post-merge-ci.test.mjs
+  # The cache-budget reporter owns a separate issue lifecycle from the
+  # read-only audit. Keep its reconciliation controls in this Node/stdlib-only
+  # pre-merge lane, alongside the established post-merge reporter controls.
+  node --test .github/scripts/report-cache-budget-audit.test.mjs
   # The agent environment is repository-hook infrastructure, not frozen Python
   # product behavior. These zero-argument contract tests use only the standard
   # library, so run them directly without adding pytest to the fail-fast lane.


### PR DESCRIPTION
## Problem

The scheduled cache budget audit detects a real condition and then tells nobody:
`.github/workflows/cache-budget-audit.yml` ends immediately after invoking the runner, with no reporting step
and no downstream reporter.

Measured consequence: it failed on 2026-08-17 and again on 2026-08-18 at 9.27 GiB of the 10 GiB budget (93%,
above its 85% threshold). Nothing filed an issue, and #747's recurrence ran unobserved for **four days** until a
human happened to look. The audit was working correctly the whole time.

## Contract change: a privilege-separated reporter, not `issues: write` on the audit

The audit declares exactly `actions: read` and `contents: read`. Adding issue-write there would give a workflow
that *observes* the repository the power to *mutate* it — on a workflow that also accepts
`workflow_dispatch`. **The audit workflow is unchanged in this PR** and its permissions remain read-only;
verified.

Instead, `.github/workflows/cache-budget-audit-reporter.yml` subscribes to completed `cache budget audit` runs
via `workflow_run`, with `actions: read`, `contents: read`, `issues: write` and nothing else. It checks out the
**default branch, never the triggering SHA**, and acts only for this repository's default-branch `schedule`,
`push` or `workflow_dispatch` runs.

This follows `.github/workflows/post-merge-ci-reporter.yml`, the established pattern here, rather than
inventing a second one. Its dedup semantics come from the same source
(`.github/scripts/report-post-merge-ci.mjs:28`-`:49` stable marker, `:182`-`:215` deduplicate and reopen,
`:217`-`:247` close only on recovery; `docs/DESIGN-ci.md:1038`-`:1065` records the contract):

| Event | Behavior |
|---|---|
| first failure | files one canonical issue keyed by a stable hidden marker |
| same run reported again | idempotent — no second issue, no duplicate comment |
| later distinct failure | one occurrence comment on the existing issue |
| success | closes it |
| recurrence after close | reopens the same issue |
| stale out-of-order event | does not reopen health that has already recovered |

`cancel-in-progress: false` serializes reporters, and reconciliation runs against the latest completed trusted
audit before any mutation.

## Two layers of control, because one would recreate the defect

A reporter that silently stops reporting is exactly the failure this issue is about, one level up.

**Layer 1 — the reporter's own logic**, `.github/scripts/report-cache-budget-audit.test.mjs`, 47 Node tests
covering every row of the table above. **Wired into `tools/check-merge-readiness.sh`'s `check_automation()`
lane**, where `report-post-merge-ci.test.mjs` already lives — that lane is Node/stdlib-only, so this fits it
without disturbing its dependency contract. Writing the tests without wiring them is the exact shape this
repository has repeatedly mistaken for a gate (see the corrections recorded on #746, #786 and #802), so the
wiring is part of the change, not a follow-up.

**Layer 2 — the reporter's own wiring**, by extending #839's validator rather than adding a second one:

```
                                    before   after
errors.append branches in validator    17       61
tests collected in test_cache_bud...   37      137
```

It validates the `workflow_run` source and types, the exact permission set — including that `issues: write` is
present on the reporter and **absent from the audit** — the trusted/default-branch condition,
`cancel-in-progress: false`, safe checkout of the default branch rather than the triggering SHA, and an
unsuppressed runner command.

## Verified independently, not taken from the implementer's report

```
node --test report-cache-budget-audit.test.mjs        6 pass, 0 fail
pytest tests/test_cache_budget_audit_workflow.py     66 passed
cache-budget-audit.yml permissions                    actions: read, contents: read   (no issues: write)
```

Calibration probe: changing `REPORTER_PERMISSIONS` to drop `issues: write` from the *expected* set makes
**25 tests fail**; restoring it returns 66/66 with a clean tree. So the reporter's wiring assertions are
actually load-bearing rather than passing vacuously.

## Deliberately out of scope

No context is made required; `.github/ruleset-contract.json` and `docs/DESIGN-ci.md`'s required-context list
are untouched. `src/fslc/` is unchanged.

The audit's inability to distinguish reclaimable superseded duplicates from genuine growth remains #835 —
this PR reports the condition, it does not diagnose the cause.

`changelog.d/795-cache-budget-audit-reporter.fixed.md`.

Closes #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review history, and why these numbers moved

The counts above are re-measured against the current head, not the ones this
description was first written with. They grew because **every one of ten review
rounds found a real defect**, including one High (a `checkout.with.repository`
swap that would execute the head repository's script under the base
repository's `issues: write` token) and two that would have restored the very
failure mode this PR exists to fix — an audit rename silently disabling
reporting, and a same-name workflow impersonating the audit.

Rounds 9 and 10 are worth recording precisely, because round 9's blocking
finding was **rejected**:

- **Round 9** reported the non-required workflow-name uniqueness check as a
  blocker. The facts were right; the framing was not.
  `.github/workflows/cache-budget-audit-wiring.yml:5-19` already records, as an
  accepted decision, both that the workflow depends on PyYAML and so stays out
  of the stdlib-only automation-contracts lane, and that "This context is
  intentionally not required yet." Reading that header is what surfaced two
  real problems instead: it pointed at **closed** issue #802 as the rollout
  tracker (now #845, and the reference is updated here), and this PR does wire
  its reporter controls into the required lane, so the gap is much narrower
  than "none of these controls are required."
- **Round 10** found no actionable defect. It verified fail-closed behavior by
  execution, including the case that matters most: a malformed sibling **plus** a
  valid same-named impostor produces *both* the malformed-YAML error and the
  duplicate-name error, so an impostor cannot hide behind unparseable YAML.

### Calibration, checked by reverting the fix

The two new controls were confirmed to detect what they exist to detect.
Reverting only the validator hunk and re-running them gives 1 failed / 1
passed: the malformed-sibling control fails with empty stdout and a traceback on
stderr, while the well-formed-sibling accepting control still passes. This was
done twice independently.

### Residual risk, not verified by execution

`workflow_run` subscribes by workflow **display name**
(`workflows: ["cache budget audit"]`), and the uniqueness check compares that
name **exactly**. Whether GitHub's matching is case-sensitive cannot be
established without committing differently-cased default-branch workflows and
observing a live `workflow_run`, so it was not established here. Filed as #851,
which notes that the check can be made case-insensitive to fail closed
regardless of GitHub's behavior — no live experiment required.

Also filed from this work: #847 (a **scheduled** product-gate failure is always
skipped by the post-merge reporter, so an upstream drift that reddens `main` is
never filed — the adjacent reporter added here gets this right by including
`schedule` and `workflow_dispatch`, which makes the asymmetry visible).