### PR TITLE
fix(rust): satisfy clippy 1.98's manual_is_variant_and and chunks_exact_to_as_chunks

### DIFF
--- a/changelog.d/846-clippy-1-98-stable-drift.fixed.md
+++ b/changelog.d/846-clippy-1-98-stable-drift.fixed.md
@@ -1,0 +1,8 @@
+Fixed (#846): the Rust workspace is clean again under `clippy` 1.98.0, whose
+new deny-by-default `manual_is_variant_and` and `chunks_exact_to_as_chunks`
+lints turned `main` red with no repository change, because every CI job uses
+the unpinned `dtolnay/rust-toolchain@stable`. Both rewrites are
+semantics-preserving. CI named only two sites, since cargo aborts at the first
+failing crate; enumerating with `--keep-going` found four, and the fix was
+also checked against the pinned 1.88.0 MSRV that `release.yml` uses so
+`as_chunks` cannot break the release build after PR CI passes on stable.

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -389,8 +389,7 @@ fn discover_domain_fixtures() -> Vec<String> {
         .into_iter()
         .filter(|path| {
             fs::read_to_string(path)
-                .ok()
-                .is_some_and(|content| content.lines().any(is_domain_declaration_line))
+                .is_ok_and(|content| content.lines().any(is_domain_declaration_line))
         })
         .map(|path| {
             path.strip_prefix(&root)

--- a/rust/fsl-lsp/src/server.rs
+++ b/rust/fsl-lsp/src/server.rs
@@ -1072,7 +1072,9 @@ mod tests {
         value
             .as_array()
             .expect("semantic token data")
-            .chunks_exact(5)
+            .as_chunks::<5>()
+            .0
+            .iter()
             .any(|token| {
                 let delta_line = token[0].as_u64().expect("delta line");
                 line += delta_line;

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -8442,8 +8442,7 @@ fn reachable_counterfactuals(path: &Path, depth: usize) -> Value {
         // liveness with mixed fair/non-fair actions (issue #633).
         model.leadstos.clear();
         if fsl_runtime::find_boundary_violation(&model, depth, fsl_runtime::CONCRETE_PROBE_BUDGET)
-            .ok()
-            .is_some_and(|probe| probe.finding.is_some())
+            .is_ok_and(|probe| probe.finding.is_some())
         {
             continue;
         }
@@ -15063,7 +15062,7 @@ fn run_refine_chain(
         first_abstraction.to_path_buf(),
     ];
     let mut mappings = vec![first_mapping.to_path_buf()];
-    for pair in rest.chunks_exact(2) {
+    for pair in rest.as_chunks::<2>().0 {
         specifications.push(pair[0].clone());
         mappings.push(pair[1].clone());
     }


### PR DESCRIPTION
## Problem

`main` is red, with no repository change responsible.

`rustc`/`clippy` **1.98.0 was released 2026-08-18**. Every CI job uses the
unpinned `dtolnay/rust-toolchain@stable` (11 uses), so the product gate
picked the new compiler up on its own:

| product gate run | time | `rust checks` / `rust workspace` |
|---|---|---|
| 32350147121 | 2026-08-20T08:42 | success |
| 32406084360 | 2026-08-20T18:58 | **failure** |

Two lints new in 1.98 are elevated to errors by this repository's `-D warnings`:
`clippy::manual_is_variant_and` and `clippy::chunks_exact_to_as_chunks`.

## What CI did not tell us

CI reported **two** violations, both in `rust/fslc/src/main.rs`, then stopped:

```
error: could not compile `fslc-rust` (bin "fslc") due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

cargo aborts at the first failing crate. Enumerating with clippy 1.98.0 and
`--keep-going` found **four**, the other two in crates CI never reached:

```
fsl-core/tests/domain_render_agreement.rs:391  manual_is_variant_and        (not reported by CI)
fsl-lsp/src/server.rs:1075                     chunks_exact_to_as_chunks    (not reported by CI)
fslc/src/main.rs:8444                          manual_is_variant_and
fslc/src/main.rs:15066                         chunks_exact_to_as_chunks
```

Fixing only the two CI named would have produced a second red `main`.

## Contract change

None. Both rewrites are semantics-preserving:

- `Result::ok().is_some_and(f)` and `Result::is_ok_and(f)` both yield `f(t)` for
  `Ok(t)` and `false` for `Err`. One narrowing, found in review: for `Err`, the
  **drop order of the error payload and the closure's captures reverses**
  (`["error", "closure"]` becomes `["closure", "error"]`). Both edited closures
  capture nothing and there is no observable operation between those drops, so
  neither site can see it — but the equivalence is not unconditional.
- `chunks_exact(N)` and `as_chunks::<N>().0` are the same non-overlapping
  `N`-length chunk prefix, and both discard the same remainder.

## Test evidence

All on `rustc 1.98.0`, the version CI's `stable` currently resolves to.

- Before: 4 errors across 4 targets (`--keep-going`).
- After: `cargo clippy --workspace --all-targets --locked -- -D warnings`
  → **exit 0**; `cargo fmt --all -- --check` → **exit 0**.
- Tests covering each edited site:
  - `fsl-core --test domain_render_agreement` → 11 passed
  - `fsl-lsp --lib` → 28 passed
  - `fslc --test explain_cli` → 13 passed (includes the mixed-fairness
    counterfactual case that reaches the edited branch)
  - `fslc --test chain_cli` → 8 passed, but see the correction below: these do
    **not** reach the edited function.

### Correction: one site has no test coverage

An earlier version of this description claimed `chain_cli` proves the
`chunks_exact(2)` rewrite consumes more than one chunk. **That was wrong**, and
review caught it. `chain_cli` runs `fslc chain`, which dispatches to
`run_project_chain` (`rust/fslc/src/main.rs:1539`) — not `run_refine_chain`
(`:15054`), the function this PR edits. `run_refine_chain` is reached only from
`fslc refine` with more than three path operands, and no test does that:
`failed_link`, a key only that function emits, appears nowhere outside
`main.rs`. So `rust/fslc/src/main.rs:15066` is an **untested** path.

Two things make the rewrite safe there anyway, both checked:

- The remainder question is moot at this call site. `main.rs:1578-1585` rejects
  an odd operand count with `refine chain must list (abs map) pairs after the
  first mapping` and exit 2 **before** calling `run_refine_chain`, so
  `chunks_exact(2)` never had a remainder to drop either.
- Equivalence was verified directly instead: a standalone probe compared both
  forms for N=2 and N=5 over input lengths 0-11, including the empty and
  remainder cases, on both 1.98.0 and 1.88.0. Same chunks, same discarded
  suffix.

The missing coverage is pre-existing, not introduced here, and is filed
separately.

### MSRV, checked deliberately

`as_chunks` is a recently stabilized API and `release.yml:56` pins
`toolchain: 1.88.0`, so PR CI on `stable` cannot see an MSRV break — it would
surface only at release time.

`cargo check -p fslc-rust -p fsl-lsp --locked` on **1.88.0** → **exit 0**.
`as_chunks` is available at the declared MSRV (`rust-version = "1.88"`).

## Not addressed here

The unpinned `stable` toolchain is the actual cause of a green-to-red
transition with no diff, and it will recur on every upstream release. Pinning
it is a repository-policy change across 13 workflows and interacts with
`release.yml`'s existing 1.88.0 pin, so it is deliberately left out of a fix
whose job is to get `main` green.

Separately, this failure produced **no automatically created issue**, and the
cause is now pinned: `post-merge-ci-reporter.yml` acts only when
`workflow_run.event == 'push'`, while the run that caught this was
`event=schedule`. Both ran on the same `head_sha` `abef68c`: product gate
`32406084360` failed, reporter `32406638065` skipped. Upstream drift by
definition arrives without a push, so the reporter has no path to report it.
`docs/DESIGN-ci.md` contradicts itself here — line 1041 documents the push-only
scope, while lines 169-172 claim schedule-triggered defects "surface through
the existing post-merge reporting contract". Filed as #847.
