### PR TITLE
chore(ci): pin the Rust toolchain and control the pin

### DIFF
--- a/.github/scripts/audit-toolchain-pin.mjs
+++ b/.github/scripts/audit-toolchain-pin.mjs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Every `dtolnay/rust-toolchain` reference under `.github/workflows` must name
+// one agreed Rust version, so an upstream `stable` release cannot turn `main`
+// red with no repository change (issue #847's live instance: rustc 1.98.0 was
+// released 2026-08-18 and the scheduled product gate began failing on a
+// zero-line diff).
+//
+// `release.yml` is deliberately exempt: it pins the MSRV declared by
+// `rust/Cargo.toml`'s `rust-version`, not the development toolchain, and it
+// pins the action by commit SHA rather than by version branch. Its exemption is
+// declared here by exact path so that renaming or removing that workflow is a
+// visible change rather than a silent widening.
+
+import { readdir, readFile } from "node:fs/promises";
+
+export const ACTION = "dtolnay/rust-toolchain";
+
+export const EXPECTED_REF = "1.98.0";
+
+// Exempt path => the reason it is exempt. An entry here is a declared decision,
+// not a wildcard: a path not listed is audited.
+export const DECLARED_EXEMPTIONS = Object.freeze({
+  "release.yml":
+    "pins the MSRV from rust/Cargo.toml's rust-version, by action commit SHA, " +
+    "not the development toolchain",
+});
+
+const USES_PATTERN = new RegExp(
+  `^\\s*-\\s*uses:\\s*${ACTION.replace("/", "\\/")}@(\\S+)\\s*$`,
+);
+
+/**
+ * Every `uses:` reference to the toolchain action in one workflow's text.
+ * Comments are not `uses:` lines and are not collected here; `auditReferences`
+ * checks them separately.
+ */
+export function collectReferences(fileName, text) {
+  const references = [];
+  text.split("\n").forEach((line, index) => {
+    const match = USES_PATTERN.exec(line);
+    if (match) {
+      references.push({ file: fileName, line: index + 1, ref: match[1] });
+    }
+  });
+  return references;
+}
+
+/**
+ * Every comment line that names the action with an explicit `@ref`. These are
+ * cited justifications -- `merge-readiness.yml` explains its restore-only cache
+ * key by naming the action and ref that produce the matching key -- so a ref
+ * bump that leaves them behind makes the citation disagree with the code.
+ */
+export function collectCitations(fileName, text) {
+  const citations = [];
+  const pattern = new RegExp(`${ACTION.replace("/", "\\/")}@([\\w.-]+)`);
+  text.split("\n").forEach((line, index) => {
+    if (!line.trimStart().startsWith("#")) {
+      return;
+    }
+    const match = pattern.exec(line);
+    if (match) {
+      citations.push({ file: fileName, line: index + 1, ref: match[1] });
+    }
+  });
+  return citations;
+}
+
+/**
+ * Audit one workflow's collected references and citations.
+ *
+ * Returns a finding per disagreement. An empty array means the workflow agrees
+ * with `EXPECTED_REF`, or is a declared exemption.
+ */
+export function auditReferences({ references, citations, expectedRef, exemptions }) {
+  const findings = [];
+  const declared = exemptions ?? DECLARED_EXEMPTIONS;
+  const expected = expectedRef ?? EXPECTED_REF;
+
+  for (const reference of references) {
+    if (Object.hasOwn(declared, reference.file)) {
+      continue;
+    }
+    if (reference.ref === "stable" || reference.ref === "nightly" || reference.ref === "beta") {
+      findings.push({
+        class: "floating-channel",
+        file: reference.file,
+        line: reference.line,
+        ref: reference.ref,
+        message:
+          `${reference.file}:${reference.line} uses ${ACTION}@${reference.ref}. ` +
+          "A floating channel lets an upstream Rust release turn `main` red with " +
+          `no repository change; pin it to ${expected} (see issue #847).`,
+      });
+      continue;
+    }
+    if (reference.ref !== expected) {
+      findings.push({
+        class: "ref-disagreement",
+        file: reference.file,
+        line: reference.line,
+        ref: reference.ref,
+        message:
+          `${reference.file}:${reference.line} uses ${ACTION}@${reference.ref} but ` +
+          `every audited workflow must use @${expected}. Swatinem/rust-cache keys ` +
+          "include the rustc version, so a split toolchain silently breaks " +
+          "merge-readiness.yml's restore-only key match against ci.yml.",
+      });
+    }
+  }
+
+  for (const citation of citations) {
+    if (Object.hasOwn(declared, citation.file)) {
+      continue;
+    }
+    if (citation.ref !== expected) {
+      findings.push({
+        class: "stale-citation",
+        file: citation.file,
+        line: citation.line,
+        ref: citation.ref,
+        message:
+          `${citation.file}:${citation.line} cites ${ACTION}@${citation.ref} as the ` +
+          `reason its cache key matches, but the workflows now use @${expected}. ` +
+          "The citation must name what the code actually does.",
+      });
+    }
+  }
+
+  return findings;
+}
+
+/** Audit every workflow file in `directory`. */
+export async function auditWorkflowDirectory(directory, options = {}) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const declared = options.exemptions ?? DECLARED_EXEMPTIONS;
+  const findings = [];
+  let audited = 0;
+  let exempted = 0;
+
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isFile() || !/\.ya?ml$/.test(entry.name)) {
+      continue;
+    }
+    const text = await readFile(new URL(entry.name, directory), "utf8");
+    const references = collectReferences(entry.name, text);
+    const citations = collectCitations(entry.name, text);
+    if (references.length === 0 && citations.length === 0) {
+      continue;
+    }
+    // Count exempt references separately. Reporting them as "at the expected
+    // ref" would be false -- release.yml is pinned by commit SHA to the MSRV.
+    if (Object.hasOwn(declared, entry.name)) {
+      exempted += references.length;
+    } else {
+      audited += references.length;
+    }
+    findings.push(...auditReferences({ references, citations, ...options }));
+  }
+
+  return { audited, exempted, findings };
+}
+
+async function main() {
+  const directory = new URL("../workflows/", import.meta.url);
+  const { audited, exempted, findings } = await auditWorkflowDirectory(directory);
+
+  if (findings.length > 0) {
+    for (const finding of findings) {
+      console.error(`FAIL -- ${finding.message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const exempt = Object.keys(DECLARED_EXEMPTIONS).join(", ");
+  console.log(
+    `rust toolchain pin: PASS -- ${audited} audited reference(s) at @${EXPECTED_REF}, ` +
+      `${exempted} exempt reference(s) in ${exempt}`,
+  );
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop())) {
+  await main();
+}

--- a/.github/scripts/audit-toolchain-pin.mjs
+++ b/.github/scripts/audit-toolchain-pin.mjs
@@ -6,11 +6,12 @@
 // released 2026-08-18 and the scheduled product gate began failing on a
 // zero-line diff).
 //
-// `release.yml` is deliberately exempt: it pins the MSRV declared by
-// `rust/Cargo.toml`'s `rust-version`, not the development toolchain, and it
-// pins the action by commit SHA rather than by version branch. Its exemption is
-// declared here by exact path so that renaming or removing that workflow is a
-// visible change rather than a silent widening.
+// `release.yml` is held to a different contract rather than skipped: it builds
+// the release artifact at the MSRV declared by `rust/Cargo.toml`'s
+// `rust-version`, pinned by action commit SHA rather than by version branch, so
+// it is audited against that instead of against `EXPECTED_REF`. It is named by
+// exact path, so renaming or removing that workflow is a visible change rather
+// than a silent widening.
 
 import { readdir, readFile } from "node:fs/promises";
 
@@ -18,13 +19,95 @@ export const ACTION = "dtolnay/rust-toolchain";
 
 export const EXPECTED_REF = "1.98.0";
 
-// Exempt path => the reason it is exempt. An entry here is a declared decision,
-// not a wildcard: a path not listed is audited.
+// Paths held to the MSRV contract instead of the development-toolchain pin.
+//
+// This is deliberately NOT a skip list. Review probed the earlier version by
+// flipping `release.yml` to `@stable` and the audit reported nothing, which made
+// "exempt" mean "anything goes here" -- so the MSRV guarantee could have been
+// dropped silently, which is the same class of drift this audit exists to catch,
+// just on a different axis. An entry here now means: audited against a different
+// contract, stated below and enforced by `auditMsrvReference`.
 export const DECLARED_EXEMPTIONS = Object.freeze({
   "release.yml":
-    "pins the MSRV from rust/Cargo.toml's rust-version, by action commit SHA, " +
-    "not the development toolchain",
+    "builds the release artifact at the MSRV declared by rust/Cargo.toml's " +
+    "rust-version, pinned by action commit SHA rather than by version branch",
 });
+
+/** A 40-character git commit SHA, the only ref form that pins action code. */
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+
+/**
+ * The MSRV declared by `rust/Cargo.toml`'s `rust-version`, or null when the
+ * declaration cannot be found. A null is a finding, not a pass: the contract
+ * cannot be checked against a value that is missing.
+ */
+export function declaredMsrv(cargoTomlText) {
+  const match = /^\s*rust-version\s*=\s*"([^"]+)"/m.exec(cargoTomlText);
+  return match ? match[1] : null;
+}
+
+/**
+ * Audit a path held to the MSRV contract rather than to `EXPECTED_REF`.
+ *
+ * Two things must hold, and both were previously unchecked:
+ *   - the action ref is a commit SHA, so the action code itself is pinned;
+ *   - the `toolchain:` input names the declared MSRV, so the release artifact
+ *     is built at the version the crates claim to support.
+ */
+export function auditMsrvReference({ file, line, ref, toolchainInput, msrv }) {
+  const findings = [];
+  if (!COMMIT_SHA.test(ref)) {
+    findings.push({
+      class: "msrv-ref-not-pinned",
+      file,
+      line,
+      ref,
+      message:
+        `${file}:${line} uses ${ACTION}@${ref}, but this workflow builds the ` +
+        "release artifact and must pin the action by 40-character commit SHA. " +
+        "A branch or channel here would let the release toolchain change " +
+        "without a reviewed diff.",
+    });
+  }
+  if (msrv === null) {
+    findings.push({
+      class: "msrv-undeclared",
+      file,
+      line,
+      ref,
+      message:
+        `${file}:${line} is held to the MSRV contract, but rust/Cargo.toml ` +
+        "declares no rust-version to check it against.",
+    });
+  } else if (toolchainInput === null) {
+    findings.push({
+      class: "msrv-toolchain-missing",
+      file,
+      line,
+      ref,
+      message:
+        `${file}:${line} must pass an explicit \`toolchain:\` input naming the ` +
+        `declared MSRV ${msrv}; without it the action's own default applies.`,
+    });
+  } else if (
+    toolchainInput !== msrv &&
+    !toolchainInput.startsWith(`${msrv}.`)
+  ) {
+    // `rust-version = "1.88"` is satisfied by `toolchain: 1.88.0`; it is not
+    // satisfied by 1.89.0 or by a channel name.
+    findings.push({
+      class: "msrv-disagreement",
+      file,
+      line,
+      ref,
+      message:
+        `${file}:${line} passes \`toolchain: ${toolchainInput}\` but ` +
+        `rust/Cargo.toml declares rust-version "${msrv}". The release artifact ` +
+        "must be built at the version the crates claim to support.",
+    });
+  }
+  return findings;
+}
 
 // A `uses:` key, with or without the list dash, and tolerating whitespace
 // before the colon.
