### PR TITLE
fix(ci): give rust tests and rust checks cold-build margin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
   rust-checks:
     name: rust checks
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -126,7 +126,7 @@ jobs:
   rust-tests:
     name: rust tests (${{ matrix.shard }}/3)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/changelog.d/857-cold-build-timeout-budget.fixed.md
+++ b/changelog.d/857-cold-build-timeout-budget.fixed.md
@@ -1,0 +1,9 @@
+Fixed (#857): `rust tests` and `rust checks` have cold-build margin. A cold
+`rust tests` shard was measured at 30m04s against its 30-minute budget and was
+cancelled, turning the aggregate `rust workspace` required context red;
+`docs/DESIGN-ci.md` had recorded that outcome as an unobserved risk. The budgets
+move to 45 and 30 minutes, sized from measured cold durations (24m59s / 27m12s /
+30m04s for the shards, 16m35s for `rust checks`) against warm baselines of
+9-11m and 2m. #747 records why cold builds recur: two concurrent pull requests
+exceed the 10 GiB Actions cache ceiling and evict each other, so a budget with
+no cold margin turns a routine eviction into a failed required context.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -696,6 +696,45 @@ mutation lanes was considered and rejected: it would cost the operators shards a
 run (~35 min measured cold vs. ~5 min warm) for less budget relief than `fsl-logic` gives for
 near-zero cost.
 
+**A cold `rust tests` shard has now timed out, which this section previously recorded as
+unobserved.** The passage above says of a 30-minute budget that "whether a cold build here would
+finish inside 30 minutes is not observed" and that a warm baseline "is not evidence that a cold run
+would succeed rather than time out." That gap is now closed by observation, on a different job than
+the one it was written about.
+
+Pull request #854 pins the Rust toolchain, which changes the `Swatinem/rust-cache` environment hash
+and therefore the cache key, so its own runs build cold. Measured on run `32430070397`
+(`chore/pin-rust-toolchain`, head `cddc70f`, `run_attempt=1`), every `rust tests` shard logged
+`No cache found.`:
+
+| job | cold duration | budget | outcome |
+|---|---|---|---|
+| `rust checks` | 16m35s | 20m | success, 83% of budget |
+| `rust tests (3/3)` | 24m59s | 30m | success |
+| `rust tests (2/3)` | 27m12s | 30m | success |
+| `rust tests (1/3)` | **30m04s** | 30m | **cancelled at the budget** |
+| `WASM` | 20m58s | 30m | success, 70% of budget |
+
+The aggregate `rust workspace` job then failed correctly, reporting
+`rust-checks=success rust-tests=cancelled` -- the shard-completeness guard converting a cancelled
+shard into a failed required context rather than treating it as success.
+
+The warm contrast is from pull request #853's run `32426383423`, which leaves the floating ref in
+place and hit the cache: `rust checks` 2m, `rust tests` 11m / 11m / 9m. So the cache is worth roughly
+2.5x on these lanes, and the budgets were provisioned for the warm case with no margin for the cold
+one.
+
+Cold builds are not exotic here. #747 records the mechanism: two concurrent pull requests running
+the full product gate exceed the repository's 10 GiB Actions cache ceiling and evict each other,
+and because `main` carried no Rust build cache, an evicted pull request paid a cold build every
+time. A budget with zero cold-build margin therefore converts a routine cache eviction into a red
+required context.
+
+`rust tests` moves from 30 to 45 minutes and `rust checks` from 20 to 30, sized from the measured
+cold durations above rather than from a guess. `WASM` (70% of its budget cold) and `fsl-logic` (no
+cold observation) are deliberately left unchanged: the change covers what was measured, and
+extending it further would be the same unevidenced provisioning this entry exists to correct.
+
 **Historical cold-run observations and the combined #752 change.** `gh api` reports
 `run_attempt=1` for `main` run `31086789147`, PR #743 run `31077948474`, and PR #744 run
 `31083643650`; each recorded cold `mutation operators` shard(s) cancelled at the old 30-minute


### PR DESCRIPTION
## Problem

`docs/DESIGN-ci.md` recorded this outcome as an **unobserved risk**. Of a
30-minute budget it says:

> whether a cold build here would finish inside 30 minutes is **not observed** …
> and is **not evidence that a cold run would succeed rather than time out**.

It has now been observed.

## Measurement

Run `32430070397` (`chore/pin-rust-toolchain`, head `cddc70f`,
`run_attempt=1`). Every `rust tests` shard logged `No cache found.`:

| job | cold | budget | outcome |
|---|---|---|---|
| `rust checks` | 16m35s | 20m | success, **83%** of budget |
| `rust tests (3/3)` | 24m59s | 30m | success |
| `rust tests (2/3)` | 27m12s | 30m | success |
| `rust tests (1/3)` | **30m04s** | 30m | **cancelled at the budget** |
| `WASM` | 20m58s | 30m | success, 70% of budget |

The aggregate `rust workspace` job then failed, reporting
`rust-checks=success rust-tests=cancelled`. **That guard did its job** — it
converted a cancelled shard into a failed required context instead of treating
it as success. The budget is what failed.

Warm contrast, PR #853's run `32426383423` (cache hit): `rust checks` 2m,
`rust tests` 11m / 11m / 9m. The cache is worth roughly **2.5x** on these lanes,
and the budgets were provisioned for the warm case with no margin for the cold
one.

## Why zero margin is a defect, not a tight fit

Cold builds are routine in this repository. #747 records the mechanism: two
concurrent pull requests running the full product gate exceed the 10 GiB Actions
cache ceiling and **evict each other**, so an evicted pull request pays a cold
build every time. With no cold margin, an ordinary eviction becomes a red
required context — and a timed-out job also **skips its cache-save post step**,
so the next run is cold too.

## Change

| job | before | after | basis |
|---|---|---|---|
| `rust tests` | 30m | **45m** | observed 30m04s cancellation; slowest successful shard 27m12s |
| `rust checks` | 20m | **30m** | observed 16m35s, 83% of budget |

`WASM` (70% cold) and `fsl-logic` (no cold observation) are **deliberately
unchanged**. Extending the change to them would be the same unevidenced
provisioning this fixes.

A timeout bounds resource consumption, not correctness. Raising it cannot mask a
defect; it can only stop a slow-but-correct run being reported as a failure.
Nothing about what these lanes verify changes.

## Relationship to #854

#854 (pin the Rust toolchain) is what made this deterministic: pinning changes
the `Swatinem/rust-cache` environment hash, so its own runs build cold. **This is
not a fix for #854** — it is a pre-existing fragility that #854 exposed, and it
applies equally to eviction, an image bump, or a lockfile change. #854 is
blocked on this landing, because merging it while the budget has no cold margin
risks turning `main` red by timeout, which is the outcome #854 exists to prevent.

## Test evidence

- `actionlint .github/workflows/ci.yml` → exit 0
- `./tools/aggregate_changelog.sh check` → exit 0
- No new `## ` heading in `docs/DESIGN-ci.md` (verified), so the
  `LANGUAGE.md`/`LANGUAGE.ja.md` section-order check is unaffected
- The observation is recorded in the "Actions cache budget" section, immediately
  before the "Historical cold-run observations" entry, next to the passage that
  called it unobserved

### Not verified by execution

That 45 minutes is sufficient for every future cold `rust tests` shard. The
largest observed cold shard is 30m04s and it was cancelled at the budget, so its
true duration is unknown — 45 is sized from the two shards that did finish
(24m59s, 27m12s) plus margin, not from a completed 1/3 run.
