### PR TITLE
fix(ci): report scheduled and dispatched product gate failures, not only pushes

### DIFF
--- a/.github/scripts/report-post-merge-ci.mjs
+++ b/.github/scripts/report-post-merge-ci.mjs
@@ -4,6 +4,11 @@ import { appendFile, readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
 export const POST_MERGE_LABEL = "ci/post-merge";
+export const TRUSTED_WORKFLOW_EVENTS = new Set([
+  "push",
+  "schedule",
+  "workflow_dispatch",
+]);
 
 const FAILURE_CONCLUSIONS = new Set([
   "action_required",
@@ -42,6 +47,18 @@ export function isNewerRun(candidate, current) {
     return candidate.run_number > current.run_number;
   }
   return (candidate.run_attempt ?? 1) > (current.run_attempt ?? 1);
+}
+
+export function isTrustedDefaultBranchWorkflowRun({
+  workflowRun,
+  repository,
+  defaultBranch,
+}) {
+  return (
+    workflowRun.head_repository?.full_name === repository &&
+    workflowRun.head_branch === defaultBranch &&
+    TRUSTED_WORKFLOW_EVENTS.has(workflowRun.event)
+  );
 }
 
 function recoveryMarker(runId, runAttempt, issueNumber) {
@@ -107,6 +124,7 @@ export function buildIssueBody({ repository, workflowRun, job, pullRequests }) {
     "",
     `- Commit: [\`${shortSha(workflowRun.head_sha)}\`](${commitUrl})`,
     `- Workflow run: [${workflowRun.id}](${workflowRun.html_url})`,
+    `- Event: \`${workflowRun.event}\``,
     `- Job: ${jobLine}`,
     `- Conclusion: \`${job.conclusion}\``,
     `- Associated PR: ${pullRequestSummary(pullRequests)}`,
@@ -123,6 +141,7 @@ function occurrenceComment({ workflowRun, job }) {
     `The failure recurred on [\`${shortSha(workflowRun.head_sha)}\`](https://github.com/${workflowRun.repository.full_name}/commit/${workflowRun.head_sha}).`,
     "",
     `- Workflow run: [${workflowRun.id}](${workflowRun.html_url})`,
+    `- Event: \`${workflowRun.event}\``,
     `- Job: [${job.name}](${job.html_url ?? workflowRun.html_url})`,
     `- Conclusion: \`${job.conclusion}\``,
   ].join("\n");
@@ -149,13 +168,36 @@ async function issueContains(client, issue, marker) {
   return comments.some((comment) => (comment.body ?? "").includes(marker));
 }
 
-export async function reconcilePostMerge({ client, repository, workflowRun }) {
+export async function reconcilePostMerge({
+  client,
+  repository,
+  defaultBranch,
+  workflowRun,
+}) {
+  if (
+    !isTrustedDefaultBranchWorkflowRun({
+      workflowRun,
+      repository,
+      defaultBranch,
+    })
+  ) {
+    return { created: 0, updated: 0, closed: 0, failures: 0, ignored: true };
+  }
+
   const triggeringRunId = workflowRun.id;
   const latestCompletedRun = await client.latestCompletedWorkflowRun(
     workflowRun.workflow_id,
     workflowRun.head_branch,
   );
-  if (latestCompletedRun && isNewerRun(latestCompletedRun, workflowRun)) {
+  if (
+    latestCompletedRun &&
+    isTrustedDefaultBranchWorkflowRun({
+      workflowRun: latestCompletedRun,
+      repository,
+      defaultBranch,
+    }) &&
+    isNewerRun(latestCompletedRun, workflowRun)
+  ) {
     workflowRun = latestCompletedRun;
   }
   workflowRun.repository = { full_name: repository };
@@ -305,13 +347,17 @@ export class GitHubRestClient {
   }
 
   async latestCompletedWorkflowRun(workflowId, branch) {
-    const response = await this.request(
-      "GET",
-      this.repoPath(
-        `/actions/workflows/${workflowId}/runs?branch=${encodeURIComponent(branch)}&event=push&status=completed&per_page=100`,
+    const responses = await Promise.all(
+      [...TRUSTED_WORKFLOW_EVENTS].map((event) =>
+        this.request(
+          "GET",
+          this.repoPath(
+            `/actions/workflows/${workflowId}/runs?branch=${encodeURIComponent(branch)}&event=${encodeURIComponent(event)}&status=completed&per_page=100`,
+          ),
+        ),
       ),
     );
-    return response.workflow_runs.reduce(
+    return responses.flatMap((response) => response.workflow_runs).reduce(
       (latest, run) => (!latest || isNewerRun(run, latest) ? run : latest),
       null,
     );
@@ -385,11 +431,12 @@ async function main() {
   const repository =
     event.repository?.full_name ?? process.env.GITHUB_REPOSITORY;
 
-  if (
-    workflowRun.event !== "push" ||
-    workflowRun.head_branch !== event.repository.default_branch
-  ) {
-    console.log("Ignoring a workflow run that is not a default-branch push.");
+  if (!isTrustedDefaultBranchWorkflowRun({
+    workflowRun,
+    repository,
+    defaultBranch: event.repository.default_branch,
+  })) {
+    console.log("Ignoring a workflow run that is not a trusted default-branch run.");
     return;
   }
 
@@ -400,6 +447,7 @@ async function main() {
   const result = await reconcilePostMerge({
     client,
     repository,
+    defaultBranch: event.repository.default_branch,
     workflowRun,
   });
   const summary = `Post-merge CI reconciliation: ${JSON.stringify(result)}`;

--- a/.github/scripts/report-post-merge-ci.test.mjs
+++ b/.github/scripts/report-post-merge-ci.test.mjs
@@ -1,11 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
-  reconcilePostMerge,
+  GitHubRestClient,
+  isTrustedDefaultBranchWorkflowRun,
+  issueMarker,
+  reconcilePostMerge as reconcilePostMergeImplementation,
 } from "./report-post-merge-ci.mjs";
+
+const REPOSITORY = "ymm-oss/fsl";
+const DEFAULT_BRANCH = "main";
+const REPORTER_WORKFLOW = fileURLToPath(
+  new URL("../workflows/post-merge-ci-reporter.yml", import.meta.url),
+);
+
+function reconcilePostMerge(options) {
+  return reconcilePostMergeImplementation({
+    defaultBranch: DEFAULT_BRANCH,
+    ...options,
+  });
+}
 
 class FakeClient {
   constructor({
@@ -14,12 +32,14 @@ class FakeClient {
     comments = [],
     pulls = [],
     latestRun = null,
+    jobsByRun = new Map(),
   } = {}) {
     this.jobs = jobs;
     this.issues = issues;
     this.comments = comments;
     this.pulls = pulls;
     this.latestRun = latestRun;
+    this.jobsByRun = jobsByRun;
     this.labels = new Set();
     this.nextIssue = 100;
   }
@@ -28,8 +48,8 @@ class FakeClient {
     this.labels.add(name);
   }
 
-  async listJobs() {
-    return this.jobs;
+  async listJobs(runId) {
+    return this.jobsByRun.get(runId) ?? this.jobs;
   }
 
   async latestCompletedWorkflowRun() {
@@ -80,6 +100,7 @@ function workflowRun(overrides = {}) {
     conclusion: "failure",
     event: "push",
     head_branch: "main",
+    head_repository: { full_name: REPOSITORY },
     head_sha: "0123456789abcdef0123456789abcdef01234567",
     html_url: "https://github.com/ymm-oss/fsl/actions/runs/41",
     ...overrides,
@@ -140,6 +161,25 @@ test("creates one actionable issue for a failed job", async () => {
   assert.match(client.issues[0].body, /Test pinned native solver/);
   assert.match(client.issues[0].body, /#247/);
   assert.doesNotMatch(client.issues[0].body, /log output/i);
+});
+
+test("reporter workflow permits exactly the trusted default-branch events", async () => {
+  const workflow = await readFile(REPORTER_WORKFLOW, "utf8");
+
+  assert.match(
+    workflow,
+    /github\.event\.workflow_run\.head_repository\.full_name == github\.repository/,
+  );
+  assert.match(
+    workflow,
+    /github\.event\.workflow_run\.head_branch == github\.event\.repository\.default_branch/,
+  );
+  assert.match(workflow, /github\.event\.workflow_run\.event == 'push'/);
+  assert.match(workflow, /github\.event\.workflow_run\.event == 'schedule'/);
+  assert.match(
+    workflow,
+    /github\.event\.workflow_run\.event == 'workflow_dispatch'/,
+  );
 });
 
 test("deduplicates the same run and comments once for a later recurrence", async () => {
@@ -259,6 +299,7 @@ test("redirects an out-of-order event to the latest completed product gate", asy
       conclusion: "failure",
       event: "push",
       head_branch: "main",
+      head_repository: { full_name: REPOSITORY },
       head_sha: "4123456789abcdef0123456789abcdef01234567",
       html_url: "https://github.com/ymm-oss/fsl/actions/runs/50",
     },
@@ -368,4 +409,163 @@ test("records recovery separately for repeated attempts of one workflow run", as
   assert.equal(recoveryComments.length, 2);
   assert.notEqual(recoveryComments[0].body, recoveryComments[1].body);
   assert.equal(client.issues[0].state, "closed");
+});
+
+test("reports a trusted scheduled failure in the canonical post-merge issue", async () => {
+  const client = new FakeClient({ jobs: [failedWindowsJob()] });
+  const pushedFailure = workflowRun();
+  await reconcilePostMerge({
+    client,
+    repository: REPOSITORY,
+    workflowRun: pushedFailure,
+  });
+
+  const scheduledFailure = workflowRun({
+    id: 42,
+    run_number: 13,
+    event: "schedule",
+    head_sha: "1123456789abcdef0123456789abcdef01234567",
+  });
+  client.jobs = [failedWindowsJob({ id: 91 })];
+  const result = await reconcilePostMerge({
+    client,
+    repository: REPOSITORY,
+    workflowRun: scheduledFailure,
+  });
+
+  assert.equal(
+    isTrustedDefaultBranchWorkflowRun({
+      workflowRun: scheduledFailure,
+      repository: REPOSITORY,
+      defaultBranch: DEFAULT_BRANCH,
+    }),
+    true,
+  );
+  assert.deepEqual(result, {
+    created: 0,
+    updated: 1,
+    closed: 0,
+    failures: 1,
+  });
+  assert.equal(client.issues.length, 1);
+  assert.ok(
+    client.issues[0].body.includes(
+      issueMarker(scheduledFailure.workflow_id, failedWindowsJob().name),
+    ),
+  );
+  assert.match(client.comments[0].body, /- Event: `schedule`/);
+});
+
+test("does not let an older successful push close a newer scheduled failure", async () => {
+  const olderSuccessfulPush = workflowRun({
+    id: 49,
+    run_number: 12,
+    conclusion: "success",
+  });
+  const scheduledFailure = workflowRun({
+    id: 50,
+    run_number: 13,
+    event: "schedule",
+    html_url: "https://github.com/ymm-oss/fsl/actions/runs/50",
+  });
+  const client = new FakeClient({
+    latestRun: olderSuccessfulPush,
+    jobsByRun: new Map([
+      [olderSuccessfulPush.id, [failedWindowsJob({ conclusion: "success" })]],
+      [scheduledFailure.id, [failedWindowsJob()]],
+    ]),
+  });
+
+  const result = await reconcilePostMerge({
+    client,
+    repository: REPOSITORY,
+    workflowRun: scheduledFailure,
+  });
+
+  assert.deepEqual(result, {
+    created: 1,
+    updated: 0,
+    closed: 0,
+    failures: 1,
+  });
+  assert.equal(client.issues[0].state, "open");
+  assert.match(client.issues[0].body, /actions\/runs\/50/);
+});
+
+test("queries each trusted event feed and selects the newer scheduled run", async (t) => {
+  const olderSuccessfulPush = workflowRun({
+    id: 49,
+    run_number: 12,
+    conclusion: "success",
+  });
+  const newerScheduledFailure = workflowRun({
+    id: 50,
+    run_number: 13,
+    event: "schedule",
+  });
+  const runsByEvent = new Map([
+    ["push", [olderSuccessfulPush]],
+    ["schedule", [newerScheduledFailure]],
+    ["workflow_dispatch", []],
+  ]);
+  const originalFetch = globalThis.fetch;
+  const queriedEvents = [];
+  globalThis.fetch = async (url) => {
+    const requestUrl = new URL(url);
+    const event = requestUrl.searchParams.get("event");
+    queriedEvents.push(event);
+    return new Response(
+      JSON.stringify({ workflow_runs: runsByEvent.get(event) }),
+      { status: 200 },
+    );
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const client = new GitHubRestClient({
+    token: "test-token",
+    repository: REPOSITORY,
+  });
+  const latest = await client.latestCompletedWorkflowRun(7, DEFAULT_BRANCH);
+
+  assert.equal(latest.id, newerScheduledFailure.id);
+  assert.equal(latest.event, "schedule");
+  assert.deepEqual(queriedEvents.sort(), [
+    "push",
+    "schedule",
+    "workflow_dispatch",
+  ]);
+});
+
+test("ignores non-default-branch and foreign-repository workflow runs", async () => {
+  for (const ignoredRun of [
+    workflowRun({ head_branch: "feature/future" }),
+    workflowRun({ head_repository: { full_name: "attacker/fsl" } }),
+  ]) {
+    const client = new FakeClient({ jobs: [failedWindowsJob()] });
+    const result = await reconcilePostMerge({
+      client,
+      repository: REPOSITORY,
+      workflowRun: ignoredRun,
+    });
+
+    assert.equal(
+      isTrustedDefaultBranchWorkflowRun({
+        workflowRun: ignoredRun,
+        repository: REPOSITORY,
+        defaultBranch: DEFAULT_BRANCH,
+      }),
+      false,
+    );
+    assert.deepEqual(result, {
+      created: 0,
+      updated: 0,
+      closed: 0,
+      failures: 0,
+      ignored: true,
+    });
+    assert.equal(client.labels.size, 0);
+    assert.equal(client.issues.length, 0);
+  }
 });

--- a/.github/scripts/report-post-merge-ci.test.mjs
+++ b/.github/scripts/report-post-merge-ci.test.mjs
@@ -187,16 +187,37 @@ function reconcileIfExpression(workflow) {
 
   const jobsAt = lines.findIndex((line) => /^jobs:\s*$/.test(line));
   assert.notEqual(jobsAt, -1, "the workflow must declare `jobs:`");
-  const reconcileAt = lines.findIndex(
-    (line, i) => i > jobsAt && /^\s{2}reconcile:\s*$/.test(line),
-  );
-  assert.notEqual(reconcileAt, -1, "the reporting job must be named `reconcile`");
 
-  // The job's keys are indented further than its own name; anything at or below
-  // that column starts a sibling job.
+  // Find the job by WHAT IT DOES, not by what it is called. Review renamed the
+  // live job to `report`, dropped `schedule` from its condition, and appended a
+  // compliant decoy named `reconcile`: actionlint accepted it, every test
+  // passed, and scheduled failures skipped the real reporter -- #847 again. The
+  // job that runs the writer is the one whose condition matters.
+  const WRITER = "node .github/scripts/report-post-merge-ci.mjs";
+  const jobStarts = [];
+  for (let i = jobsAt + 1; i < lines.length; i += 1) {
+    if (/^\s{2}[A-Za-z0-9_-]+:\s*$/.test(lines[i])) {
+      jobStarts.push(i);
+    }
+  }
+  assert.ok(jobStarts.length > 0, "the workflow must declare at least one job");
+
+  const writerJobs = jobStarts.filter((startLine, index) => {
+    const endLine = jobStarts[index + 1] ?? lines.length;
+    return lines
+      .slice(startLine, endLine)
+      .some((line) => line.includes(WRITER) && !line.includes("--test"));
+  });
+  assert.equal(
+    writerJobs.length,
+    1,
+    `exactly one job must run \`${WRITER}\`; found ${writerJobs.length}`,
+  );
+  const writerAt = writerJobs[0];
+
   const jobIndent = 2;
   let ifAt = -1;
-  for (let i = reconcileAt + 1; i < lines.length; i += 1) {
+  for (let i = writerAt + 1; i < lines.length; i += 1) {
     const line = lines[i];
     if (line.trim() === "") {
       continue;
@@ -205,19 +226,23 @@ function reconcileIfExpression(workflow) {
     if (indent <= jobIndent) {
       break;
     }
-    if (/^\s*if:\s*>-?\s*$/.test(line)) {
+    if (/^\s*if:\s*>-\s*$/.test(line)) {
       ifAt = i;
       break;
     }
   }
-  assert.notEqual(ifAt, -1, "`jobs.reconcile` must carry an `if:` block scalar");
+  assert.notEqual(
+    ifAt,
+    -1,
+    "the job running the reporter must carry an `if: >-` block scalar",
+  );
 
   const keyIndent = lines[ifAt].length - lines[ifAt].trimStart().length;
   const body = [];
   for (let i = ifAt + 1; i < lines.length; i += 1) {
     const line = lines[i];
     // A blank line inside a block scalar does NOT end it. Stopping at one is how
-    // a suffix after a blank line went unread.
+    // a negating suffix went unread in an earlier revision.
     if (line.trim() === "") {
       continue;
     }
@@ -264,6 +289,8 @@ test("a commented-out event cannot counterfeit the workflow gate", () => {
     "      (github.event.workflow_run.event == 'push' ||",
     "      github.event.workflow_run.event == 'workflow_dispatch')",
     "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: node .github/scripts/report-post-merge-ci.mjs",
   ].join("\n");
   assert.notEqual(reconcileIfExpression(counterfeit), expectedReconcileCondition());
 });
@@ -281,6 +308,8 @@ test("a negated event inside the disjunction is rejected", () => {
     "      github.event.workflow_run.event == 'schedule' && false ||",
     "      github.event.workflow_run.event == 'workflow_dispatch')",
     "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: node .github/scripts/report-post-merge-ci.mjs",
   ].join("\n");
   assert.notEqual(reconcileIfExpression(negated), expectedReconcileCondition());
 });
@@ -300,6 +329,8 @@ test("a suffix after a blank line inside the scalar is not ignored", () => {
     "",
     "      && github.event.workflow_run.event != 'schedule'",
     "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: node .github/scripts/report-post-merge-ci.mjs",
   ].join("\n");
   assert.notEqual(reconcileIfExpression(suffixed), expectedReconcileCondition());
 });
@@ -323,8 +354,82 @@ test("a decoy job carrying the approved expression is not read instead", () => {
     "      (github.event.workflow_run.event == 'push' ||",
     "      github.event.workflow_run.event == 'workflow_dispatch')",
     "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: node .github/scripts/report-post-merge-ci.mjs",
   ].join("\n");
   assert.notEqual(reconcileIfExpression(decoyed), expectedReconcileCondition());
+});
+
+test("renaming the writer job and leaving a compliant decoy is rejected", () => {
+  // Review's bypass: the control bound the condition to the job ID `reconcile`,
+  // not to the job that runs the reporter. Rename the live job, drop `schedule`
+  // from its condition, and name a decoy `reconcile`. actionlint accepted it and
+  // every test passed while scheduled failures skipped the real reporter.
+  const renamed = [
+    "jobs:",
+    "  report:",
+    "    if: >-",
+    "      github.event.workflow_run.event == 'push' &&",
+    "      github.event.workflow_run.head_branch == github.event.repository.default_branch",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: node .github/scripts/report-post-merge-ci.mjs",
+    "  reconcile:",
+    "    if: >-",
+    "      github.event.workflow_run.head_repository.full_name == github.repository &&",
+    "      github.event.workflow_run.head_branch == github.event.repository.default_branch &&",
+    "      (github.event.workflow_run.event == 'push' ||",
+    "      github.event.workflow_run.event == 'schedule' ||",
+    "      github.event.workflow_run.event == 'workflow_dispatch')",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: 'true'",
+  ].join("\n");
+  // The helper must read the `report` job, because that is where the writer is.
+  assert.notEqual(reconcileIfExpression(renamed), expectedReconcileCondition());
+});
+
+test("two jobs both running the reporter is rejected as ambiguous", () => {
+  // Splitting the writer across two jobs would leave one of them unchecked.
+  const twoWriters = [
+    "jobs:",
+    "  a:",
+    "    if: >-",
+    "      github.event.workflow_run.event == 'push'",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: node .github/scripts/report-post-merge-ci.mjs",
+    "  b:",
+    "    if: >-",
+    "      github.event.workflow_run.event == 'schedule'",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: node .github/scripts/report-post-merge-ci.mjs",
+  ].join("\n");
+  assert.throws(
+    () => reconcileIfExpression(twoWriters),
+    /exactly one job must run/,
+  );
+});
+
+test("a workflow with no job running the reporter is rejected", () => {
+  const noWriter = [
+    "jobs:",
+    "  reconcile:",
+    "    if: >-",
+    "      github.event.workflow_run.head_repository.full_name == github.repository &&",
+    "      github.event.workflow_run.head_branch == github.event.repository.default_branch &&",
+    "      (github.event.workflow_run.event == 'push' ||",
+    "      github.event.workflow_run.event == 'schedule' ||",
+    "      github.event.workflow_run.event == 'workflow_dispatch')",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: 'true'",
+  ].join("\n");
+  assert.throws(
+    () => reconcileIfExpression(noWriter),
+    /exactly one job must run/,
+  );
 });
 
 test("a condition folded across lines is still recognised", () => {
@@ -339,6 +444,8 @@ test("a condition folded across lines is still recognised", () => {
     "      == 'schedule' ||",
     "      github.event.workflow_run.event == 'workflow_dispatch')",
     "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: node .github/scripts/report-post-merge-ci.mjs",
   ].join("\n");
   assert.equal(reconcileIfExpression(folded), expectedReconcileCondition());
 });

--- a/.github/scripts/report-post-merge-ci.test.mjs
+++ b/.github/scripts/report-post-merge-ci.test.mjs
@@ -164,23 +164,121 @@ test("creates one actionable issue for a failed job", async () => {
   assert.doesNotMatch(client.issues[0].body, /log output/i);
 });
 
+/**
+ * The reconcile job's `if:` expression, with the block scalar folded back into
+ * one line.
+ *
+ * This must read the expression itself, not the workflow source. Review showed
+ * why: an earlier version regex-scanned the whole file, so deleting the live
+ * `schedule` predicate and adding
+ *
+ *     # github.event.workflow_run.event == 'schedule'
+ *
+ * as a COMMENT kept the extracted set complete, the equality assertion passed,
+ * actionlint accepted the file, and scheduled runs silently skipped the
+ * reporter -- reproducing #847 exactly. The same scan also rejected a condition
+ * legitimately split across lines inside the existing `>-` scalar, because it
+ * compared spelling rather than meaning.
+ */
+function reconcileIfExpression(workflow) {
+  const lines = workflow.split("\n");
+  const start = lines.findIndex((line) => /^\s*if:\s*>-\s*$/.test(line));
+  assert.notEqual(start, -1, "the reconcile job must use an `if: >-` block");
+  const indent =
+    lines[start + 1].length - lines[start + 1].trimStart().length;
+  const body = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === "") {
+      break;
+    }
+    const thisIndent = line.length - line.trimStart().length;
+    if (thisIndent < indent) {
+      break;
+    }
+    // A `#` inside a block scalar is literal text, not a comment, so nothing is
+    // stripped here -- but a comment OUTSIDE the scalar is never reached.
+    body.push(line.trim());
+  }
+  assert.ok(body.length > 0, "the `if:` block must not be empty");
+  // Folded scalars join with single spaces, which is what GitHub evaluates.
+  return body.join(" ").replace(/\s+/g, " ");
+}
+
 test("reporter workflow permits exactly the trusted default-branch events", async () => {
   const workflow = await readFile(REPORTER_WORKFLOW, "utf8");
+  const condition = reconcileIfExpression(workflow);
+
   const workflowEvents = new Set(
-    [...workflow.matchAll(/github\.event\.workflow_run\.event == '([^']+)'/g)].map(
+    [...condition.matchAll(/github\.event\.workflow_run\.event == '([^']+)'/g)].map(
       ([, event]) => event,
     ),
   );
 
   assert.match(
-    workflow,
+    condition,
     /github\.event\.workflow_run\.head_repository\.full_name == github\.repository/,
   );
   assert.match(
-    workflow,
+    condition,
     /github\.event\.workflow_run\.head_branch == github\.event\.repository\.default_branch/,
   );
   assert.deepEqual(workflowEvents, TRUSTED_WORKFLOW_EVENTS);
+});
+
+test("a commented-out event cannot counterfeit the workflow gate", () => {
+  // The mutation review found: remove the live predicate, restate it in a
+  // comment. The extraction must not see the comment.
+  //
+  // Built from a literal rather than by patching the committed file, so a change
+  // to how that file spells its condition cannot make this control silently
+  // stop constructing the mutation it exists to reject.
+  const counterfeit = [
+    "# github.event.workflow_run.event == 'schedule'",
+    "jobs:",
+    "  reconcile:",
+    "    if: >-",
+    "      github.event.workflow_run.head_repository.full_name == github.repository &&",
+    "      github.event.workflow_run.head_branch == github.event.repository.default_branch &&",
+    "      (github.event.workflow_run.event == 'push' ||",
+    "      github.event.workflow_run.event == 'workflow_dispatch')",
+    "    runs-on: ubuntu-latest",
+  ].join("\n");
+  const condition = reconcileIfExpression(counterfeit);
+  const events = new Set(
+    [...condition.matchAll(/github\.event\.workflow_run\.event == '([^']+)'/g)].map(
+      ([, event]) => event,
+    ),
+  );
+  assert.ok(
+    !events.has("schedule"),
+    "a comment must not supply a missing predicate",
+  );
+  assert.notDeepEqual(events, TRUSTED_WORKFLOW_EVENTS);
+});
+
+test("a condition folded across lines is still recognised", () => {
+  // Valid inside a `>-` scalar, and falsely rejected by the earlier source scan.
+  // Also built from a literal, for the same reason as above.
+  const folded = [
+    "jobs:",
+    "  reconcile:",
+    "    if: >-",
+    "      github.event.workflow_run.head_repository.full_name == github.repository &&",
+    "      github.event.workflow_run.head_branch == github.event.repository.default_branch &&",
+    "      (github.event.workflow_run.event == 'push' ||",
+    "      github.event.workflow_run.event",
+    "      == 'schedule' ||",
+    "      github.event.workflow_run.event == 'workflow_dispatch')",
+    "    runs-on: ubuntu-latest",
+  ].join("\n");
+  const condition = reconcileIfExpression(folded);
+  const events = new Set(
+    [...condition.matchAll(/github\.event\.workflow_run\.event == '([^']+)'/g)].map(
+      ([, event]) => event,
+    ),
+  );
+  assert.deepEqual(events, TRUSTED_WORKFLOW_EVENTS);
 });
 
 test("deduplicates the same run and comments once for a later recurrence", async () => {

--- a/.github/scripts/report-post-merge-ci.test.mjs
+++ b/.github/scripts/report-post-merge-ci.test.mjs
@@ -165,74 +165,95 @@ test("creates one actionable issue for a failed job", async () => {
 });
 
 /**
- * The reconcile job's `if:` expression, with the block scalar folded back into
- * one line.
+ * The `if:` expression of the **`reconcile` job specifically**, normalised to one
+ * line the way a YAML folded scalar joins it.
  *
- * This must read the expression itself, not the workflow source. Review showed
- * why: an earlier version regex-scanned the whole file, so deleting the live
- * `schedule` predicate and adding
+ * Three revisions of this control were bypassed, each teaching the same lesson.
  *
- *     # github.event.workflow_run.event == 'schedule'
+ * First it regex-scanned the whole file, so a commented-out predicate could
+ * counterfeit a deleted one. Then it compared the SET of event-name tokens,
+ * which is not the same thing as comparing the expression: review passed
+ * `event == 'schedule' && false ||` (set unchanged, schedules rejected), and a
+ * blank line followed by `&& ... != 'schedule'` (helper stopped at the blank
+ * line, suffix ignored). It also located the first `if:` in the file, so a decoy
+ * job carrying the approved expression let the real one drop `schedule`.
  *
- * as a COMMENT kept the extracted set complete, the equality assertion passed,
- * actionlint accepted the file, and scheduled runs silently skipped the
- * reporter -- reproducing #847 exactly. The same scan also rejected a condition
- * legitimately split across lines inside the existing `>-` scalar, because it
- * compared spelling rather than meaning.
+ * All three recreated #847 with the control green and `actionlint` clean. So this
+ * pins the whole expression by equality, anchored at `jobs.reconcile`, and reads
+ * to the end of the block rather than to the first blank line.
  */
 function reconcileIfExpression(workflow) {
   const lines = workflow.split("\n");
-  const start = lines.findIndex((line) => /^\s*if:\s*>-\s*$/.test(line));
-  assert.notEqual(start, -1, "the reconcile job must use an `if: >-` block");
-  const indent =
-    lines[start + 1].length - lines[start + 1].trimStart().length;
-  const body = [];
-  for (let i = start + 1; i < lines.length; i += 1) {
+
+  const jobsAt = lines.findIndex((line) => /^jobs:\s*$/.test(line));
+  assert.notEqual(jobsAt, -1, "the workflow must declare `jobs:`");
+  const reconcileAt = lines.findIndex(
+    (line, i) => i > jobsAt && /^\s{2}reconcile:\s*$/.test(line),
+  );
+  assert.notEqual(reconcileAt, -1, "the reporting job must be named `reconcile`");
+
+  // The job's keys are indented further than its own name; anything at or below
+  // that column starts a sibling job.
+  const jobIndent = 2;
+  let ifAt = -1;
+  for (let i = reconcileAt + 1; i < lines.length; i += 1) {
     const line = lines[i];
     if (line.trim() === "") {
+      continue;
+    }
+    const indent = line.length - line.trimStart().length;
+    if (indent <= jobIndent) {
       break;
     }
-    const thisIndent = line.length - line.trimStart().length;
-    if (thisIndent < indent) {
+    if (/^\s*if:\s*>-?\s*$/.test(line)) {
+      ifAt = i;
       break;
     }
-    // A `#` inside a block scalar is literal text, not a comment, so nothing is
-    // stripped here -- but a comment OUTSIDE the scalar is never reached.
+  }
+  assert.notEqual(ifAt, -1, "`jobs.reconcile` must carry an `if:` block scalar");
+
+  const keyIndent = lines[ifAt].length - lines[ifAt].trimStart().length;
+  const body = [];
+  for (let i = ifAt + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    // A blank line inside a block scalar does NOT end it. Stopping at one is how
+    // a suffix after a blank line went unread.
+    if (line.trim() === "") {
+      continue;
+    }
+    const indent = line.length - line.trimStart().length;
+    if (indent <= keyIndent) {
+      break;
+    }
     body.push(line.trim());
   }
   assert.ok(body.length > 0, "the `if:` block must not be empty");
-  // Folded scalars join with single spaces, which is what GitHub evaluates.
-  return body.join(" ").replace(/\s+/g, " ");
+  return body.join(" ").replace(/\s+/g, " ").trim();
 }
 
-test("reporter workflow permits exactly the trusted default-branch events", async () => {
+/**
+ * The exact expression `jobs.reconcile` must carry, built from
+ * `TRUSTED_WORKFLOW_EVENTS` so the YAML and the JavaScript cannot drift apart.
+ */
+function expectedReconcileCondition() {
+  const events = [...TRUSTED_WORKFLOW_EVENTS]
+    .map((event) => `github.event.workflow_run.event == '${event}'`)
+    .join(" || ");
+  return [
+    "github.event.workflow_run.head_repository.full_name == github.repository &&",
+    "github.event.workflow_run.head_branch == github.event.repository.default_branch &&",
+    `(${events})`,
+  ].join(" ");
+}
+
+test("the reconcile job's if: expression is exactly the trusted condition", async () => {
   const workflow = await readFile(REPORTER_WORKFLOW, "utf8");
-  const condition = reconcileIfExpression(workflow);
-
-  const workflowEvents = new Set(
-    [...condition.matchAll(/github\.event\.workflow_run\.event == '([^']+)'/g)].map(
-      ([, event]) => event,
-    ),
-  );
-
-  assert.match(
-    condition,
-    /github\.event\.workflow_run\.head_repository\.full_name == github\.repository/,
-  );
-  assert.match(
-    condition,
-    /github\.event\.workflow_run\.head_branch == github\.event\.repository\.default_branch/,
-  );
-  assert.deepEqual(workflowEvents, TRUSTED_WORKFLOW_EVENTS);
+  // Equality of the whole expression, not of the event tokens inside it. A set
+  // comparison cannot see `&& false`, a negating suffix, or a decoy job.
+  assert.equal(reconcileIfExpression(workflow), expectedReconcileCondition());
 });
 
 test("a commented-out event cannot counterfeit the workflow gate", () => {
-  // The mutation review found: remove the live predicate, restate it in a
-  // comment. The extraction must not see the comment.
-  //
-  // Built from a literal rather than by patching the committed file, so a change
-  // to how that file spells its condition cannot make this control silently
-  // stop constructing the mutation it exists to reject.
   const counterfeit = [
     "# github.event.workflow_run.event == 'schedule'",
     "jobs:",
@@ -244,22 +265,69 @@ test("a commented-out event cannot counterfeit the workflow gate", () => {
     "      github.event.workflow_run.event == 'workflow_dispatch')",
     "    runs-on: ubuntu-latest",
   ].join("\n");
-  const condition = reconcileIfExpression(counterfeit);
-  const events = new Set(
-    [...condition.matchAll(/github\.event\.workflow_run\.event == '([^']+)'/g)].map(
-      ([, event]) => event,
-    ),
-  );
-  assert.ok(
-    !events.has("schedule"),
-    "a comment must not supply a missing predicate",
-  );
-  assert.notDeepEqual(events, TRUSTED_WORKFLOW_EVENTS);
+  assert.notEqual(reconcileIfExpression(counterfeit), expectedReconcileCondition());
+});
+
+test("a negated event inside the disjunction is rejected", () => {
+  // `event == 'schedule' && false ||` keeps the token set intact and rejects
+  // schedules. Review passed this through the previous control.
+  const negated = [
+    "jobs:",
+    "  reconcile:",
+    "    if: >-",
+    "      github.event.workflow_run.head_repository.full_name == github.repository &&",
+    "      github.event.workflow_run.head_branch == github.event.repository.default_branch &&",
+    "      (github.event.workflow_run.event == 'push' ||",
+    "      github.event.workflow_run.event == 'schedule' && false ||",
+    "      github.event.workflow_run.event == 'workflow_dispatch')",
+    "    runs-on: ubuntu-latest",
+  ].join("\n");
+  assert.notEqual(reconcileIfExpression(negated), expectedReconcileCondition());
+});
+
+test("a suffix after a blank line inside the scalar is not ignored", () => {
+  // YAML keeps this inside the block scalar; the earlier helper stopped reading
+  // at the blank line and never saw the negation.
+  const suffixed = [
+    "jobs:",
+    "  reconcile:",
+    "    if: >-",
+    "      github.event.workflow_run.head_repository.full_name == github.repository &&",
+    "      github.event.workflow_run.head_branch == github.event.repository.default_branch &&",
+    "      (github.event.workflow_run.event == 'push' ||",
+    "      github.event.workflow_run.event == 'schedule' ||",
+    "      github.event.workflow_run.event == 'workflow_dispatch')",
+    "",
+    "      && github.event.workflow_run.event != 'schedule'",
+    "    runs-on: ubuntu-latest",
+  ].join("\n");
+  assert.notEqual(reconcileIfExpression(suffixed), expectedReconcileCondition());
+});
+
+test("a decoy job carrying the approved expression is not read instead", () => {
+  // The earlier helper took the FIRST `if:` in the file.
+  const decoyed = [
+    "jobs:",
+    "  decoy:",
+    "    if: >-",
+    "      github.event.workflow_run.head_repository.full_name == github.repository &&",
+    "      github.event.workflow_run.head_branch == github.event.repository.default_branch &&",
+    "      (github.event.workflow_run.event == 'push' ||",
+    "      github.event.workflow_run.event == 'schedule' ||",
+    "      github.event.workflow_run.event == 'workflow_dispatch')",
+    "    runs-on: ubuntu-latest",
+    "  reconcile:",
+    "    if: >-",
+    "      github.event.workflow_run.head_repository.full_name == github.repository &&",
+    "      github.event.workflow_run.head_branch == github.event.repository.default_branch &&",
+    "      (github.event.workflow_run.event == 'push' ||",
+    "      github.event.workflow_run.event == 'workflow_dispatch')",
+    "    runs-on: ubuntu-latest",
+  ].join("\n");
+  assert.notEqual(reconcileIfExpression(decoyed), expectedReconcileCondition());
 });
 
 test("a condition folded across lines is still recognised", () => {
-  // Valid inside a `>-` scalar, and falsely rejected by the earlier source scan.
-  // Also built from a literal, for the same reason as above.
   const folded = [
     "jobs:",
     "  reconcile:",
@@ -272,13 +340,7 @@ test("a condition folded across lines is still recognised", () => {
     "      github.event.workflow_run.event == 'workflow_dispatch')",
     "    runs-on: ubuntu-latest",
   ].join("\n");
-  const condition = reconcileIfExpression(folded);
-  const events = new Set(
-    [...condition.matchAll(/github\.event\.workflow_run\.event == '([^']+)'/g)].map(
-      ([, event]) => event,
-    ),
-  );
-  assert.deepEqual(events, TRUSTED_WORKFLOW_EVENTS);
+  assert.equal(reconcileIfExpression(folded), expectedReconcileCondition());
 });
 
 test("deduplicates the same run and comments once for a later recurrence", async () => {

--- a/.github/scripts/report-post-merge-ci.test.mjs
+++ b/.github/scripts/report-post-merge-ci.test.mjs
@@ -10,6 +10,7 @@ import {
   isTrustedDefaultBranchWorkflowRun,
   issueMarker,
   reconcilePostMerge as reconcilePostMergeImplementation,
+  TRUSTED_WORKFLOW_EVENTS,
 } from "./report-post-merge-ci.mjs";
 
 const REPOSITORY = "ymm-oss/fsl";
@@ -165,6 +166,11 @@ test("creates one actionable issue for a failed job", async () => {
 
 test("reporter workflow permits exactly the trusted default-branch events", async () => {
   const workflow = await readFile(REPORTER_WORKFLOW, "utf8");
+  const workflowEvents = new Set(
+    [...workflow.matchAll(/github\.event\.workflow_run\.event == '([^']+)'/g)].map(
+      ([, event]) => event,
+    ),
+  );
 
   assert.match(
     workflow,
@@ -174,12 +180,7 @@ test("reporter workflow permits exactly the trusted default-branch events", asyn
     workflow,
     /github\.event\.workflow_run\.head_branch == github\.event\.repository\.default_branch/,
   );
-  assert.match(workflow, /github\.event\.workflow_run\.event == 'push'/);
-  assert.match(workflow, /github\.event\.workflow_run\.event == 'schedule'/);
-  assert.match(
-    workflow,
-    /github\.event\.workflow_run\.event == 'workflow_dispatch'/,
-  );
+  assert.deepEqual(workflowEvents, TRUSTED_WORKFLOW_EVENTS);
 });
 
 test("deduplicates the same run and comments once for a later recurrence", async () => {

--- a/.github/workflows/post-merge-ci-reporter.yml
+++ b/.github/workflows/post-merge-ci-reporter.yml
@@ -25,8 +25,11 @@ jobs:
   reconcile:
     name: reconcile post-merge CI issue
     if: >-
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == github.event.repository.default_branch
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+      (github.event.workflow_run.event == 'push' ||
+      github.event.workflow_run.event == 'schedule' ||
+      github.event.workflow_run.event == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/changelog.d/847-scheduled-gate-reporting.fixed.md
+++ b/changelog.d/847-scheduled-gate-reporting.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#847): Scheduled and manually dispatched product-gate failures now reconcile through the post-merge CI reporter.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -169,8 +169,9 @@ run. A missing base/head SHA, a failed `git diff`, or an event the script does n
 resolve to `run=true` — never to a stub. The `main` push, schedule, and dispatch triggers carry no
 exemption at all: `tools/check-product-gate-scope.sh` returns `run=true` unconditionally for
 those events, so every merged `main` state still receives the complete product evidence, and a
-wrongly exempted defect surfaces through the existing post-merge reporting contract below instead
-of reaching `production`. And a pull request into `production` that matches the list is blocked
+wrongly exempted defect surfaces through the existing post-merge reporting contract below for a
+trusted default-branch push, schedule, or dispatch run instead of reaching `production`. And a
+pull request into `production` that matches the list is blocked
 rather than waved through: the script's `production` branch always returns `run=true`, so the
 production ruleset's required contexts (`rust workspace`, `WASM`, the `native Z3 4.16` matrix)
 still report real evidence — such a pull request should not exist, and the gate does not invent a
@@ -1159,8 +1160,9 @@ suite above, not a live run.
 ## Failure reporting contract
 
 `.github/workflows/post-merge-ci-reporter.yml` listens for completed `product gate` runs. It acts
-only when the triggering run was a push to the repository's default branch. The workflow receives
-read access to Actions, contents, and pull requests, and write access only to issues.
+only for a run from this repository's default branch whose event is `push`, `schedule`, or
+`workflow_dispatch`; pull-request and foreign-repository runs cannot mutate issues. The workflow
+receives read access to Actions, contents, and pull requests, and write access only to issues.
 
 For each failed, timed-out, cancelled, stale, startup-failed, or action-required job, the reporter:
 
@@ -1169,16 +1171,22 @@ For each failed, timed-out, cancelled, stale, startup-failed, or action-required
   the same issue after a later recurrence;
 - records the commit, associated merged pull request, run, job, conclusion, and failed step names;
 - copies no build log text or secret-bearing output into the issue;
-- adds one occurrence comment for a later failing run instead of opening a duplicate;
+- adds one occurrence comment for a later failing run instead of opening a duplicate, including
+  the triggering event so scheduled drift is distinguishable from a merged-commit failure;
 - closes the matching issue only after that job, or the complete product gate, succeeds on a later
   `main` run.
 
 An unsuccessful workflow with no failed-job metadata gets a workflow-level issue, so startup and
 orchestration failures do not disappear. Re-running the reporter for the same product-gate run is
-idempotent. Before mutating issues, the reporter queries the latest completed trusted push run for
-the same workflow. When an older `run_number`/`run_attempt` event arrives, it reconciles that latest
-run instead of the stale trigger; out-of-order platform completion cannot overwrite newer
-default-branch health or cancel the only reporter for a persistent newer failure.
+idempotent. The canonical marker remains keyed by workflow ID and stable job name, not event:
+push, scheduled, and manual runs all measure the same default-branch job health, so separate
+issues would duplicate one unresolved breakage. Before mutating issues, the reporter queries the
+latest completed trusted run for the same workflow by making one event-filtered request for each
+of `push`, `schedule`, and `workflow_dispatch`; this keeps a page of pull-request runs from
+displacing trusted evidence. When an older `run_number`/`run_attempt` event arrives, it reconciles
+that latest run instead of the stale trigger; GitHub numbers runs per workflow across events, so
+out-of-order platform completion cannot overwrite newer default-branch health or cancel the only
+reporter for a persistent newer failure.
 
 Reporter jobs are also serialized to avoid duplicate-creation races. When product gates finish
 faster than reporting, GitHub may coalesce pending reporter runs toward the newest default-branch


### PR DESCRIPTION
## Problem

`main` was red for hours and **nothing filed an issue**. It was found by manual
inspection while investigating something else.

The scheduled `product gate` failed and the reporter for the *same commit* was
skipped:

| run | workflow | event | `head_sha` | result |
|---|---|---|---|---|
| `32406084360` | product gate | **schedule** | `abef68c` | **failure** |
| `32406638065` | post-merge CI reporter | workflow_run | `abef68c` | **skipped** |

The last eight reporter runs were all `skipped`. The cause was
`post-merge-ci-reporter.yml` requiring `workflow_run.event == 'push'`.

The daily cron is the **only** mechanism that revalidates `main` without a new
commit — so it is the only detector of upstream drift: a new compiler, a new
transitive dependency, an expired cache. Its entire output was being dropped.
The live instance: `rustc`/`clippy` 1.98.0 released 2026-08-18, `main` went
green-to-red with a zero-line diff, and nothing reported it (fixed by #846).

## Contract conflict, resolved

`docs/DESIGN-ci.md` contradicted itself, and resolving that is most of this PR:

- **:1123** documented the reporter as acting "only when the triggering run was
  a push to the repository's default branch."
- **:172** claimed a wrongly exempted defect "surfaces through the existing
  post-merge reporting contract below" — for the `main` push, **schedule** and
  dispatch triggers.

Resolved in the *widen-the-reporter* direction, and both passages now say the
same thing. There was already a precedent in the same document: **:896**
describes the cache-budget-audit reporter (merged in #840) as requiring "the same
repository, the default branch, and one of `push`, `schedule`, or
`workflow_dispatch`". This aligns the older reporter with the newer one rather
than inventing a second shape.

## The part that is not just the workflow `if`

The push assumption lived in **three** places, and widening only one would have
reproduced the "nothing gets filed" symptom by a different route:

| # | location | before |
|---|---|---|
| 1 | `post-merge-ci-reporter.yml` job `if` | `event == 'push'` |
| 2 | `report-post-merge-ci.mjs` `main()` guard | `event !== "push"` → return |
| 3 | `report-post-merge-ci.mjs` `latestCompletedWorkflowRun` | `&event=push` **hardcoded in the API query** |

(3) was the trap. `reconcilePostMerge` replaces the triggering run with that
"latest completed trusted run" when `isNewerRun` says so. Widen only the `if`,
and a schedule failure gets reconciled against the latest **push** run — which
may be older and successful — so the real failure is overwritten and the issue
wrongly **closed**.

All three now derive from one exported `TRUSTED_WORKFLOW_EVENTS` set, so they
cannot drift apart again.

`latestCompletedWorkflowRun` issues **one event-filtered request per trusted
event** and merges the results, rather than dropping the filter. Dropping it
would let `pull_request` runs be selected as "latest" — a PR run is not `main`'s
health — and would let a page of PR runs exhaust `per_page=100` and push trusted
runs out of the window.

Cross-event ordering is sound without redesign: GitHub numbers runs **per
workflow** across events, so the existing `run_number` → `run_attempt`
comparison already compares correctly.

`reconcilePostMerge` additionally re-validates the candidate through the same
trust predicate before adopting it, so an unexpected API result cannot be
adopted. This depends on `head_repository` being present in list-runs responses,
which was checked against the live API rather than assumed:

```
$ gh api "repos/ymm-oss/fsl/actions/workflows/296597288/runs?branch=main&event=schedule&status=completed&per_page=1"
{"event":"schedule","has_head_repository":true,
 "head_repository_full_name":"ymm-oss/fsl","head_branch":"main",
 "id":32406084360,"run_attempt":1,"run_number":1164}
```

## Also fixed: the missing fork guard

The older reporter had no `head_repository.full_name == github.repository`
condition (`grep` returned 0) while the newer one does. This was **not
exploitable before this PR** — `workflow_run` fires in the repository where the
triggering workflow ran, so a fork push cannot trigger the upstream reporter, and
a fork PR arrives as `event == 'pull_request'`, which the old gate excluded. But
that reasoning rested entirely on the event list, which this PR changes, so the
guard is added here rather than left implicit. This job holds `issues: write`.

## Issue keying: one canonical issue, event recorded

The marker stays keyed by workflow ID and stable job name, **not** by event.
Push, scheduled and manual runs all measure the same default-branch job health,
so separate issues would duplicate one unresolved breakage. To keep the history
readable, the issue body and every occurrence comment now record the triggering
event, so scheduled drift is distinguishable from a merged-commit failure. The
rationale is written into `docs/DESIGN-ci.md`.

## Test evidence

`node --test .github/scripts/report-post-merge-ci.test.mjs` → **exit 0, 13/13**.

`./tools/check-merge-readiness.sh automation` → **exit 0**: post-merge reporter
13, cache-budget reporter 47, ruleset-drift 42, cache-audit 65, plus the
automation self-tests. This is the **required** lane, so the new controls are
mechanically enforced rather than merely present.

`actionlint .github/workflows/post-merge-ci-reporter.yml` → exit 0.
`./tools/aggregate_changelog.sh check` → exit 0.

### Calibration: each rejecting control was seen to fail

A control that has not been observed failing has not been shown to detect
anything. Each new rejecting control was confirmed to exit 1 when **its own**
fix was reverted, one at a time:

| reverted | control that failed |
|---|---|
| the schedule workflow condition | scheduled reporting |
| the trusted event set | trusted-event wiring |
| the ordering comparison | older-push must not overwrite a newer schedule failure |
| the push-only query | three event-filtered queries |
| the repository guard | foreign-repository rejection |

Existing push behavior — dedup, occurrence comment, close-on-recovery,
reopen-on-recurrence — remains green.

## Not verified by execution

No live `workflow_run` was dispatched; a real scheduled failure was not induced.
The behavior is covered by the controls above against synthetic run payloads
shaped to match the live API response verified in the block above.

Closes #847