@@ -85,6 +168,31 @@ export function collectReferences(fileName, text) {
 }
 
 /**
+ * The `toolchain:` input belonging to each toolchain-action `uses:` line, keyed
+ * by that line's one-based number. Read from the `with:` block that follows,
+ * stopping at the next `- ` list item so a later step's input cannot be
+ * attributed to this one.
+ */
+export function collectToolchainInputs(text, references) {
+  const lines = text.split("\n");
+  const inputs = new Map();
+  for (const reference of references) {
+    for (let i = reference.line; i < lines.length; i += 1) {
+      const line = lines[i];
+      if (/^\s*-\s/.test(line)) {
+        break;
+      }
+      const match = /^\s*toolchain\s*:\s*(.+?)\s*$/.exec(line);
+      if (match) {
+        inputs.set(reference.line, unquote(match[1].replace(/\s+#.*$/, "").trim()));
+        break;
+      }
+    }
+  }
+  return inputs;
+}
+
+/**
  * Every comment line that names the action with an explicit `@ref`. These are
  * cited justifications -- `merge-readiness.yml` explains its restore-only cache
  * key by naming the action and ref that produce the matching key -- so a ref
@@ -111,13 +219,34 @@ export function collectCitations(fileName, text) {
  * Returns a finding per disagreement. An empty array means the workflow agrees
  * with `EXPECTED_REF`, or is a declared exemption.
  */
-export function auditReferences({ references, citations, expectedRef, exemptions }) {
+export function auditReferences({
+  references,
+  citations,
+  expectedRef,
+  exemptions,
+  msrv,
+  toolchainInputs,
+}) {
   const findings = [];
   const declared = exemptions ?? DECLARED_EXEMPTIONS;
   const expected = expectedRef ?? EXPECTED_REF;
+  const inputs = toolchainInputs ?? new Map();
 
   for (const reference of references) {
     if (Object.hasOwn(declared, reference.file)) {
+      // Held to the MSRV contract, not skipped. `msrv` is only undefined when a
+      // caller audits references in isolation; a real run always supplies it.
+      if (msrv !== undefined) {
+        findings.push(
+          ...auditMsrvReference({
+            file: reference.file,
+            line: reference.line,
+            ref: reference.ref,
+            toolchainInput: inputs.get(reference.line) ?? null,
+            msrv,
+          }),
+        );
+      }
       continue;
     }
     // A ref computed at run time cannot be statically shown to be pinned, and
@@ -205,6 +334,7 @@ export async function auditWorkflowDirectory(directory, options = {}) {
     if (references.length === 0 && citations.length === 0) {
       continue;
     }
+    const toolchainInputs = collectToolchainInputs(text, references);
     // Count exempt references separately. Reporting them as "at the expected
     // ref" would be false -- release.yml is pinned by commit SHA to the MSRV.
     if (Object.hasOwn(declared, entry.name)) {
@@ -212,7 +342,9 @@ export async function auditWorkflowDirectory(directory, options = {}) {
     } else {
       audited += references.length;
     }
-    findings.push(...auditReferences({ references, citations, ...options }));
+    findings.push(
+      ...auditReferences({ references, citations, toolchainInputs, ...options }),
+    );
   }
 
   return { audited, exempted, findings };
@@ -230,7 +362,15 @@ async function main() {
   let exempted;
   let findings;
   try {
-    ({ audited, exempted, findings } = await auditWorkflowDirectory(directory));
+    // The MSRV contract needs the declaration to check against, so read it here
+    // rather than letting a missing file quietly turn that check off.
+    const cargoToml = await readFile(
+      new URL("../../rust/Cargo.toml", import.meta.url),
+      "utf8",
+    );
+    ({ audited, exempted, findings } = await auditWorkflowDirectory(directory, {
+      msrv: declaredMsrv(cargoToml),
+    }));
   } catch (error) {
     // An unreadable or missing workflows directory must fail, not be reported as
     // a clean audit.
@@ -261,10 +401,10 @@ async function main() {
     return;
   }
 
-  const exempt = Object.keys(DECLARED_EXEMPTIONS).join(", ");
+  const msrvPaths = Object.keys(DECLARED_EXEMPTIONS).join(", ");
   console.log(
-    `rust toolchain pin: PASS -- ${audited} audited reference(s) at @${EXPECTED_REF}, ` +
-      `${exempted} exempt reference(s) in ${exempt}`,
+    `rust toolchain pin: PASS -- ${audited} reference(s) at @${EXPECTED_REF}, ` +
+      `${exempted} reference(s) held to the MSRV contract in ${msrvPaths}`,
   );
 }
 

--- a/.github/scripts/audit-toolchain-pin.mjs
+++ b/.github/scripts/audit-toolchain-pin.mjs
@@ -206,14 +206,45 @@ export async function auditWorkflowDirectory(directory, options = {}) {
   return { audited, exempted, findings };
 }
 
+// The repository must always contain at least this many audited references.
+// Set from the measured count, deliberately as a floor rather than an equality:
+// adding a workflow that installs the toolchain is normal, removing every one of
+// them is not.
+export const MINIMUM_AUDITED_REFERENCES = 11;
+
 async function main() {
   const directory = new URL("../workflows/", import.meta.url);
-  const { audited, exempted, findings } = await auditWorkflowDirectory(directory);
+  let audited;
+  let exempted;
+  let findings;
+  try {
+    ({ audited, exempted, findings } = await auditWorkflowDirectory(directory));
+  } catch (error) {
+    // An unreadable or missing workflows directory must fail, not be reported as
+    // a clean audit.
+    console.error(
+      `FAIL -- could not read the workflow directory: ${error.message}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
 
   if (findings.length > 0) {
     for (const finding of findings) {
       console.error(`FAIL -- ${finding.message}`);
     }
+    process.exitCode = 1;
+    return;
+  }
+
+  // A pin audit that audited nothing and reported PASS would be the exact
+  // defect it exists to prevent: confidence with no evidence behind it.
+  if (audited < MINIMUM_AUDITED_REFERENCES) {
+    console.error(
+      `FAIL -- audited only ${audited} toolchain reference(s); expected at least ` +
+        `${MINIMUM_AUDITED_REFERENCES}. Either the workflows moved, or this audit ` +
+        "stopped seeing them -- both mean it is no longer enforcing the pin.",
+    );
     process.exitCode = 1;
     return;
   }

--- a/.github/scripts/audit-toolchain-pin.mjs
+++ b/.github/scripts/audit-toolchain-pin.mjs
@@ -169,18 +169,46 @@ export function collectReferences(fileName, text) {
 
 /**
  * The `toolchain:` input belonging to each toolchain-action `uses:` line, keyed
- * by that line's one-based number. Read from the `with:` block that follows,
- * stopping at the next `- ` list item so a later step's input cannot be
- * attributed to this one.
+ * by that line's one-based number.
+ *
+ * The key must sit inside the step's `with:` mapping. Review found that an
+ * earlier version accepted
+ *
+ *     - uses: dtolnay/rust-toolchain@<sha>
+ *       env:
+ *         toolchain: 1.88.0
+ *
+ * because it matched any later `toolchain:` line. The action receives no input
+ * there, so the audit was satisfied by something that does nothing: `env:` and
+ * `with:` are different mappings and only `with:` supplies action inputs.
+ *
+ * Scanning stops at the next `- ` list item, so a following step's `with:`
+ * cannot be attributed to this one.
  */
 export function collectToolchainInputs(text, references) {
   const lines = text.split("\n");
   const inputs = new Map();
   for (const reference of references) {
+    let withIndent = null;
     for (let i = reference.line; i < lines.length; i += 1) {
       const line = lines[i];
       if (/^\s*-\s/.test(line)) {
         break;
+      }
+      if (line.trim() === "" || /^\s*#/.test(line)) {
+        continue;
+      }
+      const indent = line.length - line.trimStart().length;
+      if (withIndent !== null && indent <= withIndent) {
+        // Dedented back out of the `with:` mapping without finding the key.
+        withIndent = null;
+      }
+      if (/^\s*with\s*:\s*$/.test(line)) {
+        withIndent = indent;
+        continue;
+      }
+      if (withIndent === null) {
+        continue;
       }
       const match = /^\s*toolchain\s*:\s*(.+?)\s*$/.exec(line);
       if (match) {
@@ -234,19 +262,23 @@ export function auditReferences({
 
   for (const reference of references) {
     if (Object.hasOwn(declared, reference.file)) {
-      // Held to the MSRV contract, not skipped. `msrv` is only undefined when a
-      // caller audits references in isolation; a real run always supplies it.
-      if (msrv !== undefined) {
-        findings.push(
-          ...auditMsrvReference({
-            file: reference.file,
-            line: reference.line,
-            ref: reference.ref,
-            toolchainInput: inputs.get(reference.line) ?? null,
-            msrv,
-          }),
-        );
-      }
+      // Held to the MSRV contract, not skipped.
+      //
+      // An earlier version skipped this whole branch when `msrv` was undefined.
+      // Review showed the consequence: the repository-level suite scanned the
+      // workflows without supplying it, so the required lane never ran the MSRV
+      // contract at all and a floating `release.yml` passed. Omitting the MSRV
+      // is now a finding rather than a silent pass -- a caller that forgets it
+      // gets told, instead of getting a green audit of nothing.
+      findings.push(
+        ...auditMsrvReference({
+          file: reference.file,
+          line: reference.line,
+          ref: reference.ref,
+          toolchainInput: inputs.get(reference.line) ?? null,
+          msrv: msrv === undefined ? null : msrv,
+        }),
+      );
       continue;
     }
     // A ref computed at run time cannot be statically shown to be pinned, and

--- a/.github/scripts/audit-toolchain-pin.mjs
+++ b/.github/scripts/audit-toolchain-pin.mjs
@@ -188,30 +188,52 @@ export function collectReferences(fileName, text) {
 export function collectToolchainInputs(text, references) {
   const lines = text.split("\n");
   const inputs = new Map();
+
   for (const reference of references) {
+    // A step is a list item, so scan from its `- ` line to the next one. The
+    // `uses:` key may appear anywhere inside it, including after `with:`.
+    let start = reference.line - 1;
+    while (start > 0 && !/^\s*-\s/.test(lines[start])) {
+      start -= 1;
+    }
+    let end = reference.line;
+    while (end < lines.length && !/^\s*-\s/.test(lines[end])) {
+      end += 1;
+    }
+
     let withIndent = null;
-    for (let i = reference.line; i < lines.length; i += 1) {
-      const line = lines[i];
-      if (/^\s*-\s/.test(line)) {
-        break;
-      }
+    for (let i = start; i < end; i += 1) {
+      // Normalise the leading dash so `- with:` is seen at its key's column.
+      const line = lines[i].replace(/^(\s*)-(\s)/, "$1 $2");
       if (line.trim() === "" || /^\s*#/.test(line)) {
         continue;
       }
       const indent = line.length - line.trimStart().length;
-      if (withIndent !== null && indent <= withIndent) {
-        // Dedented back out of the `with:` mapping without finding the key.
-        withIndent = null;
+
+      // Flow style: `with: {toolchain: 1.88.0}` is one line and valid YAML.
+      const flow = /^\s*with\s*:\s*\{(.*)\}\s*$/.exec(line);
+      if (flow) {
+        const entry = new RegExp("(?:^|,)\\s*toolchain\\s*:\\s*([^,}]+)").exec(flow[1]);
+        if (entry) {
+          inputs.set(reference.line, unquote(entry[1].trim()));
+        }
+        continue;
       }
+
       if (/^\s*with\s*:\s*$/.test(line)) {
         withIndent = indent;
         continue;
       }
+      if (withIndent !== null && indent <= withIndent) {
+        withIndent = null;
+      }
       if (withIndent === null) {
         continue;
       }
+      // Only a DIRECT child of `with:` is an action input. A key nested deeper
+      // belongs to some other input's value, so it must not count.
       const match = /^\s*toolchain\s*:\s*(.+?)\s*$/.exec(line);
-      if (match) {
+      if (match && indent === withIndent + 2) {
         inputs.set(reference.line, unquote(match[1].replace(/\s+#.*$/, "").trim()));
         break;
       }

--- a/.github/scripts/audit-toolchain-pin.mjs
+++ b/.github/scripts/audit-toolchain-pin.mjs
@@ -26,11 +26,23 @@ export const DECLARED_EXEMPTIONS = Object.freeze({
     "not the development toolchain",
 });
 
-// A `uses:` key, with or without the list dash. The dash is optional because
-// `- name:` followed by a sibling `uses:` is ordinary YAML and requiring the
-// dash made every step written that way invisible to this audit -- measured,
-// not hypothesised.
-const USES_KEY_PATTERN = /^\s*(?:-\s*)?uses:\s*(.+?)\s*$/;
+// A `uses:` key, with or without the list dash, and tolerating whitespace
+// before the colon.
+//
+// Every relaxation here was found by probing, not by imagination:
+//   - the dash is optional because `- name:` followed by a sibling `uses:` is
+//     ordinary YAML, and requiring the dash made every step written that way
+//     invisible;
+//   - whitespace may precede the colon because `uses : action@ref` is valid
+//     YAML whose key is `uses` -- confirmed with a YAML parser, not assumed.
+//
+// This is a line scan rather than a YAML parse, which is why each of those was
+// a hole. Keep that in mind before adding a fifth relaxation: at some point the
+// honest fix is to parse the document. It is a line scan today only because the
+// required lane is stdlib/Node-only and adding a YAML dependency to it is a
+// separate decision (see .github/workflows/cache-budget-audit-wiring.yml for
+// why PyYAML lives outside that lane).
+const USES_KEY_PATTERN = /^\s*(?:-\s*)?uses\s*:\s*(.+?)\s*$/;
 
 /** Strip one layer of matching YAML quotes, if present. */
 function unquote(value) {

--- a/.github/scripts/audit-toolchain-pin.mjs
+++ b/.github/scripts/audit-toolchain-pin.mjs
@@ -89,6 +89,24 @@ export function auditMsrvReference({ file, line, ref, toolchainInput, msrv }) {
         `${file}:${line} must pass an explicit \`toolchain:\` input naming the ` +
         `declared MSRV ${msrv}; without it the action's own default applies.`,
     });
+  } else if (toolchainInput.startsWith("*")) {
+    // A YAML alias cannot be resolved by a line scan, and guessing would be
+    // worse than saying so. Review probed `toolchain: *msrv` against an anchor
+    // defined elsewhere in the file; the earlier version reported
+    // `msrv-disagreement`, which named the wrong problem. Fail closed, but with
+    // a diagnostic that states what is actually unproven. Resolving aliases
+    // needs a real YAML parse -- tracked by #856.
+    findings.push({
+      class: "msrv-alias-unresolved",
+      file,
+      line,
+      ref,
+      message:
+        `${file}:${line} passes \`toolchain: ${toolchainInput}\`, a YAML alias. ` +
+        "This audit is a line scan and cannot resolve it, so it cannot show the " +
+        `release toolchain equals rust-version "${msrv}". Write the version ` +
+        "literally, or resolve aliases (see issue #856).",
+    });
   } else if (
     toolchainInput !== msrv &&
     !toolchainInput.startsWith(`${msrv}.`)
@@ -202,25 +220,50 @@ export function collectToolchainInputs(text, references) {
     }
 
     let withIndent = null;
+    let flowDepth = 0;
+    let flowText = "";
+
     for (let i = start; i < end; i += 1) {
       // Normalise the leading dash so `- with:` is seen at its key's column.
-      const line = lines[i].replace(/^(\s*)-(\s)/, "$1 $2");
-      if (line.trim() === "" || /^\s*#/.test(line)) {
-        continue;
-      }
-      const indent = line.length - line.trimStart().length;
+      const raw = lines[i].replace(/^(\s*)-(\s)/, "$1 $2");
 
-      // Flow style: `with: {toolchain: 1.88.0}` is one line and valid YAML.
-      const flow = /^\s*with\s*:\s*\{(.*)\}\s*$/.exec(line);
-      if (flow) {
-        const entry = new RegExp("(?:^|,)\\s*toolchain\\s*:\\s*([^,}]+)").exec(flow[1]);
-        if (entry) {
-          inputs.set(reference.line, unquote(entry[1].trim()));
+      // A flow mapping may span lines, so accumulate until the braces balance.
+      if (flowDepth > 0) {
+        flowText += " " + raw.trim();
+        flowDepth += (raw.match(/\{/g) ?? []).length;
+        flowDepth -= (raw.match(/\}/g) ?? []).length;
+        if (flowDepth === 0) {
+          const entry = /(?:^|,|\{)\s*toolchain\s*:\s*([^,}]+)/.exec(flowText);
+          if (entry) {
+            inputs.set(reference.line, unquote(entry[1].trim()));
+            break;
+          }
         }
         continue;
       }
 
-      if (/^\s*with\s*:\s*$/.test(line)) {
+      if (raw.trim() === "" || /^\s*#/.test(raw)) {
+        continue;
+      }
+      const indent = raw.length - raw.trimStart().length;
+
+      const flowStart = /^\s*with\s*:\s*\{/.exec(raw);
+      if (flowStart) {
+        // Drop a trailing `# comment`, which is not part of the mapping.
+        flowText = raw.replace(/\s+#.*$/, "").trim();
+        flowDepth =
+          (flowText.match(/\{/g) ?? []).length - (flowText.match(/\}/g) ?? []).length;
+        if (flowDepth === 0) {
+          const entry = /(?:^|,|\{)\s*toolchain\s*:\s*([^,}]+)/.exec(flowText);
+          if (entry) {
+            inputs.set(reference.line, unquote(entry[1].trim()));
+            break;
+          }
+        }
+        continue;
+      }
+
+      if (/^\s*with\s*:\s*$/.test(raw)) {
         withIndent = indent;
         continue;
       }
@@ -230,16 +273,41 @@ export function collectToolchainInputs(text, references) {
       if (withIndent === null) {
         continue;
       }
-      // Only a DIRECT child of `with:` is an action input. A key nested deeper
-      // belongs to some other input's value, so it must not count.
-      const match = /^\s*toolchain\s*:\s*(.+?)\s*$/.exec(line);
-      if (match && indent === withIndent + 2) {
-        inputs.set(reference.line, unquote(match[1].replace(/\s+#.*$/, "").trim()));
-        break;
+      // A direct child of `with:` is any key indented FURTHER than `with:` but
+      // not nested under another key of it. YAML does not mandate two spaces,
+      // so the first child's indent defines the level for this mapping.
+      const match = /^\s*toolchain\s*:\s*(.+?)\s*$/.exec(raw);
+      if (match) {
+        const childIndent = firstChildIndent(lines, i, withIndent);
+        if (indent === childIndent) {
+          inputs.set(reference.line, unquote(match[1].replace(/\s+#.*$/, "").trim()));
+          break;
+        }
       }
     }
   }
   return inputs;
+}
+
+/**
+ * The indentation of the first key directly under a `with:` at `withIndent`,
+ * searching back from `from`. GitHub does not require two-space indentation, so
+ * hardcoding `withIndent + 2` falsely rejected a mapping indented by four.
+ */
+function firstChildIndent(lines, from, withIndent) {
+  let candidate = null;
+  for (let i = from; i >= 0; i -= 1) {
+    const raw = lines[i].replace(/^(\s*)-(\s)/, "$1 $2");
+    if (raw.trim() === "" || /^\s*#/.test(raw)) {
+      continue;
+    }
+    const indent = raw.length - raw.trimStart().length;
+    if (indent <= withIndent) {
+      break;
+    }
+    candidate = indent;
+  }
+  return candidate;
 }
 
 /**
@@ -410,6 +478,14 @@ export async function auditWorkflowDirectory(directory, options = {}) {
 // them is not.
 export const MINIMUM_AUDITED_REFERENCES = 11;
 
+// Each declared MSRV path must actually contain a toolchain reference. Review
+// deleted release.yml's toolchain step entirely and the CLI reported
+// `PASS -- ... 0 reference(s) held to the MSRV contract`: a declared contract
+// with nothing to apply it to is the same vacuous pass the audited floor exists
+// to prevent. The required lane already caught it, because its test asserts the
+// count; the CLI did not.
+export const MINIMUM_MSRV_REFERENCES = Object.keys(DECLARED_EXEMPTIONS).length;
+
 async function main() {
   const directory = new URL("../workflows/", import.meta.url);
   let audited;
@@ -450,6 +526,17 @@ async function main() {
       `FAIL -- audited only ${audited} toolchain reference(s); expected at least ` +
         `${MINIMUM_AUDITED_REFERENCES}. Either the workflows moved, or this audit ` +
         "stopped seeing them -- both mean it is no longer enforcing the pin.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (exempted < MINIMUM_MSRV_REFERENCES) {
+    console.error(
+      `FAIL -- ${exempted} reference(s) held to the MSRV contract; expected ` +
+        `${MINIMUM_MSRV_REFERENCES}, one per declared path ` +
+        `(${Object.keys(DECLARED_EXEMPTIONS).join(", ")}). A declared contract ` +
+        "with no reference to apply it to enforces nothing.",
     );
     process.exitCode = 1;
     return;

--- a/.github/scripts/audit-toolchain-pin.mjs
+++ b/.github/scripts/audit-toolchain-pin.mjs
@@ -26,22 +26,48 @@ export const DECLARED_EXEMPTIONS = Object.freeze({
     "not the development toolchain",
 });
 
-const USES_PATTERN = new RegExp(
-  `^\\s*-\\s*uses:\\s*${ACTION.replace("/", "\\/")}@(\\S+)\\s*$`,
-);
+// A `uses:` key, with or without the list dash. The dash is optional because
+// `- name:` followed by a sibling `uses:` is ordinary YAML and requiring the
+// dash made every step written that way invisible to this audit -- measured,
+// not hypothesised.
+const USES_KEY_PATTERN = /^\s*(?:-\s*)?uses:\s*(.+?)\s*$/;
+
+/** Strip one layer of matching YAML quotes, if present. */
+function unquote(value) {
+  const match = /^(['"])(.*)\1$/.exec(value);
+  return match ? match[2] : value;
+}
 
 /**
  * Every `uses:` reference to the toolchain action in one workflow's text.
+ *
+ * The value is unquoted first: `uses: "dtolnay/rust-toolchain@stable"` is valid
+ * YAML and equivalent to the bare form, so a pattern anchored on the bare form
+ * alone would let a quoted floating channel through.
+ *
  * Comments are not `uses:` lines and are not collected here; `auditReferences`
  * checks them separately.
  */
 export function collectReferences(fileName, text) {
   const references = [];
+  const prefix = `${ACTION}@`;
   text.split("\n").forEach((line, index) => {
-    const match = USES_PATTERN.exec(line);
-    if (match) {
-      references.push({ file: fileName, line: index + 1, ref: match[1] });
+    const match = USES_KEY_PATTERN.exec(line);
+    if (!match) {
+      return;
     }
+    // A trailing `# comment` on the same line is not part of the value. Only
+    // strip it when whitespace precedes the `#`, so a `#` inside the ref is
+    // preserved rather than silently truncating the ref we are about to judge.
+    const value = unquote(match[1].replace(/\s+#.*$/, "").trim());
+    if (!value.startsWith(prefix)) {
+      return;
+    }
+    references.push({
+      file: fileName,
+      line: index + 1,
+      ref: value.slice(prefix.length),
+    });
   });
   return references;
 }
@@ -80,6 +106,24 @@ export function auditReferences({ references, citations, expectedRef, exemptions
 
   for (const reference of references) {
     if (Object.hasOwn(declared, reference.file)) {
+      continue;
+    }
+    // A ref computed at run time cannot be statically shown to be pinned, and
+    // `@${{ matrix.toolchain }}` with `stable` in the matrix reintroduces
+    // exactly the drift this audit exists to prevent. Fail closed rather than
+    // pass something unverifiable.
+    if (reference.ref.includes("${{")) {
+      findings.push({
+        class: "expression-ref",
+        file: reference.file,
+        line: reference.line,
+        ref: reference.ref,
+        message:
+          `${reference.file}:${reference.line} resolves ${ACTION} through the ` +
+          `expression \`${reference.ref}\`. A run-time ref cannot be shown to be ` +
+          `pinned, and a matrix containing \`stable\` would reintroduce the drift ` +
+          `this audit prevents; write @${expected} literally.`,
+      });
       continue;
     }
     if (reference.ref === "stable" || reference.ref === "nightly" || reference.ref === "beta") {

--- a/.github/scripts/audit-toolchain-pin.test.mjs
+++ b/.github/scripts/audit-toolchain-pin.test.mjs
@@ -182,6 +182,21 @@ test("a uses: sibling of - name: is collected without the list dash", () => {
   ]);
 });
 
+test("whitespace before the colon does not hide the reference", () => {
+  // `uses : action@ref` is valid YAML whose key is `uses` -- confirmed with a
+  // YAML parser. An earlier revision required `uses:` exactly and missed it.
+  const text = `      - uses : ${ACTION}@stable`;
+  assert.deepEqual(collectReferences("probe.yml", text), [
+    { file: "probe.yml", line: 1, ref: "stable" },
+  ]);
+  const findings = auditReferences({
+    references: collectReferences("probe.yml", text),
+    citations: [],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "floating-channel");
+});
+
 test("an expression ref is rejected because it cannot be shown to be pinned", () => {
   const text = `      - uses: ${ACTION}@\${{ matrix.toolchain }}`;
   const references = collectReferences("probe.yml", text);

--- a/.github/scripts/audit-toolchain-pin.test.mjs
+++ b/.github/scripts/audit-toolchain-pin.test.mjs
@@ -12,10 +12,13 @@ import {
   DECLARED_EXEMPTIONS,
   EXPECTED_REF,
   MINIMUM_AUDITED_REFERENCES,
+  auditMsrvReference,
   auditReferences,
   auditWorkflowDirectory,
   collectCitations,
   collectReferences,
+  collectToolchainInputs,
+  declaredMsrv,
 } from "./audit-toolchain-pin.mjs";
 
 const WORKFLOWS = new URL("../workflows/", import.meta.url);
@@ -36,15 +39,97 @@ test("the committed workflows agree on one pinned toolchain", async () => {
   assert.equal(exempted, 1, `expected 1 exempt reference, saw ${exempted}`);
 });
 
-test("the declared exemption is release.yml and it is not audited", async () => {
+// --- release.yml is held to the MSRV contract, not skipped --------------------
+//
+// Review probed the earlier version by flipping release.yml to @stable and the
+// audit reported nothing: "exempt" meant "anything goes here", so the MSRV
+// guarantee could have been dropped silently. Each mutation below was measured
+// against the replacement.
+
+const RELEASE_SHA = "4cda84d5c5c54efe2404f9d843567869ab1699d4";
+
+test("release.yml as committed satisfies the MSRV contract", () => {
   assert.deepEqual(Object.keys(DECLARED_EXEMPTIONS), ["release.yml"]);
-  const findings = auditReferences({
-    references: [
-      { file: "release.yml", line: 54, ref: "4cda84d5c5c54efe2404f9d843567869ab1699d4" },
-    ],
-    citations: [],
+  assert.deepEqual(
+    auditMsrvReference({
+      file: "release.yml",
+      line: 54,
+      ref: RELEASE_SHA,
+      toolchainInput: "1.88.0",
+      msrv: "1.88",
+    }),
+    [],
+    "rust-version 1.88 must be satisfied by toolchain 1.88.0",
+  );
+});
+
+test("flipping release.yml to a floating channel is rejected", () => {
+  const findings = auditMsrvReference({
+    file: "release.yml",
+    line: 54,
+    ref: "stable",
+    toolchainInput: "1.88.0",
+    msrv: "1.88",
   });
-  assert.deepEqual(findings, []);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "msrv-ref-not-pinned");
+  assert.match(findings[0].message, /40-character commit SHA/);
+});
+
+test("dropping the toolchain input from release.yml is rejected", () => {
+  const findings = auditMsrvReference({
+    file: "release.yml",
+    line: 54,
+    ref: RELEASE_SHA,
+    toolchainInput: null,
+    msrv: "1.88",
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "msrv-toolchain-missing");
+});
+
+test("a release toolchain that drifts off the declared MSRV is rejected", () => {
+  const findings = auditMsrvReference({
+    file: "release.yml",
+    line: 54,
+    ref: RELEASE_SHA,
+    toolchainInput: "1.89.0",
+    msrv: "1.88",
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "msrv-disagreement");
+});
+
+test("a missing rust-version declaration is a finding, not a pass", () => {
+  const findings = auditMsrvReference({
+    file: "release.yml",
+    line: 54,
+    ref: RELEASE_SHA,
+    toolchainInput: "1.88.0",
+    msrv: null,
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "msrv-undeclared");
+});
+
+test("declaredMsrv reads rust-version and reports absence as null", () => {
+  assert.equal(declaredMsrv('[workspace.package]\nrust-version = "1.88"\n'), "1.88");
+  assert.equal(declaredMsrv("[workspace.package]\nedition = \"2021\"\n"), null);
+});
+
+test("collectToolchainInputs attributes the input to its own step", () => {
+  const text = [
+    `      - uses: ${ACTION}@${RELEASE_SHA}`,
+    "        with:",
+    "          toolchain: 1.88.0",
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          toolchain: 9.9.9",
+  ].join("\n");
+  const references = collectReferences("release.yml", text);
+  assert.equal(references.length, 1);
+  const inputs = collectToolchainInputs(text, references);
+  assert.equal(inputs.get(1), "1.88.0", "must not read the next step's input");
 });
 
 test("an unrelated workflow with no toolchain reference is not a finding", () => {

--- a/.github/scripts/audit-toolchain-pin.test.mjs
+++ b/.github/scripts/audit-toolchain-pin.test.mjs
@@ -110,6 +110,63 @@ test("an undeclared workflow cannot inherit release.yml's exemption", () => {
   assert.equal(findings[0].class, "floating-channel");
 });
 
+// --- escape routes that an earlier revision of this audit did not see ----------
+//
+// Each of these was measured against the first implementation and passed
+// silently. A pin audit with holes is worse than no audit, because it creates
+// confidence the pin does not have. Do not relax collectReferences without
+// re-running these.
+
+test("a quoted uses value is collected, not skipped", () => {
+  const text = `      - uses: "${ACTION}@stable"`;
+  assert.deepEqual(collectReferences("probe.yml", text), [
+    { file: "probe.yml", line: 1, ref: "stable" },
+  ]);
+  const findings = auditReferences({
+    references: collectReferences("probe.yml", text),
+    citations: [],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "floating-channel");
+});
+
+test("a single-quoted uses value is collected too", () => {
+  const text = `      - uses: '${ACTION}@stable'`;
+  assert.deepEqual(collectReferences("probe.yml", text), [
+    { file: "probe.yml", line: 1, ref: "stable" },
+  ]);
+});
+
+test("a uses: sibling of - name: is collected without the list dash", () => {
+  const text = ["      - name: install the toolchain", `        uses: ${ACTION}@stable`].join(
+    "\n",
+  );
+  assert.deepEqual(collectReferences("probe.yml", text), [
+    { file: "probe.yml", line: 2, ref: "stable" },
+  ]);
+});
+
+test("an expression ref is rejected because it cannot be shown to be pinned", () => {
+  const text = `      - uses: ${ACTION}@\${{ matrix.toolchain }}`;
+  const references = collectReferences("probe.yml", text);
+  assert.equal(references.length, 1);
+  const findings = auditReferences({ references, citations: [] });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "expression-ref");
+  assert.match(findings[0].message, /cannot be shown to be\s+pinned/);
+});
+
+test("a trailing comment is not treated as part of the ref", () => {
+  const text = `      - uses: ${ACTION}@1.98.0  # keep in sync with EXPECTED_REF`;
+  assert.deepEqual(collectReferences("probe.yml", text), [
+    { file: "probe.yml", line: 1, ref: "1.98.0" },
+  ]);
+  assert.deepEqual(
+    auditReferences({ references: collectReferences("probe.yml", text), citations: [] }),
+    [],
+  );
+});
+
 // --- the collectors themselves -------------------------------------------------
 
 test("collectReferences reads the ref and the one-based line", () => {

--- a/.github/scripts/audit-toolchain-pin.test.mjs
+++ b/.github/scripts/audit-toolchain-pin.test.mjs
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 
 import {
   ACTION,
   DECLARED_EXEMPTIONS,
   EXPECTED_REF,
+  MINIMUM_AUDITED_REFERENCES,
   auditReferences,
   auditWorkflowDirectory,
   collectCitations,
@@ -108,6 +113,37 @@ test("an undeclared workflow cannot inherit release.yml's exemption", () => {
   });
   assert.equal(findings.length, 1);
   assert.equal(findings[0].class, "floating-channel");
+});
+
+// --- the audit must not pass vacuously ----------------------------------------
+//
+// Review found the CLI reporting `PASS -- 0 audited reference(s)` against a
+// workflow directory with no toolchain references. An audit that audited
+// nothing and reported success is the exact defect this file exists to prevent,
+// so the floor is enforced in the script and pinned here.
+
+test("MINIMUM_AUDITED_REFERENCES matches what the repository actually has", async () => {
+  const { audited } = await auditWorkflowDirectory(WORKFLOWS);
+  assert.equal(audited, MINIMUM_AUDITED_REFERENCES);
+});
+
+test("an empty workflow directory audits nothing, which the CLI must reject", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "toolchain-pin-empty-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+
+  const { audited, exempted, findings } = await auditWorkflowDirectory(
+    pathToFileURL(`${directory}/`),
+  );
+  // The pure function has nothing to complain about -- there are no references
+  // to disagree with. That is precisely why the count, not the findings list,
+  // has to be what fails.
+  assert.deepEqual(findings, []);
+  assert.equal(audited, 0);
+  assert.equal(exempted, 0);
+  assert.ok(
+    audited < MINIMUM_AUDITED_REFERENCES,
+    "an empty directory must fall below the floor",
+  );
 });
 
 // --- escape routes that an earlier revision of this audit did not see ----------

--- a/.github/scripts/audit-toolchain-pin.test.mjs
+++ b/.github/scripts/audit-toolchain-pin.test.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -22,6 +22,13 @@ import {
 } from "./audit-toolchain-pin.mjs";
 
 const WORKFLOWS = new URL("../workflows/", import.meta.url);
+const CARGO_TOML = new URL("../../rust/Cargo.toml", import.meta.url);
+
+// The suite must audit the repository the way the CLI does, MSRV included.
+// Review found that scanning without the MSRV made the required lane skip the
+// release contract entirely, so a floating release.yml passed the gate while
+// only the standalone CLI caught it. Read the real declaration here.
+const REPO_MSRV = declaredMsrv(await readFile(CARGO_TOML, "utf8"));
 
 function usesLine(ref) {
   return `      - uses: ${ACTION}@${ref}`;
@@ -29,8 +36,15 @@ function usesLine(ref) {
 
 // --- accepting: the repository as committed ------------------------------------
 
+test("the declared MSRV is readable, so the contract below is not vacuous", () => {
+  assert.ok(REPO_MSRV, "rust/Cargo.toml must declare a rust-version");
+});
+
 test("the committed workflows agree on one pinned toolchain", async () => {
-  const { audited, exempted, findings } = await auditWorkflowDirectory(WORKFLOWS);
+  // Passing the MSRV is what makes this exercise the release contract too.
+  const { audited, exempted, findings } = await auditWorkflowDirectory(WORKFLOWS, {
+    msrv: REPO_MSRV,
+  });
   assert.deepEqual(findings, [], JSON.stringify(findings, null, 2));
   // A pin audit that audited nothing would pass vacuously. Assert it saw work,
   // and that the exempt reference is counted separately rather than reported as
@@ -107,6 +121,54 @@ test("a missing rust-version declaration is a finding, not a pass", () => {
     ref: RELEASE_SHA,
     toolchainInput: "1.88.0",
     msrv: null,
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "msrv-undeclared");
+});
+
+test("an env: toolchain is not an action input and must not satisfy the contract", () => {
+  // Review probed this and it passed BOTH the suite and the standalone CLI:
+  // the action receives no input from `env:`, so the audit was satisfied by
+  // something that does nothing.
+  const text = [
+    `      - uses: ${ACTION}@${RELEASE_SHA}`,
+    "        env:",
+    "          toolchain: 1.88.0",
+  ].join("\n");
+  const references = collectReferences("release.yml", text);
+  assert.equal(references.length, 1);
+  const inputs = collectToolchainInputs(text, references);
+  assert.equal(inputs.get(1), undefined, "env: must not be read as an input");
+
+  const findings = auditReferences({
+    references,
+    citations: [],
+    msrv: "1.88",
+    toolchainInputs: inputs,
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "msrv-toolchain-missing");
+});
+
+test("a with: toolchain in a LATER step is not attributed to this one", () => {
+  const text = [
+    `      - uses: ${ACTION}@${RELEASE_SHA}`,
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          toolchain: 1.88.0",
+  ].join("\n");
+  const references = collectReferences("release.yml", text);
+  const inputs = collectToolchainInputs(text, references);
+  assert.equal(inputs.get(1), undefined, "the next step's with: is not ours");
+});
+
+test("omitting the MSRV is a finding rather than a silent skip", () => {
+  // The earlier version skipped the whole contract when msrv was undefined,
+  // which is how the required lane came to never run it.
+  const findings = auditReferences({
+    references: [{ file: "release.yml", line: 54, ref: RELEASE_SHA }],
+    citations: [],
+    toolchainInputs: new Map([[54, "1.88.0"]]),
   });
   assert.equal(findings.length, 1);
   assert.equal(findings[0].class, "msrv-undeclared");

--- a/.github/scripts/audit-toolchain-pin.test.mjs
+++ b/.github/scripts/audit-toolchain-pin.test.mjs
@@ -150,6 +150,53 @@ test("an env: toolchain is not an action input and must not satisfy the contract
   assert.equal(findings[0].class, "msrv-toolchain-missing");
 });
 
+// Probed by hand after the with:-mapping rule was added. Three of these were
+// wrong on the first attempt -- two FALSE REJECTS (flow style, `with:` before
+// `uses:`) and one FALSE ACCEPT (a key nested deeper than `with:`). A false
+// reject matters as much as a false accept: it rejects a legitimate spelling,
+// which invites someone to loosen the rule and reopen the hole.
+test("the with: mapping is recognised in every legitimate spelling", () => {
+  const cases = [
+    ["block", `      - uses: ${ACTION}@${RELEASE_SHA}\n        with:\n          toolchain: 1.88.0`, "1.88.0"],
+    ["flow", `      - uses: ${ACTION}@${RELEASE_SHA}\n        with: {toolchain: 1.88.0}`, "1.88.0"],
+    [
+      "comment between",
+      `      - uses: ${ACTION}@${RELEASE_SHA}\n        with:\n          # pinned MSRV\n          toolchain: 1.88.0`,
+      "1.88.0",
+    ],
+    [
+      "with: before uses:",
+      `      - with:\n          toolchain: 1.88.0\n        uses: ${ACTION}@${RELEASE_SHA}`,
+      "1.88.0",
+    ],
+  ];
+  for (const [label, text, expected] of cases) {
+    const references = collectReferences("release.yml", text);
+    assert.equal(references.length, 1, label);
+    assert.equal(
+      collectToolchainInputs(text, references).get(references[0].line),
+      expected,
+      label,
+    );
+  }
+});
+
+test("a toolchain key nested deeper than with: is not an action input", () => {
+  const text = [
+    `      - uses: ${ACTION}@${RELEASE_SHA}`,
+    "        with:",
+    "          extra:",
+    "            toolchain: 1.88.0",
+  ].join("\n");
+  const references = collectReferences("release.yml", text);
+  const inputs = collectToolchainInputs(text, references);
+  assert.equal(
+    inputs.get(references[0].line),
+    undefined,
+    "only a direct child of with: is an input",
+  );
+});
+
 test("a with: toolchain in a LATER step is not attributed to this one", () => {
   const text = [
     `      - uses: ${ACTION}@${RELEASE_SHA}`,

--- a/.github/scripts/audit-toolchain-pin.test.mjs
+++ b/.github/scripts/audit-toolchain-pin.test.mjs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ACTION,
+  DECLARED_EXEMPTIONS,
+  EXPECTED_REF,
+  auditReferences,
+  auditWorkflowDirectory,
+  collectCitations,
+  collectReferences,
+} from "./audit-toolchain-pin.mjs";
+
+const WORKFLOWS = new URL("../workflows/", import.meta.url);
+
+function usesLine(ref) {
+  return `      - uses: ${ACTION}@${ref}`;
+}
+
+// --- accepting: the repository as committed ------------------------------------
+
+test("the committed workflows agree on one pinned toolchain", async () => {
+  const { audited, exempted, findings } = await auditWorkflowDirectory(WORKFLOWS);
+  assert.deepEqual(findings, [], JSON.stringify(findings, null, 2));
+  // A pin audit that audited nothing would pass vacuously. Assert it saw work,
+  // and that the exempt reference is counted separately rather than reported as
+  // if it were at the expected ref -- release.yml is pinned by commit SHA.
+  assert.equal(audited, 11, `expected 11 audited references, saw ${audited}`);
+  assert.equal(exempted, 1, `expected 1 exempt reference, saw ${exempted}`);
+});
+
+test("the declared exemption is release.yml and it is not audited", async () => {
+  assert.deepEqual(Object.keys(DECLARED_EXEMPTIONS), ["release.yml"]);
+  const findings = auditReferences({
+    references: [
+      { file: "release.yml", line: 54, ref: "4cda84d5c5c54efe2404f9d843567869ab1699d4" },
+    ],
+    citations: [],
+  });
+  assert.deepEqual(findings, []);
+});
+
+test("an unrelated workflow with no toolchain reference is not a finding", () => {
+  assert.deepEqual(collectReferences("site.yml", "jobs:\n  build:\n    steps: []\n"), []);
+  assert.deepEqual(collectCitations("site.yml", "# nothing to see\n"), []);
+});
+
+// --- rejecting: each mutation this control exists to catch ---------------------
+
+test("reverting one reference to @stable is rejected", () => {
+  const findings = auditReferences({
+    references: [
+      { file: "ci.yml", line: 98, ref: EXPECTED_REF },
+      { file: "ci.yml", line: 146, ref: "stable" },
+    ],
+    citations: [],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "floating-channel");
+  assert.equal(findings[0].line, 146);
+  assert.match(findings[0].message, /turn `main` red with no repository change/);
+});
+
+test("nightly and beta are rejected for the same reason as stable", () => {
+  for (const channel of ["nightly", "beta"]) {
+    const findings = auditReferences({
+      references: [{ file: "ci.yml", line: 98, ref: channel }],
+      citations: [],
+    });
+    assert.equal(findings.length, 1, channel);
+    assert.equal(findings[0].class, "floating-channel", channel);
+  }
+});
+
+test("a split toolchain across two workflows is rejected", () => {
+  const findings = auditReferences({
+    references: [
+      { file: "ci.yml", line: 98, ref: EXPECTED_REF },
+      { file: "merge-readiness.yml", line: 26, ref: "1.97.0" },
+    ],
+    citations: [],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "ref-disagreement");
+  assert.equal(findings[0].file, "merge-readiness.yml");
+  // The consequence is specific and worth stating in the diagnostic: the
+  // restore-only cache key stops matching.
+  assert.match(findings[0].message, /restore-only key match against ci\.yml/);
+});
+
+test("a citation left behind by a version bump is rejected", () => {
+  const findings = auditReferences({
+    references: [{ file: "merge-readiness.yml", line: 26, ref: EXPECTED_REF }],
+    citations: [{ file: "merge-readiness.yml", line: 43, ref: "stable" }],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "stale-citation");
+  assert.equal(findings[0].line, 43);
+  assert.match(findings[0].message, /must name what the code actually does/);
+});
+
+test("an undeclared workflow cannot inherit release.yml's exemption", () => {
+  const findings = auditReferences({
+    references: [{ file: "impostor-release.yml", line: 10, ref: "stable" }],
+    citations: [],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "floating-channel");
+});
+
+// --- the collectors themselves -------------------------------------------------
+
+test("collectReferences reads the ref and the one-based line", () => {
+  const text = ["jobs:", "  a:", "    steps:", usesLine("1.98.0")].join("\n");
+  assert.deepEqual(collectReferences("ci.yml", text), [
+    { file: "ci.yml", line: 4, ref: "1.98.0" },
+  ]);
+});
+
+test("collectCitations reads comments and collectReferences does not", () => {
+  const text = `      # ${ACTION}@stable on ubuntu-latest\n${usesLine("1.98.0")}`;
+  assert.deepEqual(collectCitations("merge-readiness.yml", text), [
+    { file: "merge-readiness.yml", line: 1, ref: "stable" },
+  ]);
+  assert.deepEqual(collectReferences("merge-readiness.yml", text), [
+    { file: "merge-readiness.yml", line: 2, ref: "1.98.0" },
+  ]);
+});

--- a/.github/scripts/audit-toolchain-pin.test.mjs
+++ b/.github/scripts/audit-toolchain-pin.test.mjs
@@ -12,6 +12,7 @@ import {
   DECLARED_EXEMPTIONS,
   EXPECTED_REF,
   MINIMUM_AUDITED_REFERENCES,
+  MINIMUM_MSRV_REFERENCES,
   auditMsrvReference,
   auditReferences,
   auditWorkflowDirectory,
@@ -102,6 +103,28 @@ test("dropping the toolchain input from release.yml is rejected", () => {
   assert.equal(findings[0].class, "msrv-toolchain-missing");
 });
 
+test("a YAML alias is reported as unresolved, not as a disagreement", () => {
+  // Review probed `toolchain: *msrv` with the anchor defined elsewhere in the
+  // file. The earlier version reported msrv-disagreement, which named a
+  // disagreement it had not established. A line scan cannot resolve an alias, so
+  // the honest finding is that the equality is unproven.
+  const findings = auditMsrvReference({
+    file: "release.yml",
+    line: 54,
+    ref: RELEASE_SHA,
+    toolchainInput: "*msrv",
+    msrv: "1.88",
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].class, "msrv-alias-unresolved");
+  assert.match(findings[0].message, /cannot resolve it/);
+  assert.doesNotMatch(
+    findings[0].message,
+    /must be built at the version/,
+    "must not claim a disagreement it has not established",
+  );
+});
+
 test("a release toolchain that drifts off the declared MSRV is rejected", () => {
   const findings = auditMsrvReference({
     file: "release.yml",
@@ -155,6 +178,67 @@ test("an env: toolchain is not an action input and must not satisfy the contract
 // `uses:`) and one FALSE ACCEPT (a key nested deeper than `with:`). A false
 // reject matters as much as a false accept: it rejects a legitimate spelling,
 // which invites someone to loosen the rule and reopen the hole.
+// Every spelling below was probed against an earlier revision and MISSED, and
+// actionlint accepts each one, so each was a false reject of valid workflow YAML.
+// A false reject invites someone to loosen the rule and reopen the hole it
+// exists to close, which is why they are controls rather than notes.
+test("the with: mapping is recognised whatever its child indentation", () => {
+  // GitHub does not mandate two-space indentation. An earlier revision required
+  // exactly `with:` + 2 and therefore missed a four-space mapping.
+  for (const pad of ["  ", "    ", "      "]) {
+    const text = [
+      `      - uses: ${ACTION}@${RELEASE_SHA}`,
+      "        with:",
+      `        ${pad}toolchain: 1.88.0`,
+    ].join("\n");
+    const references = collectReferences("release.yml", text);
+    assert.equal(
+      collectToolchainInputs(text, references).get(references[0].line),
+      "1.88.0",
+      `child indented by ${pad.length}`,
+    );
+  }
+});
+
+test("a flow mapping spanning several lines is recognised", () => {
+  const text = [
+    `      - uses: ${ACTION}@${RELEASE_SHA}`,
+    "        with: {",
+    "          toolchain: 1.88.0",
+    "        }",
+  ].join("\n");
+  const references = collectReferences("release.yml", text);
+  assert.equal(
+    collectToolchainInputs(text, references).get(references[0].line),
+    "1.88.0",
+  );
+});
+
+test("a trailing comment after a flow mapping is not part of the value", () => {
+  const text = [
+    `      - uses: ${ACTION}@${RELEASE_SHA}`,
+    "        with: {toolchain: 1.88.0} # MSRV, keep in sync with rust/Cargo.toml",
+  ].join("\n");
+  const references = collectReferences("release.yml", text);
+  assert.equal(
+    collectToolchainInputs(text, references).get(references[0].line),
+    "1.88.0",
+  );
+});
+
+test("a declared MSRV path with no reference at all is rejected", async () => {
+  // Review deleted release.yml's toolchain step outright. The required lane
+  // caught it because the test below asserts the count, but the CLI reported
+  // `PASS -- ... 0 reference(s) held to the MSRV contract`: a declared contract
+  // with nothing to apply it to enforces nothing.
+  assert.equal(MINIMUM_MSRV_REFERENCES, Object.keys(DECLARED_EXEMPTIONS).length);
+  const { exempted } = await auditWorkflowDirectory(WORKFLOWS, { msrv: REPO_MSRV });
+  assert.ok(
+    exempted >= MINIMUM_MSRV_REFERENCES,
+    `expected at least ${MINIMUM_MSRV_REFERENCES} MSRV reference(s), saw ${exempted}`,
+  );
+});
+
 test("the with: mapping is recognised in every legitimate spelling", () => {
   const cases = [
     ["block", `      - uses: ${ACTION}@${RELEASE_SHA}\n        with:\n          toolchain: 1.88.0`, "1.88.0"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         if: steps.scope.outputs.run == 'true'
         with:
           components: clippy,rustfmt
@@ -143,7 +143,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         if: steps.scope.outputs.run == 'true'
 
       - uses: Swatinem/rust-cache@v2
@@ -273,7 +273,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         if: steps.scope.outputs.run == 'true'
         with:
           targets: wasm32-unknown-unknown
@@ -358,7 +358,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -409,7 +409,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -462,7 +462,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         if: steps.scope.outputs.run == 'true'
 
       - uses: Swatinem/rust-cache@v2
@@ -518,7 +518,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         if: steps.scope.outputs.run == 'true'
 
       - uses: Swatinem/rust-cache@v2
@@ -669,7 +669,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: ./tools/check-product-gate-scope.sh >>"$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         if: steps.scope.outputs.run == 'true'
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/merge-readiness.yml
+++ b/.github/workflows/merge-readiness.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -40,7 +40,7 @@ jobs:
           # `GITHUB_JOB` once `shared-key` is set, and otherwise hashes the rustc version
           # plus `CARGO|CC|CFLAGS|CXX|CMAKE|RUST`-prefixed env vars and the workspace
           # lockfiles. This job and `ci.yml`'s `rust workspace` job both run
-          # `dtolnay/rust-toolchain@stable` on `ubuntu-latest` against the same checkout.
+          # `dtolnay/rust-toolchain@1.98.0` on `ubuntu-latest` against the same checkout.
           # The expected exact key match is directly observed in four pull-request logs:
           # run 31581715093 attempt 1 logged it for core contracts at 09:11:00.77Z and Rust compile
           # at 09:11:04.76Z; run 31583381471 attempt 1 logged it at 09:33:03.06Z and 09:33:05.55Z,
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         with:
           components: rustfmt
 
@@ -96,7 +96,7 @@ jobs:
           # `GITHUB_JOB` once `shared-key` is set, and otherwise hashes the rustc version
           # plus `CARGO|CC|CFLAGS|CXX|CMAKE|RUST`-prefixed env vars and the workspace
           # lockfiles. This job and `ci.yml`'s `rust workspace` job both run
-          # `dtolnay/rust-toolchain@stable` on `ubuntu-latest` against the same checkout.
+          # `dtolnay/rust-toolchain@1.98.0` on `ubuntu-latest` against the same checkout.
           # The expected exact key match is directly observed in four pull-request logs:
           # run 31581715093 attempt 1 logged it for core contracts at 09:11:00.77Z and Rust compile
           # at 09:11:04.76Z; run 31583381471 attempt 1 logged it at 09:33:03.06Z and 09:33:05.55Z,

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         with:
           targets: wasm32-unknown-unknown
       - uses: actions/setup-node@v4

--- a/changelog.d/852-pin-rust-toolchain.fixed.md
+++ b/changelog.d/852-pin-rust-toolchain.fixed.md
@@ -1,0 +1,10 @@
+Fixed (#852): CI pins `dtolnay/rust-toolchain@1.98.0` across all eleven audited
+workflow references instead of the floating `@stable`, so an upstream Rust
+release can no longer turn `main` red with no repository change — the 2026-08-20
+breakage where rustc 1.98.0 shipped and the scheduled product gate began failing
+on a zero-line diff. `release.yml` stays exempt because it pins the MSRV from
+`rust/Cargo.toml`'s `rust-version` by action commit SHA. A new
+`audit-toolchain-pin` control runs in the required merge-readiness automation
+lane and rejects a reverted reference, a floating channel, a split toolchain
+across workflows (which would break `merge-readiness.yml`'s restore-only
+cache-key match against `ci.yml`), and a comment left citing the old ref.

--- a/changelog.d/854-pin-rust-toolchain.fixed.md
+++ b/changelog.d/854-pin-rust-toolchain.fixed.md
@@ -1,4 +1,4 @@
-Fixed (#852): CI pins `dtolnay/rust-toolchain@1.98.0` across all eleven audited
+Fixed (#854): CI pins `dtolnay/rust-toolchain@1.98.0` across all eleven audited
 workflow references instead of the floating `@stable`, so an upstream Rust
 release can no longer turn `main` red with no repository change — the 2026-08-20
 breakage where rustc 1.98.0 shipped and the scheduled product gate began failing

--- a/changelog.d/854-pin-rust-toolchain.fixed.md
+++ b/changelog.d/854-pin-rust-toolchain.fixed.md
@@ -2,9 +2,12 @@ Fixed (#854): CI pins `dtolnay/rust-toolchain@1.98.0` across all eleven audited
 workflow references instead of the floating `@stable`, so an upstream Rust
 release can no longer turn `main` red with no repository change — the 2026-08-20
 breakage where rustc 1.98.0 shipped and the scheduled product gate began failing
-on a zero-line diff. `release.yml` stays exempt because it pins the MSRV from
-`rust/Cargo.toml`'s `rust-version` by action commit SHA. A new
+on a zero-line diff. `release.yml` is held to a separate MSRV contract rather
+than exempted: its action must stay pinned by commit SHA and its `with:`
+`toolchain:` input must name `rust/Cargo.toml`'s `rust-version`. A new
 `audit-toolchain-pin` control runs in the required merge-readiness automation
-lane and rejects a reverted reference, a floating channel, a split toolchain
-across workflows (which would break `merge-readiness.yml`'s restore-only
-cache-key match against `ci.yml`), and a comment left citing the old ref.
+lane and rejects a reverted reference, a floating channel, a matrix-expression
+ref, a split toolchain across workflows (which would break
+`merge-readiness.yml`'s restore-only cache-key match against `ci.yml`), a comment
+left citing the old ref, an `env:` `toolchain:` that the action never receives,
+and an audit that inspected nothing.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -586,10 +586,24 @@ some other event on the same workflow saving a `main`-branch copy to restore fro
 it would make every pull request permanently cold — the workflow would never save a cache under its
 own key, from any event. `merge-readiness.yml`'s two `Swatinem/rust-cache` steps instead go
 **restore-only against `ci.yml`'s own `rust-workspace` key** (`shared-key: rust-workspace`,
-`save-if: false`): both jobs run `dtolnay/rust-toolchain@stable` on `ubuntu-latest` against the same
-checkout as `ci.yml`'s `rust workspace` job, and `Swatinem/rust-cache` derives its key from the
-rustc version, `CARGO`/`CC`/`CFLAGS`/`CXX`/`CMAKE`/`RUST`-prefixed env vars, and the workspace
-lockfiles — none of which differ between the two workflows. That mechanism-derived expectation is now
+`save-if: false`): both jobs run the same pinned `dtolnay/rust-toolchain` reference on
+`ubuntu-latest` against the same checkout as `ci.yml`'s `rust workspace` job, and
+`Swatinem/rust-cache` derives its key from **every installed** Rust toolchain's release, host triple
+and commit hash, the `CARGO`/`CC`/`CFLAGS`/`CXX`/`CMAKE`/`RUST`-prefixed env vars, and the workspace
+lockfiles — none of which differ between the two workflows.
+
+Two corrections to that sentence, both measured while #854 pinned the toolchain. The reference is no
+longer `@stable`; it is the version pinned in all three workflows, and keeping them equal is what
+preserves this key match, which is why a split toolchain is a finding in
+`.github/scripts/audit-toolchain-pin.mjs`. And the key hashes the **set** of installed toolchains,
+not a single selected version: on `chore/pin-rust-toolchain` the `Rust Versions` list was
+`1.97.1` (the runner image's own) *and* `1.98.0` (installed by the action), keying
+`...-718c915e-...`, where the floating reference had listed only `1.98.0` and keyed
+`...-0b9fd15e-...`. Equal references therefore do not guarantee a match across a runner-image
+rollover, and unequal references do not invariably cause a miss. What the equality buys is that the
+two workflows agree with each other, which is the property this paragraph is about; the
+cross-workflow match was re-measured as identical on PR #854 (`merge readiness / core contracts` and
+`rust checks` both `...-718c915e-9efe1eb7`). That mechanism-derived expectation is now
 supported by direct pull-request log evidence: on run `31581715093` attempt 1, `merge readiness / core
 contracts` logged `Restored from cache key
 "v0-rust-rust-workspace-Linux-x64-e8b3ee54-09fbaf53" full match: true.` at 09:11:00.77Z and

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -53,6 +53,13 @@ check_automation() {
   # Accepting/rejecting controls for the ruleset drift audit's compareRuleset/
   # validateContract classifier (docs/DESIGN-ci.md, "Ruleset drift audit").
   node --test .github/scripts/audit-ruleset-drift.test.mjs
+  # Accepting/rejecting controls for the Rust toolchain pin. `main` went red on
+  # 2026-08-20 with no repository change because every workflow used the
+  # floating `dtolnay/rust-toolchain@stable` and rustc 1.98.0 had just been
+  # released (#847, fixed by #846). Pinning without a control would let one
+  # reverted reference reintroduce that silently, and a split toolchain also
+  # breaks merge-readiness.yml's restore-only cache-key match against ci.yml.
+  node --test .github/scripts/audit-toolchain-pin.test.mjs
   # Accepting/rejecting controls for the Actions cache budget audit, including
   # the rejecting fixture for `ci.yml`'s `save-if` guard: a pull-request-scoped
   # cache for one of its shared keys must fail the audit, so removing that guard


### PR DESCRIPTION
## Problem

`main` went red on 2026-08-20 **with no repository change**.

`rustc`/`clippy` 1.98.0 was released 2026-08-18. All eleven audited workflow
references used the floating `dtolnay/rust-toolchain@stable`, so the scheduled
`product gate` picked up two new lints that this repository's `-D warnings`
turns into errors, on a zero-line diff:

| `product gate` run | time | event | result |
|---|---|---|---|
| `32350147121` | 08-20T08:42 | push | success |
| `32406084360` | 08-20T18:58 | **schedule** | **failure** |

#846 fixed the lints. #847 fixed the reporting half — nothing had filed an
issue. **This PR removes the cause**, so the next upstream release does not
repeat it.

## Change

Pin all eleven audited references to `@1.98.0`. `stable` resolves to 1.98.0
today — verified against
`https://static.rust-lang.org/dist/channel-rust-stable.toml`, whose
`[pkg.rustc] version = "1.98.0 (88d9e12ae 2026-08-18)"` matches the commit hash
of the toolchain this was tested on — so the compiler that actually runs does
not change.

**Correction:** an earlier version of this description also claimed
`Swatinem/rust-cache` keys are unaffected. **That is wrong**, measured on this
PR against #853, which leaves `@stable` in place:

| PR | ref | cache key |
|---|---|---|
| #853 | `@stable` | `v0-rust-rust-workspace-Linux-x64-`**`0b9fd15e`**`-9efe1eb7` |
| #854 | `@1.98.0` | `v0-rust-rust-workspace-Linux-x64-`**`718c915e`**`-9efe1eb7` |

The lockfile component is identical; the environment component differs, because
the "Rust Versions" list `rust-cache` hashes differs. `@stable` lists only
1.98.0; `@1.98.0` lists the runner image's preinstalled 1.97.1 **as well as**
1.98.0. See the comment thread for the raw output.

A cache miss is slower, never wrong, and it is transient: once this merges,
`main`'s own runs produce the same two-version list and the saved caches realign.
`merge-readiness.yml`'s restore-only match against `ci.yml` still holds, since
both are pinned to the same ref — which is exactly what its `:43`/`:99` comments
claim. The residual cost is that the cache key now depends on the image's
preinstalled Rust, which is itself unpinned, so an image bump will invalidate
caches where it previously would not.

| file | references |
|---|---|
| `ci.yml` | 8 |
| `merge-readiness.yml` | 2 |
| `pages.yml` | 1 |

`release.yml` stays exempt and is unchanged: it pins the **MSRV** declared by
`rust/Cargo.toml`'s `rust-version` (1.88.0), by action **commit SHA** rather
than version branch. The exemption is declared by exact path in the audit, so
renaming or removing that workflow is a visible change, not a silent widening.

Note this pins the *toolchain*, not the action code — `@1.98.0` is a version
branch, not an immutable tag. Pinning action code is a separate supply-chain
concern that `release.yml` already handles its own way; bundling both changes
here would have mixed two unrelated risks.

## A pin with no control enforces nothing

The next pull request could revert one reference and nothing would fail. That is
the defect class this repository has removed six times in the last two days, so
the control is part of the change rather than a follow-up.

`.github/scripts/audit-toolchain-pin.mjs` runs from `check_automation()` in
`tools/check-merge-readiness.sh` — the **required** merge-readiness lane, which
is Node/stdlib-only, so it fits without disturbing that lane's dependency
contract. It rejects four distinct mutations:

1. a reference reverted to a floating channel (`stable`, `beta`, `nightly`);
2. a **split** toolchain across workflows. This one is not cosmetic:
   `Swatinem/rust-cache` keys include the rustc version, and
   `merge-readiness.yml` deliberately does a *restore-only* fetch against
   `ci.yml`'s `rust-workspace` key. A split toolchain silently turns that exact
   key match into a miss — the lane still passes, just slowly, which is exactly
   the kind of silent degradation nothing would otherwise catch;
3. a workflow other than the declared exemption claiming exempt status;
4. a **comment left citing the old ref**. `merge-readiness.yml:43` and `:99`
   justify their restore-only key by naming the action and ref that produce the
   matching key. A bump that leaves them behind makes the cited justification
   disagree with the code, which is its own recurring defect here.

## Test evidence

- `node --test .github/scripts/audit-toolchain-pin.test.mjs` → **exit 0, 10/10**
- `./tools/check-merge-readiness.sh automation` → **exit 0**, with the new
  controls running inside it
- `actionlint` on all three changed workflows → exit 0
- `./tools/aggregate_changelog.sh check` → exit 0
- `node .github/scripts/audit-toolchain-pin.mjs` →
  `PASS -- 11 audited reference(s) at @1.98.0, 1 exempt reference(s) in release.yml`

### Calibration: measured, not asserted

A control that has not been observed failing has not been shown to detect
anything.

| mutation applied | result |
|---|---|
| one `ci.yml` reference reverted to `@stable` | **exit 1**, 9 pass / 1 fail, diagnostic `ci.yml:98 uses dtolnay/rust-toolchain@stable` |
| one citation reverted to `@stable` | **exit 1** |
| both restored | exit 0 |

The audit's own summary line was also corrected during this work: it first
reported "12 reference(s) at @1.98.0", counting `release.yml` — which is pinned
by SHA and is *not* at that ref. It now reports audited and exempt counts
separately, and a test pins both numbers so the summary cannot drift back into
claiming something untrue.

## Accepted tradeoff

Two costs, both stated rather than discovered later:

1. A toolchain bump is now an explicit pull request rather than automatic.
2. Cache keys change once, and afterwards track the runner image's preinstalled
   Rust (see the correction above).


A toolchain bump is now an explicit pull request rather than automatic. That is
the intent: it moves the moment of breakage from an upstream release date to a
reviewed change. The cost is that adopting a new Rust release requires a PR that
also fixes whatever new lints it brings — which is what #846 was, except
unplanned and on `main`.

---

## Known residual: this is a line scan, not a YAML parse

Four escape routes were found by probing this audit, and **every one of them
left the verdict on the committed workflows unchanged** — which is what makes
them holes rather than disagreements:

| # | form | why it passed | now classified as |
|---|---|---|---|
| 1 | `- uses: "action@stable"` | quotes were not stripped | `floating-channel` |
| 2 | `- uses: action@${{ matrix.tc }}` | `(\S+)\s*$` missed the space in the expression | `expression-ref` |
| 3 | `- name: x` with a sibling `uses:` | the list dash was required | `floating-channel` |
| 4 | `- uses : action@stable` | whitespace before the colon was not allowed | `floating-channel` |

Number 4 was found by review; 1-3 by me. Number 4 is valid YAML, verified with
a parser rather than assumed:

```
>>> yaml.safe_load("steps:\n  - uses : action@stable")
step keys: ['uses']   uses value: 'action@stable'
```

Each is now a test carrying a comment that it passed silently against an earlier
revision, so relaxing the collector re-opens a known hole rather than an
imagined one. Audited references across the probe directory went from 12 to 15.

**I cannot claim there is no fifth hole.** The root cause is structural: this
scans lines instead of parsing the document, and it does so because
`check_automation()` is Node/stdlib-only by contract. Migrating to a real parse
— and the dependency decision that implies — is tracked as **#856**, which also
lists the unprobed candidates (flow scalars, anchors/aliases, reusable-workflow
and composite indirection, `rust-toolchain.toml` and `RUSTUP_TOOLCHAIN`
overrides).

This is merged as a line scan deliberately: the pin's value — `main` not
breaking on an upstream release — does not depend on the audit being complete,
and an incomplete audit that rejects four real mutations is worth more than no
audit. It is worth less than it looks, which is why the limit is stated here
rather than left for someone to discover.

Also fixed during review: the CLI reported `PASS -- 0 audited reference(s)`
against a directory with no references. A pin audit that audits nothing and
reports success is the exact defect it exists to prevent, so `main()` now fails
below a measured floor, and a missing or unreadable directory produces a
diagnostic instead of an uncaught exception.