### PR TITLE
fix(runtime): resolve integer const init map keys

### DIFF
--- a/changelog.d/825-init-int-const-keys.fixed.md
+++ b/changelog.d/825-init-int-const-keys.fixed.md
@@ -1,1 +1,0 @@
-Fixed (#825): recognize integer constants as distinct concrete keys when checking `init` coverage for integer-keyed maps.

--- a/changelog.d/825-init-int-const-keys.fixed.md
+++ b/changelog.d/825-init-int-const-keys.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#825): recognize integer constants as distinct concrete keys when checking `init` coverage for integer-keyed maps.

--- a/changelog.d/860-init-int-const-keys.fixed.md
+++ b/changelog.d/860-init-int-const-keys.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#860): recognize integer constants as distinct concrete keys when checking `init` coverage for integer-keyed maps.

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -603,6 +603,32 @@ fn resolve_enum_key(model: &KernelModel, key_type: &TypeRef, name: &str) -> Opti
         .find(|value| matches!(value, Value::Enum { member, .. } if member == name))
 }
 
+/// Resolve `name` as an integer constant only when `key_type` is integer-valued.
+///
+/// Map-key coverage is typed: an integer constant must not stand in for an enum
+/// member merely because they share a spelling.
+fn resolve_integer_const_key(model: &KernelModel, key_type: &TypeRef, name: &str) -> Option<Value> {
+    let is_integer_key = match key_type {
+        TypeRef::Int | TypeRef::Range(_, _) => true,
+        TypeRef::Named(type_name) => {
+            matches!(model.types.get(type_name), Some(TypeDef::Domain { .. }))
+        }
+        TypeRef::Bool
+        | TypeRef::Map(_, _)
+        | TypeRef::Relation(_, _)
+        | TypeRef::Set(_)
+        | TypeRef::Seq(_, _)
+        | TypeRef::Option(_) => false,
+    };
+    if !is_integer_key {
+        return None;
+    }
+    match model.consts.get(name) {
+        Some(Value::Int(value)) => Some(Value::Int(*value)),
+        _ => None,
+    }
+}
+
 /// The coverage a single assignment statement contributes to its logical
 /// root, independent of whatever the root already had. Returns `None` when
 /// the target's key/field shape carries no provable component information
