### PR TITLE
fix(ci): reject case-insensitive audit workflow name collisions

### DIFF
--- a/.github/scripts/validate-cache-budget-audit-workflow.py
+++ b/.github/scripts/validate-cache-budget-audit-workflow.py
@@ -13,6 +13,7 @@ import argparse
 import copy
 import re
 import shlex
+import unicodedata
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Optional
@@ -127,6 +128,21 @@ def load_workflow(path: Path) -> Any:
     return yaml.load(path.read_text(encoding="utf-8"), Loader=WorkflowLoader)
 
 
+def _normalized_workflow_name(value: Any) -> str | None:
+    """Return the fail-closed comparison key for a workflow display name."""
+    if not isinstance(value, str):
+        return None
+    return unicodedata.normalize("NFKC", value).strip().casefold()
+
+
+def _is_audit_workflow_name(value: Any) -> bool:
+    return _normalized_workflow_name(value) == AUDIT_WORKFLOW_NAME
+
+
+def _is_audit_workflow_subscription(value: Any) -> bool:
+    return isinstance(value, list) and len(value) == 1 and _is_audit_workflow_name(value[0])
+
+
 def _mapping(value: Any, label: str, errors: list[str]) -> Optional[Mapping[str, Any]]:
     if not isinstance(value, Mapping):
         errors.append(f"{label} must be a mapping")
@@ -178,8 +194,8 @@ def validate_workflow(document: Any) -> list[str]:
         "workflow",
         errors,
     )
-    if workflow.get("name") != AUDIT_WORKFLOW_NAME:
-        errors.append("audit workflow name must be exactly 'cache budget audit'")
+    if not _is_audit_workflow_name(workflow.get("name")):
+        errors.append("audit workflow name must match 'cache budget audit'")
 
     triggers = _mapping(workflow.get("on"), "workflow 'on'", errors)
     if triggers is not None:
@@ -381,7 +397,7 @@ def validate_reporter_workflow(document: Any) -> list[str]:
                 "reporter trigger 'workflow_run'",
                 errors,
             )
-            if workflow_run.get("workflows") != [AUDIT_WORKFLOW_NAME]:
+            if not _is_audit_workflow_subscription(workflow_run.get("workflows")):
                 errors.append(
                     f"reporter workflow_run.workflows must be exactly ['{AUDIT_WORKFLOW_NAME}']"
                 )
