### PR TITLE
fix(release): make the libz3 linkage guard actually fail the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,8 @@ jobs:
             required=$(readelf --version-info "$binary" | grep -o 'GLIBC_[0-9.]*' | sort -V | tail -1)
             test -n "$required"
             test "$(printf '%s\n' GLIBC_2.39 "$required" | sort -V | tail -1)" = GLIBC_2.39
-            ! ldd "$binary" | grep -q libz3
           done
+          ./tools/check-release-binary-linkage.sh rust/target/release/fslc rust/target/release/fslc-lsp
 
       - name: Smoke test (Windows)
         if: runner.os == 'Windows'

--- a/changelog.d/861-release-libz3-abi-guard.fixed.md
+++ b/changelog.d/861-release-libz3-abi-guard.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#861): make the release Linux linkage guard reject binaries dynamically linked to libz3, with accepting and rejecting ldd fixtures. The separate GLIBC behavioral-control finding is tracked in #865.

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -38,6 +38,7 @@ check_rust() {
 # using `cargo-nextest`, which nextest cannot do for doctests. Doctests
 # therefore stay here, explicit and unsharded, rather than silently dropped.
 check_rust_checks() {
+  ./tools/check-release-binary-linkage.sh --self-test
   check_stack_parity
   cargo fmt --manifest-path rust/Cargo.toml --all -- --check
   cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings

--- a/tools/check-release-binary-linkage.sh
+++ b/tools/check-release-binary-linkage.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+check_binary() {
+  local binary="$1" ldd_output linked
+
+  ldd_output="$(ldd "$binary")"
+  if linked="$(grep libz3 <<<"$ldd_output")"; then
+    printf 'release linkage check failed: %s dynamically links libz3:\n%s\n' "$binary" "$linked" >&2
+    return 1
+  fi
+}
+
+run_check() {
+  local binary
+  for binary in "$@"; do
+    check_binary "$binary"
+  done
+}
+
+run_self_test() {
+  local mode="$1" fixture unfixed output
+  fixture="$(mktemp -d)"
+  trap 'rm -rf "$fixture"' RETURN
+  mkdir -p "$fixture/bin"
+  : >"$fixture/fslc"
+  : >"$fixture/fslc-lsp"
+  : >"$fixture/fslc-with-libz3"
+
+  # This PATH stub stands in for Linux ldd so the shell control can run on
+  # any host; it does not claim to inspect a real release artifact.
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    "case \"\$1\" in" \
+    '  *with-libz3) printf "\\tlibz3.so.4 => /fixture/libz3.so.4 (0x00000000)\\n" ;;' \
+    '  *) printf "\\tlibc.so.6 => /fixture/libc.so.6 (0x00000000)\\n" ;;' \
+    'esac' \
+    >"$fixture/bin/ldd"
+  chmod +x "$fixture/bin/ldd"
+
+  # Calibration: this is the pre-fix loop. A bad non-final binary is accepted
+  # because the final clean iteration supplies the loop's successful status.
+  unfixed="$fixture/unfixed-guard.sh"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -e' \
+    'for binary in "$@"; do' \
+    "  ! ldd \"\$binary\" | grep -q libz3" \
+    'done' \
+    >"$unfixed"
+  chmod +x "$unfixed"
+  if PATH="$fixture/bin:$PATH" bash -e "$unfixed" "$fixture/fslc-with-libz3" "$fixture/fslc-lsp"; then
+    echo "release linkage self-test: unfixed guard accepts a libz3-linked non-final binary"
+  else
+    echo "release linkage self-test: unfixed guard did not reproduce the expected hole" >&2
+    return 1
+  fi
+
+  if [ "$mode" = accept ]; then
+    PATH="$fixture/bin:$PATH" "$0" "$fixture/fslc" "$fixture/fslc-lsp"
+    echo "release linkage self-test: clean ldd fixture accepted"
+    return 0
+  fi
+
+  if [ "$mode" = reject ]; then
+    PATH="$fixture/bin:$PATH" "$0" "$fixture/fslc-with-libz3" "$fixture/fslc-lsp"
+    return 0
+  fi
+
+  if ! PATH="$fixture/bin:$PATH" "$0" "$fixture/fslc" "$fixture/fslc-lsp"; then
+    echo "release linkage self-test: clean ldd fixture was rejected" >&2
+    return 1
+  fi
+  echo "release linkage self-test: clean ldd fixture accepted"
+
+  if output="$(PATH="$fixture/bin:$PATH" "$0" "$fixture/fslc-with-libz3" "$fixture/fslc-lsp" 2>&1)"; then
+    echo "release linkage self-test: libz3 ldd fixture unexpectedly passed" >&2
+    return 1
+  fi
+  if ! grep -Fq "$fixture/fslc-with-libz3 dynamically links libz3" <<<"$output"; then
+    printf 'release linkage self-test: rejecting diagnostic was incomplete:\n%s\n' "$output" >&2
+    return 1
+  fi
+  echo "release linkage self-test: libz3 ldd fixture rejected"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  shift
+  if [ "$#" -gt 1 ] || { [ "$#" -eq 1 ] && [ "$1" != accept ] && [ "$1" != reject ]; }; then
+    echo "usage: $0 --self-test [accept|reject]" >&2
+    exit 2
+  fi
+  run_self_test "${1:-all}"
+elif [ "$#" -eq 0 ]; then
+  echo "usage: $0 BINARY [BINARY ...]" >&2
+  exit 2
+else
+  run_check "$@"
+fi


### PR DESCRIPTION
## Problem

`release.yml`'s Linux ABI step guarded against a dynamically linked Z3 with a bare `!` command inside
a loop:

```yaml
for binary in rust/target/release/fslc rust/target/release/fslc-lsp; do
  required=$(readelf --version-info "$binary" | grep -o 'GLIBC_[0-9.]*' | sort -V | tail -1)
  test -n "$required"
  test "$(printf '%s\n' GLIBC_2.39 "$required" | sort -V | tail -1)" = GLIBC_2.39
  ! ldd "$binary" | grep -q libz3          # <- never failed the job
done
```

The two `test` lines above it do fail the step. That last line did not. With `set -e`, a failing
non-final loop iteration does not abort, and the loop's exit status is the status of the **last**
iteration — so a `libz3`-linked `fslc` followed by a clean `fslc-lsp` passed. This is also why the
form looks correct under casual reading and would have behaved correctly with a single binary: the
defect only appears once the loop has more than one iteration.

The guard exists because a release binary that dynamically links `libz3` fails on a machine without a
matching Z3, which is the failure mode users hit first and maintainers see last.

## Contract change

The check moves out of the workflow into `tools/check-release-binary-linkage.sh`, invoked with the
same two binaries the loop covered — `rust/target/release/fslc` and `rust/target/release/fslc-lsp`,
verified to be exactly the loop's set, so coverage does not shrink. The script runs under
`set -euo pipefail` and reports the offending `ldd` lines rather than only failing:

```bash
if linked="$(grep libz3 <<<"$ldd_output")"; then
  printf 'release linkage check failed: %s dynamically links libz3:\n%s\n' "$binary" "$linked" >&2
  return 1
fi
```

No `!`, so nothing is exempt from `errexit`, and each binary is checked on its own status.

`--self-test` is wired into `check_rust_checks()` in `tools/check-native-integration.sh`, which is
already invoked from the required lane. `.github/workflows/ci.yml` is deliberately untouched: #863
changes that file, and the lane needs no new wiring there.

## Test evidence

`./tools/check-release-binary-linkage.sh --self-test` — exit 0, printing all three edges:

```
release linkage self-test: unfixed guard accepts a libz3-linked non-final binary
release linkage self-test: clean ldd fixture accepted
release linkage self-test: libz3 ldd fixture rejected
```

The first line is the calibration that matters: the self-test reconstructs the **pre-fix** loop and
asserts it accepts a `libz3`-linked non-final binary. If that reconstruction ever stops reproducing
the hole, the self-test fails rather than quietly passing — so the control is pinned to the defect it
was written for, not merely to the fixed behaviour.

Re-run by me after rebasing onto `c92b232`: exit 0, same three lines.

Also: `actionlint .github/workflows/release.yml` exit 0 with SC2251 gone and no other findings;
`./tools/aggregate_changelog.sh check` exit 0.

## Stated limits

The self-test installs a PATH stub `ldd`. It assumes a real Z3 dependency appears on an `ldd` output
line containing the literal substring `libz3`. **Real Linux `ldd` output was not verified locally**
(this is macOS); the stub stands in for it and does not claim to inspect a real release artifact. The
first release build after this merge is the first observation of the real thing.

The `GLIBC_2.39` assertions immediately above have only a static presence check and no behavioural
control — a positive path with nothing proving it can reject a too-new binary. That is out of scope
here and tracked in #865.

Closes #861
