### PR TITLE
fix(core): explain when a const shadows an enum member used as a map key

### DIFF
--- a/changelog.d/855-const-enum-map-key-shadowing.fixed.md
+++ b/changelog.d/855-const-enum-map-key-shadowing.fixed.md
@@ -1,0 +1,2 @@
+Fixed (#855): map-key diagnostics now explain when a `const` shadows a member of
+the map key enum and advise renaming one of the colliding declarations.

--- a/rust/fsl-core/src/typecheck.rs
+++ b/rust/fsl-core/src/typecheck.rs
@@ -2,7 +2,7 @@
 
 //! Checked-model expression and statement type validation.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 
 use fsl_syntax::{
@@ -1007,10 +1007,57 @@ fn validate_lvalue(
     }
 }
 
+fn validate_map_key_const_shadowing(
+    target: &LValue,
+    env: &TypeEnv,
+    model: &KernelModel,
+    visible_consts: &BTreeSet<String>,
+    span: Span,
+) -> Result<(), TypecheckError> {
+    match target {
+        LValue::Var(_) => Ok(()),
+        LValue::Index(name, index) => {
+            let (TypeRef::Map(key, _) | TypeRef::Relation(key, _)) = resolve(
+                model,
+                env.get(name)
+                    .ok_or_else(|| error(format!("unknown update target '{name}'")))?,
+            )?
+            else {
+                return Ok(());
+            };
+            let (Expr::Var(member), TypeRef::Named(enum_name)) = (index, key.as_ref()) else {
+                return Ok(());
+            };
+            let Some(TypeDef::Enum { members, .. }) = model.types.get(enum_name) else {
+                return Ok(());
+            };
+            let Some(value) = model.consts.get(member) else {
+                return Ok(());
+            };
+            if !visible_consts.contains(member) || !members.contains(member) {
+                return Ok(());
+            }
+            let (value, actual) = match value {
+                crate::FslValue::Int(value) => (value.to_string(), TypeRef::Int),
+                crate::FslValue::Bool(value) => (value.to_string(), TypeRef::Bool),
+                _ => return Ok(()),
+            };
+            Err(error(format!(
+                "expression of type {actual:?} is not assignable to {key:?}; cause: map key '{member}' resolves to const {member} = {value} ({actual:?}), not to member {member} of enum {enum_name} because a const shadows an enum member of the same name; hint: rename the const or enum member to make the map key unambiguous"
+            ))
+            .with_span(span))
+        }
+        LValue::Field(base, _) => {
+            validate_map_key_const_shadowing(base, env, model, visible_consts, span)
+        }
+    }
+}
+
 fn validate_statement_assignments(
     statement: &Statement,
     env: &TypeEnv,
     model: &KernelModel,
+    visible_consts: &BTreeSet<String>,
 ) -> Result<(), TypecheckError> {
     match statement {
         Statement::Assign {
@@ -1020,6 +1067,7 @@ fn validate_statement_assignments(
         } => {
             let ty = lvalue_type(target, env, model)?;
             ensure_assignable(value, &ty, env, model, *span)?;
+            validate_map_key_const_shadowing(target, env, model, visible_consts, *span)?;
             validate_lvalue(target, env, model, *span)?;
             validate_expression(value, env, model, *span, Some(&ty))
         }
@@ -1030,7 +1078,7 @@ fn validate_statement_assignments(
         } => then_statements
             .iter()
             .chain(else_statements)
-            .try_for_each(|item| validate_statement_assignments(item, env, model)),
+            .try_for_each(|item| validate_statement_assignments(item, env, model, visible_consts)),
         Statement::ForAll {
             binder, statements, ..
         } => {
@@ -1051,9 +1099,11 @@ fn validate_statement_assignments(
             };
             let mut local = env.clone();
             local.insert(name.clone(), ty);
-            statements
-                .iter()
-                .try_for_each(|item| validate_statement_assignments(item, &local, model))
+            let mut local_visible_consts = visible_consts.clone();
+            local_visible_consts.remove(name);
+            statements.iter().try_for_each(|item| {
+                validate_statement_assignments(item, &local, model, &local_visible_consts)
+            })
         }
     }
 }
@@ -1091,7 +1141,18 @@ pub(crate) fn validate_statement_types(
     statement: &Statement,
     model: &KernelModel,
 ) -> Result<(), TypecheckError> {
-    validate_statement_assignments(statement, &base_env(model), model)
+    let visible_consts = model
+        .consts
+        .keys()
+        .filter(|name| {
+            !model
+                .state
+                .iter()
+                .any(|(state_name, _)| state_name == *name)
+        })
+        .cloned()
+        .collect();
+    validate_statement_assignments(statement, &base_env(model), model, &visible_consts)
 }
 
 pub(crate) fn validate_checked_model_types(model: &KernelModel) -> Result<(), TypecheckError> {

--- a/rust/fslc/tests/explicit_engine.rs
+++ b/rust/fslc/tests/explicit_engine.rs
@@ -432,8 +432,33 @@ fn enum_map_key_name_collision_with_an_integer_const_is_rejected_before_runtime(
     assert_eq!(result["kind"], "semantics");
     assert_eq!(
         result["message"],
-        "invalid init statement: expression of type Int is not assignable to Named(\"Key\") at 12:5"
+        "invalid init statement: expression of type Int is not assignable to Named(\"Key\"); cause: map key 'A' resolves to const A = 0 (Int), not to member A of enum Key because a const shadows an enum member of the same name; hint: rename the const or enum member to make the map key unambiguous at 12:5"
     );
+    assert_eq!(result["loc"], json!({"line": 12, "column": 5}));
+}
+
+#[test]
+fn explicit_accepts_enum_map_key_without_a_colliding_const() {
+    let (result, status) = verify(
+        &fixture_path("issue_855_enum_map_key_without_const_collision.fsl"),
+        "explicit",
+        4,
+        &[],
+    );
+    assert_eq!(status, 0);
+    assert_eq!(result["result"], "proved");
+}
+
+#[test]
+fn explicit_accepts_unrelated_const_beside_an_enum_map_key() {
+    let (result, status) = verify(
+        &fixture_path("issue_855_enum_map_key_with_unrelated_const.fsl"),
+        "explicit",
+        4,
+        &[],
+    );
+    assert_eq!(status, 0);
+    assert_eq!(result["result"], "proved");
 }
 
 #[test]

--- a/rust/fslc/tests/fixtures/issue_855_enum_map_key_with_unrelated_const.fsl
+++ b/rust/fslc/tests/fixtures/issue_855_enum_map_key_with_unrelated_const.fsl
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec EnumMapKeyWithUnrelatedConst {
+  const Limit = 0
+  enum Key { A, B }
+
+  state {
+    m: Map<Key, Bool>
+  }
+
+  init {
+    m[A] = true
+    m[B] = false
+  }
+
+  action noop() { }
+}

--- a/rust/fslc/tests/fixtures/issue_855_enum_map_key_without_const_collision.fsl
+++ b/rust/fslc/tests/fixtures/issue_855_enum_map_key_without_const_collision.fsl
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec EnumMapKeyWithoutConstCollision {
+  enum Key { A, B }
+
+  state {
+    m: Map<Key, Bool>
+  }
+
+  init {
+    m[A] = true
+    m[B] = false
+  }
+
+  action noop() { }
+}


### PR DESCRIPTION
## Problem

When a `const` shares a name with a member of a map's key enum, the name resolves to the `const`, so
that member becomes unwritable as a map key. The diagnostic reported only the type mismatch:

```
invalid init statement: expression of type Int is not assignable to Named("Key") at 12:5
```

`m[B] = false` is fine; only `m[A] = true` fails, because `A` resolved to `const A = 0` rather than
`Key::A`. From the author's side the spec looks correct and the message names neither the shadowing nor
what to do about it.

## What this is not

This is **not** a soundness defect and the fix does not treat it as one. Nothing is silently accepted
and no wrong semantics is adopted: `check` fails with a located `kind: semantics` error, and there is no
path that accepts an `Int` as an enum key. Name-resolution precedence is unchanged — altering it would
be a language contract change with a far larger blast radius than the problem, and it is not what #855
asks for.

## Contract change

The existing message, error kind, exit code, and location are all preserved. The diagnostic gains the
cause and a hint:

```
invalid init statement: expression of type Int is not assignable to Named("Key"); cause: map key 'A'
resolves to const A = 0 (Int), not to member A of enum Key because a const shadows an enum member of
the same name; hint: rename the const or enum member to make the map key unambiguous at 12:5
```

**The hint rides inside `message` because the semantic-error envelope has no `hint` field.**
`render_semantic_error` (`rust/fslc/src/verification_output.rs:137`) takes `message`, `loc`, and
`name_resolution` only; the `hint` key at `main.rs:13419` is a pass-through for envelope shapes that
have one. Adding a hint channel to semantic errors would be an envelope contract change outside this
issue's scope. Noting it explicitly so a reviewer does not read the embedding as a style choice and
"fix" it into a field that does not exist.

Related observation, not addressed here: `docs/LANGUAGE.md` specifies check-time rejection "with a hint"
in places, and **#841** is an open three-way mismatch about exactly that. If the documented contract
requires a hint on a semantic error, this missing channel is part of #841's scope.

## Controls

The rejecting control is the pre-existing test for this case, whose expected message is extended and
which now also pins the location (`assert_eq!(result["loc"], json!({"line": 12, "column": 5}))`). Two
accepting controls are added, and the pair is what matters:

| fixture | contents | shows |
|---|---|---|
| `issue_855_enum_map_key_without_const_collision.fsl` | `enum Key { A, B }`, no const | an enum map key still works |
| `issue_855_enum_map_key_with_unrelated_const.fsl` | `const Limit = 0` **plus** `enum Key { A, B }` | the diagnostic fires on the *collision*, not on "a const exists in scope" |

Without the second fixture, an implementation that emitted the cause whenever any const was visible
would pass the accepting side. That is the narrowing the pair establishes.

## Test evidence

Reported by the implementer, with the calibration run as a reverted-detector rather than as a reading
of the new tests:

- fix reverted: 1 test selected, **1 failed** on the old message
- fix restored: focused rejecting and accepting controls, 3 passed
- `fsl-core` package tests: passed
- `cargo fmt --check`: passed
- workspace Clippy, `--keep-going` with `-D warnings`: passed
- `./tools/aggregate_changelog.sh check`: passed

**Disclosure about my own verification.** For the other PRs in this batch I re-ran the calibration
myself rather than relying on the reported result. Here I did not: rebasing onto `46ce2db` invalidated
the `fsl-core` build cache and three other cargo tracks were already running on this machine, which is
above the measured concurrency ceiling of two — starting a fourth would have made every timing on the
box untrustworthy, which has already cost this session one unusable measurement. What I did verify
directly is the diff scope (diagnostic and tests only, no resolution change), that the two accepting
fixtures differ in the discriminating way described above, that `loc` is asserted, and that the message
prefix and error kind are unchanged. The calibration itself rests on the implementer's report and on
CI.

Closes #855