@@ -623,6 +649,7 @@ fn assignment_coverage(
                         .map(|values| Coverage::Keys(values.into_iter().collect()))
                 } else if let Some(TypeRef::Map(key_ty, _)) = model.state_type(name) {
                     resolve_enum_key(model, key_ty, key)
+                        .or_else(|| resolve_integer_const_key(model, key_ty, key))
                         .map(|value| Coverage::Keys(BTreeSet::from([value])))
                 } else {
                     None

--- a/rust/fsl-runtime/tests/explicit_engine.rs
+++ b/rust/fsl-runtime/tests/explicit_engine.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Ryoichi Izumita
 
-use fsl_core::{FsResolver, build_model, parse_kernel_source};
+use fsl_core::{FsResolver, TypeDef, TypeRef, build_model, parse_kernel_source};
 
 fn model(source: &str) -> fsl_core::KernelModel {
     build_model(parse_kernel_source(source, &FsResolver::new(".")).expect("parse kernel"))
@@ -193,6 +193,130 @@ fn deterministic_init_tracks_branches_foralls_and_duplicate_locations() {
     let error = fsl_runtime::verify_explicit(nested_forall, 1, 100)
         .expect_err("nested init forall rejected");
     assert_eq!(error.message, "nested forall in init is not supported");
+}
+
+#[test]
+fn init_accepts_distinct_integer_const_keys_for_map_int_and_bounded_maps() {
+    let integer_consts = model(
+        "spec IntegerConstKeys { const K = 0 const J = 1 \
+         state { m: Map<Int, Bool> } \
+         init { m[K] = true m[J] = false } action noop() { } }",
+    );
+    let TypeRef::Map(key_type, _) = integer_consts.state_type("m").expect("map state type") else {
+        panic!("m must be a map");
+    };
+    assert!(matches!(key_type.as_ref(), TypeRef::Int));
+    fsl_runtime::Monitor::new(integer_consts.clone())
+        .expect("Monitor accepts the issue #825 Map<Int, Bool> reproducer");
+    let result = fsl_runtime::verify_explicit(integer_consts, 1, 100)
+        .expect("explicit BFS accepts the issue #825 Map<Int, Bool> reproducer");
+    assert!(result.closure);
+    assert!(result.violation.is_none());
+
+    // A named integer domain lowers to TypeRef::Named. Keep this control so
+    // the TypeDef::Domain arm of resolve_integer_const_key remains covered.
+    let named_domain_consts = model(
+        "spec NamedDomainConstKeys { const K = 0 const J = 1 type Key = 0..1 \
+         state { m: Map<Key, Bool> } \
+         init { m[K] = true m[J] = false } action noop() { } }",
+    );
+    let TypeRef::Map(key_type, _) = named_domain_consts.state_type("m").expect("map state type")
+    else {
+        panic!("m must be a map");
+    };
+    assert!(matches!(
+        key_type.as_ref(),
+        TypeRef::Named(type_name)
+            if matches!(named_domain_consts.types.get(type_name), Some(TypeDef::Domain { .. }))
+    ));
+    fsl_runtime::Monitor::new(named_domain_consts.clone())
+        .expect("Monitor accepts fully covered named-domain const keys");
+    let result = fsl_runtime::verify_explicit(named_domain_consts, 1, 100)
+        .expect("explicit BFS accepts fully covered named-domain const keys");
+    assert!(result.closure);
+    assert!(result.violation.is_none());
+
+    // Inline map bounds lower directly to TypeRef::Range rather than the
+    // named-domain representation above, so exercise that separate type gate.
+    let inline_range_consts = model(
+        "spec InlineRangeConstKeys { const K = 0 const J = 1 \
+         state { m: Map<0..1, Bool> } \
+         init { m[K] = true m[J] = false } action noop() { } }",
+    );
+    let TypeRef::Map(key_type, _) = inline_range_consts.state_type("m").expect("map state type")
+    else {
+        panic!("m must be a map");
+    };
+    assert!(matches!(key_type.as_ref(), TypeRef::Range(0, 1)));
+    fsl_runtime::Monitor::new(inline_range_consts.clone())
+        .expect("Monitor accepts fully covered inline-range const keys");
+    let result = fsl_runtime::verify_explicit(inline_range_consts, 1, 100)
+        .expect("explicit BFS accepts fully covered inline-range const keys");
+    assert!(result.closure);
+    assert!(result.violation.is_none());
+
+    // Regression control: enum-key coverage is still resolved as enum values.
+    let enum_keys = model(
+        "spec EnumKeys { enum Key { A, B } state { m: Map<Key, Bool> } \
+         init { m[A] = true m[B] = false } action noop() { } }",
+    );
+    fsl_runtime::Monitor::new(enum_keys.clone())
+        .expect("Monitor still accepts fully covered enum keys");
+    let result = fsl_runtime::verify_explicit(enum_keys, 1, 100)
+        .expect("explicit BFS still accepts fully covered enum keys");
+    assert!(result.closure);
+    assert!(result.violation.is_none());
+}
+
+#[test]
+fn init_integer_const_keys_preserve_duplicate_and_partial_coverage_rejection() {
+    let duplicate = model(
+        "spec DuplicateConst { const K = 0 state { m: Map<Int, Bool> } \
+         init { m[K] = true m[K] = false } action noop() { } }",
+    );
+    let error = fsl_runtime::verify_explicit(duplicate, 1, 100)
+        .expect_err("the same integer const key remains a duplicate init write");
+    assert_eq!(
+        error.message,
+        "state variable 'm' assigned more than once in init"
+    );
+
+    let bound_alias = model(
+        "spec BoundAlias { const K = 0 const MAX = 1 state { m: Map<Int, Bool> } \
+         init { forall i in 0..MAX { m[i] = true } m[K] = false } action noop() { } }",
+    );
+    let error = fsl_runtime::verify_explicit(bound_alias, 1, 100)
+        .expect_err("a const key still collides with a bound key that can alias it");
+    assert_eq!(
+        error.message,
+        "state variable 'm' assigned more than once in init"
+    );
+
+    let partial = model(
+        "spec PartialConst { const K = 0 const J = 1 type Key = 0..2 \
+         state { m: Map<Key, Bool> } init { m[K] = true m[J] = false } action noop() { } }",
+    );
+    let error = fsl_runtime::verify_explicit(partial, 1, 100)
+        .expect_err("integer constants must not make a partially initialized map complete");
+    assert_eq!(
+        error.message,
+        "init does not assign state variable(s): m (partial component initialization is rejected by the explicit engine)"
+    );
+
+    // For Map<Int, _>, map_key_values covers every integer from zero through
+    // the largest integer constant in the model. An otherwise unused higher
+    // constant therefore makes K and J a partial concrete initialization.
+    let partial_int = model(
+        "spec PartialIntConst { const K = 0 const J = 1 const HIGH = 2 \
+         state { m: Map<Int, Bool> } \
+         init { m[K] = true m[J] = false } action noop() { } }",
+    );
+    let error = fsl_runtime::verify_explicit(partial_int, 1, 100)
+        .expect_err("the derived Map<Int, _> compatibility domain remains partially assigned");
+    assert_eq!(
+        error.message,
+        "init does not assign state variable(s): m (partial component initialization is rejected by the explicit engine)"
+    );
 }
 
 /// Negative control for #480: a `forall` binder over more than one value

--- a/rust/fslc/tests/explicit_engine.rs
+++ b/rust/fslc/tests/explicit_engine.rs
@@ -420,6 +420,23 @@ fn explicit_rejects_partial_component_init_coverage() {
 }
 
 #[test]
+fn enum_map_key_name_collision_with_an_integer_const_is_rejected_before_runtime() {
+    let (result, status) = verify(
+        &fixture_path("issue_825_enum_const_name_collision.fsl"),
+        "explicit",
+        4,
+        &[],
+    );
+    assert_eq!(status, 2);
+    assert_eq!(result["result"], "error");
+    assert_eq!(result["kind"], "semantics");
+    assert_eq!(
+        result["message"],
+        "invalid init statement: expression of type Int is not assignable to Named(\"Key\") at 12:5"
+    );
+}
+
+#[test]
 fn explicit_accepts_map_fully_covered_by_separate_concrete_key_statements() {
     // The fsl-db "per-column" pattern: distinct concrete-key writes that
     // together cover the whole enum key domain must count as full coverage.

--- a/rust/fslc/tests/fixtures/issue_825_enum_const_name_collision.fsl
+++ b/rust/fslc/tests/fixtures/issue_825_enum_const_name_collision.fsl
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec EnumConstName {
+  const A = 0
+  enum Key { A, B }
+
+  state {
+    m: Map<Key, Bool>
+  }
+
+  init {
+    m[A] = true
+    m[B] = false
+  }
+
+  action noop() { }
+}


### PR DESCRIPTION
## Problem

`init`'s duplicate-write rule reported

```
state variable 'm' assigned more than once in init
```

for a spec in which **each concrete key is assigned exactly once**:

```fsl
const K = 0
const J = 1
init {
  m[K] = true
  m[J] = false
}
```

The diagnostic is factually false — `K` and `J` denote distinct keys.

Reproduced before any edit, on `main`:

```
$ fslc verify /private/tmp/issue825-repro.fsl --engine explicit --depth 4
exit 2   state variable 'm' assigned more than once in init
```

Note the gate lives only in the runtime: `fslc check` exits 0, because the
deterministic-init rule is `explicit.rs`'s and `check` does not execute it.

## Cause

`assignment_coverage` (`rust/fsl-runtime/src/explicit.rs`) resolved an
**enum-member** key to a `Value` but had no path for an integer `const`, so both
writes yielded `None` coverage and fell back to `InitWriteKey::Root(m)`, where
they collided.

The same `match` already handled `Expr::Num`, so `m[0] = true; m[1] = false` was
accepted while `m[K] = true; m[J] = false` was not — and `const_int_bound`, 24
lines above, already resolved `Expr::Var` through `model.consts`.

## Change

One new function and one line of wiring. `coverage_is_full` and every other
existing behaviour are **byte-identical to `main`**; the diff is 187 insertions
and a single deletion, that deletion being the line `.or_else()` was inserted
into.

Resolution is **type-gated**, and deliberately so: an integer constant must not
stand in for an enum member merely because they share a spelling. `resolve_enum_key`
is tried first, `resolve_integer_const_key` second.

## The issue's second claim turned out to be right

#825 said resolving int consts would fix the coverage gate as well as the
duplicate rule. I told the implementer not to assume that and to measure it. The
measurement came out in the issue's favour, and understanding why is the
interesting part:

`KernelModel::map_key_values` has a deliberate case for `TypeRef::Int` — it
derives a **concrete compatibility domain** of `0..=max(integer const)`. So with
`const K = 0` and `const J = 1` the key domain is `{0, 1}`, and the two writes
cover it exactly. The original reproducer needs no named range type:

```
$ fslc verify /private/tmp/issue825-int-map.fsl --engine explicit --depth 4
result = proved
```

A consequence worth stating, because it is not obvious: a `Map<Int, _>` key
domain is derived from the spec's own constants, so **adding an otherwise-unused
`const HIGH = 2` widens the domain to `{0, 1, 2}`** and makes `K`/`J` a partial
initialization. That is what the partial-coverage control below uses.

## Controls

Accepting:

- the issue's actual reproducer, `Map<Int, Bool>` with `const K`/`const J` and no
  named range type, asserted to be `TypeRef::Int` at the type level so the test
  cannot silently stop exercising that arm;
- a named integer domain (`type Key = 0..1`), which lowers to `TypeRef::Named`
  backed by `TypeDef::Domain`, keeping that arm covered;
- enum-key coverage still resolving as enum values (regression control).

Rejecting, each asserting the **exact** diagnostic:

- the same const key written twice — still a duplicate;
- a const key plus a `forall` binder that can alias it — still a duplicate,
  per `docs/LANGUAGE.md`'s clause about a key that is itself a bound loop
  variable;
- `Map<Int, _>` left partially assigned via an unused higher const — coverage gate
  still fires. **This is the control that proves the fix did not weaken the
  coverage gate to force acceptance.**

At the CLI level, a `const` sharing a name with an enum member is rejected during
core type checking (`expression of type Int is not assignable to Named("Key")`),
pinned by exact message. So the enum-before-const precedence is protected twice:
by the type gate inside `resolve_integer_const_key`, and by the type checker
before the runtime is reached. Filed separately as #855, since the diagnostic
names the type mismatch rather than the shadowing that causes it.

## Test evidence

All on `rustc 1.98.0` with a **private** target directory:

| gate | result |
|---|---|
| `cargo test -p fsl-runtime` | exit 0, 50 passed |
| `cargo test -p fsl-core -p fslc-rust` | exit 0, **1,036 passed** |
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets --locked -- -D warnings` | exit 0 |
| `./tools/aggregate_changelog.sh check` | exit 0 |

`rust/fsl-runtime/Cargo.toml` is untouched, so `fsl-runtime` gained no solver, Z3
or JS-bridge dependency.

`docs/LANGUAGE.md` needs no change: `:1776-1780` already documents that separate
flat writes to two *different* keys are fine, so this makes the implementation
match the existing contract rather than changing it.

## A wrong turn worth recording

An earlier revision of this branch also replaced `map_key_values` with
`domain_values` in `coverage_is_full`. That change was never asked for by #825
and it **broke `specs/cart_buggy.fsl`**, a real corpus spec, because
`domain_values` has no `Int` case and every `Map<Int, _>` became uncoverable. It
has been reverted; `coverage_is_full` is unchanged from `main`.

That regression was initially masked twice over. First a **shared
`CARGO_TARGET_DIR` across two git worktrees** produced a *phantom* failure of the
same test on unmodified `main` — measured: shared target FAILED, clean private
target passed, CI passed — which led to the corpus test being repointed at a
hand-written fixture. The repoint has been reverted and the corpus reference
restored. Then, on a clean target, the *real* regression appeared and was
reported rather than worked around, which is what allowed the one-line cause to
be found.

Closes #825