@@ -523,7 +539,7 @@ def validate_audit_workflow_name_uniqueness(workflows_directory: Path) -> list[s
         except yaml.YAMLError as error:
             errors.append(f"workflow YAML is invalid: sibling workflow file '{path}': {error}")
             continue
-        if isinstance(document, Mapping) and document.get("name") == AUDIT_WORKFLOW_NAME:
+        if isinstance(document, Mapping) and _is_audit_workflow_name(document.get("name")):
             matching_workflows.append(path.name)
 
     if len(matching_workflows) > 1:

--- a/changelog.d/851-case-insensitive-workflow-name.fixed.md
+++ b/changelog.d/851-case-insensitive-workflow-name.fixed.md
@@ -1,0 +1,2 @@
+Fixed (#851): Cache-budget audit workflow-name validation now rejects case-only,
+surrounding-whitespace, and compatibility-Unicode collisions with the reporter source.

--- a/tests/test_cache_budget_audit_workflow.py
+++ b/tests/test_cache_budget_audit_workflow.py
@@ -512,7 +512,7 @@ Mutation = tuple[str, Callable[[dict[str, Any]], Any], str]
 MUTATIONS: list[Mutation] = [
     ("replace workflow with a YAML list", _replace_workflow_with_list, "workflow must be a mapping"),
     ("add audit workflow key", _add_audit_workflow_key, "workflow must not declare unapproved keys: defaults"),
-    ("rename audit workflow", _rename_audit_workflow, "audit workflow name must be exactly 'cache budget audit'"),
+    ("rename audit workflow", _rename_audit_workflow, "audit workflow name must match 'cache budget audit'"),
     ("set on to a list", _set_on_to_list, "workflow 'on' must be a mapping"),
     ("empty schedule", _empty_schedule, "trigger 'schedule' must be a non-empty list"),
     ("disable workflow_dispatch", _disable_workflow_dispatch, "trigger 'workflow_dispatch' must be enabled"),
@@ -704,6 +704,22 @@ def test_real_cache_budget_audit_reporter_workflow_is_accepted():
     assert validator.validate_reporter_workflow(_real_reporter_workflow()) == []
 
 
+@pytest.mark.parametrize("name", ["Cache Budget Audit", "CACHE BUDGET AUDIT", " cache budget audit "])
+def test_audit_workflow_name_uses_the_collision_comparison_key(name: str):
+    document = _real_workflow()
+    document["name"] = name
+
+    assert validator.validate_workflow(document) == []
+
+
+@pytest.mark.parametrize("name", ["Cache Budget Audit", "CACHE BUDGET AUDIT", " cache budget audit "])
+def test_reporter_subscription_uses_the_collision_comparison_key(name: str):
+    document = _real_reporter_workflow()
+    document["on"]["workflow_run"]["workflows"] = [name]
+
+    assert validator.validate_reporter_workflow(document) == []
+
+
 def test_audit_workflow_name_rejects_a_third_same_named_workflow(tmp_path: Path):
     (tmp_path / WORKFLOW_PATH.name).write_text(WORKFLOW_PATH.read_text(encoding="utf-8"), encoding="utf-8")
     (tmp_path / REPORTER_WORKFLOW_PATH.name).write_text(
@@ -718,6 +734,30 @@ def test_audit_workflow_name_rejects_a_third_same_named_workflow(tmp_path: Path)
     assert validator.validate_audit_workflow_name_uniqueness(tmp_path) == [
         "audit workflow name 'cache budget audit' must be unique; found in: "
         "cache-budget-audit.yml, unrelated-cache-audit.yml"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("sibling_name", "sibling_filename"),
+    [
+        ("Cache Budget Audit", "sibling-title-case.yml"),
+        ("CACHE BUDGET AUDIT", "sibling-upper-case.yml"),
+        (" cache budget audit ", "sibling-surrounding-space.yml"),
+    ],
+)
+def test_audit_workflow_name_rejects_casefolded_or_trimmed_sibling_workflow(
+    tmp_path: Path, sibling_name: str, sibling_filename: str
+):
+    (tmp_path / WORKFLOW_PATH.name).write_text(WORKFLOW_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / REPORTER_WORKFLOW_PATH.name).write_text(
+        REPORTER_WORKFLOW_PATH.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (tmp_path / sibling_filename).write_text(f"name: {sibling_name!r}\n", encoding="utf-8")
+
+    assert validator.validate_audit_workflow_name_uniqueness(tmp_path) == [
+        "audit workflow name 'cache budget audit' must be unique; found in: "
+        f"cache-budget-audit.yml, {sibling_filename}"
     ]
 
 


### PR DESCRIPTION
## Problem

The check that stops workflow-name impersonation compared **exactly**, while what
it protects subscribes by **display name**:

```python
# validate-cache-budget-audit-workflow.py
AUDIT_WORKFLOW_NAME = "cache budget audit"
:181  if workflow.get("name") != AUDIT_WORKFLOW_NAME
:384  if workflow_run.get("workflows") != [AUDIT_WORKFLOW_NAME]
:526  if document.get("name") == AUDIT_WORKFLOW_NAME
```

```yaml
# cache-budget-audit-reporter.yml:7
workflows: ["cache budget audit"]
```

If GitHub's `workflow_run` name matching is case-insensitive, a default-branch
workflow named `Cache Budget Audit` triggers the reporter while the exact
comparison never flags it. The consequence is the one #795 closed: the reporter
follows the impostor's `workflow_id`, so unrelated health opens or closes the
canonical issue.

## Why this did not need GitHub's behaviour settled

Determining whether GitHub folds case would mean committing differently-cased
default-branch workflows and observing a live `workflow_run` — out of scope, and
review of #840 explicitly left it unverified for that reason. **Making the check
case-insensitive fails closed either way**: if GitHub is case-sensitive nothing is
lost, and if it is not, the gap closes. No live experiment required.

## Change

One normalisation helper, applied at **all three** comparison sites:

```python
def _normalized_workflow_name(value: Any) -> str | None:
    if not isinstance(value, str):
        return None
    return unicodedata.normalize("NFKC", value).strip().casefold()
```

- **NFKC** so a compatibility-equivalent spelling cannot slip past.
- **`.strip()`** for surrounding whitespace. Interior whitespace stays
  significant — `cache  budget  audit` is a different name, and collapsing it
  would start matching names that are genuinely distinct.
- **`.casefold()`** rather than `.lower()`, since casefold is the correct
  operation for caseless comparison beyond ASCII.

Applying it to only one site would have created a new asymmetry, with the
subscription check and the collision check using different bases — the same shape
as the original defect. `_is_audit_workflow_subscription` also keeps its
`len(value) == 1` requirement, so this does not quietly relax the rule that the
reporter subscribes to exactly one workflow.

## Test evidence

| check | result |
|---|---|
| `validate-cache-budget-audit-workflow.py` | exit 0 |
| `pytest tests/test_cache_budget_audit_workflow.py` | exit 0, **146 passed** |
| `./tools/aggregate_changelog.sh check` | exit 0 |

### Calibration: the new controls were seen to fail

Not asserted — run against the unfixed validator in a private copy. **3 selected,
3 failed**: title case, all caps, and surrounding whitespace. Each rejecting
control asserts the specific diagnostic naming both files, not merely a non-zero
exit. An accepting control confirms an unrelated sibling name still passes, since
relaxing the comparison naively could start colliding merely-similar names — the
boundary is calibrated in both directions.

## Scope

Deliberately confined to the cache-budget validator and its tests. `#863` is in
flight on `tools/check-merge-readiness.sh`, `docs/DESIGN-ci.md`, and the workflow
files; this branch shares **no file** with it, verified with `comm` on the two
diffs, so neither forces the other to rebase.

Closes #851
