### PR TITLE
test(fslc): cover the refine chain CLI path and its failed_link envelope

### DIFF
--- a/changelog.d/850-refine-chain-cli-tests.required.md
+++ b/changelog.d/850-refine-chain-cli-tests.required.md
@@ -1,0 +1,2 @@
+Required (#850): Native CLI regression coverage now detects incorrect failed-link
+identities and composed action maps in multi-link `fslc refine` chains.

--- a/rust/fslc/tests/refine_chain_cli.rs
+++ b/rust/fslc/tests/refine_chain_cli.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native CLI coverage for `fslc refine`'s multi-link chain route (issue #850).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use serde_json::{Value, json};
+
+static NEXT_SCRATCH: AtomicUsize = AtomicUsize::new(0);
+
+struct ChainFiles {
+    implementation: PathBuf,
+    middle: PathBuf,
+    top: PathBuf,
+    impl_to_middle: PathBuf,
+    middle_to_top: PathBuf,
+    broken_middle_to_top: PathBuf,
+}
+
+fn scratch(label: &str) -> PathBuf {
+    let ordinal = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+    let directory = std::env::temp_dir().join(format!(
+        "fslc-issue-850-{label}-{}-{ordinal}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&directory).expect("create scratch directory");
+    directory
+}
+
+fn write(path: &Path, source: &str) {
+    std::fs::write(path, source).expect("write fixture");
+}
+
+fn chain_files(directory: &Path) -> ChainFiles {
+    let implementation = directory.join("impl.fsl");
+    let middle = directory.join("middle.fsl");
+    let top = directory.join("top.fsl");
+    let impl_to_middle = directory.join("impl-middle.fsl");
+    let middle_to_top = directory.join("middle-top.fsl");
+    let broken_middle_to_top = directory.join("middle-top-broken.fsl");
+
+    // The three layers deliberately use distinct enum names. `refine` merges
+    // type metadata by name, so reusing a name would let this fixture hide a
+    // layer's members instead of exercising the complete chain.
+    write(
+        &implementation,
+        r"spec ImplLayer {
+  enum ImplPhase { ImplIdle, ImplDone }
+  state { impl_phase: ImplPhase }
+  init { impl_phase = ImplIdle }
+  action advance() { requires impl_phase == ImplIdle impl_phase = ImplDone }
+  action ping() { requires impl_phase == ImplIdle impl_phase = ImplIdle }
+}
+",
+    );
+    write(
+        &middle,
+        r"spec MiddleLayer {
+  enum MiddlePhase { MiddleWaiting, MiddleComplete }
+  state { middle_phase: MiddlePhase }
+  init { middle_phase = MiddleWaiting }
+  action advance_middle() { requires middle_phase == MiddleWaiting middle_phase = MiddleComplete }
+  action ping_middle() { requires middle_phase == MiddleWaiting middle_phase = MiddleWaiting }
+}
+",
+    );
+    write(
+        &top,
+        r"spec TopLayer {
+  enum TopPhase { TopOpen, TopClosed }
+  state { top_phase: TopPhase }
+  init { top_phase = TopOpen }
+  action advance_top() { requires top_phase == TopOpen top_phase = TopClosed }
+}
+",
+    );
+    write(
+        &impl_to_middle,
+        r"refinement ImplToMiddle {
+  impl ImplLayer
+  abs MiddleLayer
+  enum conversion impl_middle ImplPhase -> MiddlePhase {
+    ImplIdle -> MiddleWaiting
+    ImplDone -> MiddleComplete
+  }
+  map middle_phase = convert(impl_middle, impl_phase)
+  action advance() -> advance_middle()
+  action ping() -> ping_middle()
+}
+",
+    );
+    write(
+        &middle_to_top,
+        r"refinement MiddleToTop {
+  impl MiddleLayer
+  abs TopLayer
+  enum conversion middle_top MiddlePhase -> TopPhase {
+    MiddleWaiting -> TopOpen
+    MiddleComplete -> TopClosed
+  }
+  map top_phase = convert(middle_top, middle_phase)
+  action advance_middle() -> advance_top()
+  action ping_middle() -> stutter
+}
+",
+    );
+    write(
+        &broken_middle_to_top,
+        r"refinement BrokenMiddleToTop {
+  impl MiddleLayer
+  abs TopLayer
+  enum conversion middle_top MiddlePhase -> TopPhase {
+    MiddleWaiting -> TopOpen
+    MiddleComplete -> TopClosed
+  }
+  map top_phase = TopOpen
+  action advance_middle() -> advance_top()
+  action ping_middle() -> stutter
+}
+",
+    );
+
+    ChainFiles {
+        implementation,
+        middle,
+        top,
+        impl_to_middle,
+        middle_to_top,
+        broken_middle_to_top,
+    }
+}
+
+fn run(args: &[String]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .output()
+        .expect("run native CLI");
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc {}`: {error}; stderr={}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let status = output
+        .status
+        .code()
+        .expect("native CLI terminated without a signal");
+    (value, status)
+}
+
+fn chain_args(files: &ChainFiles, final_mapping: &Path) -> Vec<String> {
+    vec![
+        "refine".to_owned(),
+        files.implementation.display().to_string(),
+        files.middle.display().to_string(),
+        files.impl_to_middle.display().to_string(),
+        files.top.display().to_string(),
+        final_mapping.display().to_string(),
+        "--depth".to_owned(),
+        "2".to_owned(),
+    ]
+}
+
+#[test]
+fn refine_chain_composes_action_maps_across_three_distinct_layers() {
+    let files = chain_files(&scratch("success"));
+    let (result, status) = run(&chain_args(&files, &files.middle_to_top));
+
+    assert_eq!(status, 0, "{result}");
+    assert_eq!(result["result"], "refines", "{result}");
+    assert_eq!(
+        result["chain"],
+        json!(["ImplLayer", "MiddleLayer", "TopLayer"]),
+        "{result}"
+    );
+    assert_eq!(
+        result["action_map"],
+        json!({"advance": "advance_top", "ping": "stutter"}),
+        "{result}"
+    );
+}
+
+#[test]
+fn refine_chain_reports_the_intermediate_link_that_fails() {
+    let files = chain_files(&scratch("intermediate-failure"));
+    let (result, status) = run(&chain_args(&files, &files.broken_middle_to_top));
+
+    assert_eq!(status, 1, "{result}");
+    assert_eq!(result["result"], "refinement_failed", "{result}");
+    assert_eq!(
+        result["failed_link"],
+        json!({
+            "from": "MiddleLayer",
+            "to": "TopLayer",
+            "kind": "abs_state_mismatch",
+        }),
+        "{result}"
+    );
+}
+
+#[test]
+fn refine_chain_rejects_an_unpaired_final_operand() {
+    let files = chain_files(&scratch("unpaired-operand"));
+    let args = vec![
+        "refine".to_owned(),
+        files.implementation.display().to_string(),
+        files.middle.display().to_string(),
+        files.impl_to_middle.display().to_string(),
+        files.top.display().to_string(),
+        "--depth".to_owned(),
+        "2".to_owned(),
+    ];
+    let (result, status) = run(&args);
+
+    assert_eq!(status, 2, "{result}");
+    assert_eq!(result["result"], "error", "{result}");
+    assert_eq!(result["kind"], "io", "{result}");
+    assert_eq!(
+        result["message"], "refine chain must list (abs map) pairs after the first mapping",
+        "{result}"
+    );
+}


### PR DESCRIPTION
## Problem

`run_refine_chain` (`rust/fslc/src/main.rs`) had **no executable test coverage**, although it emits a
JSON envelope no other code path produces.

The route into it is narrow: `fslc refine IMPL ABS MAPPING <ABS MAP>...` with more than three path
operands. Three operands reach `run_refine`; an odd count is rejected with exit 2 by the operand guard
at `main.rs:1578-1585` before the chain function is entered. Nothing in the repository passed four or
more. `fslc chain` is unrelated — it dispatches to `run_project_chain`.

The decisive evidence was that `failed_link` is a JSON key only this function emits, and
`grep -rn --include='*.rs' 'failed_link' rust/` returned exactly one hit: the emit site. So `chain`,
`failed_link`, and the composed `action_map` were all unverified.

## What this PR is not

**No production code changes.** `git diff origin/main -- rust/fslc/src/main.rs` is empty.

I want to be explicit about this because I got it wrong mid-review and briefly directed the work down
the wrong path. I read the working tree with `sed` while a calibration mutation was applied, saw
`"from": abs_name, "to": abs_name`, and concluded `failed_link` reported the same layer for both ends.
`origin/main` in fact reads `"from": impl_name, "to": abs_name`, which is correct. The implementer had
announced that exact mutation beforehand; my "correction" of their label was the error, not their label.
The changelog category was moved from `fixed` to `required` for the same reason — `changelog.d/README.md`
defines `fixed` as "a defect corrected", and no defect was corrected here.

## Coverage added

`rust/fslc/tests/refine_chain_cli.rs`, three tests:

| test | asserts |
|---|---|
| `refine_chain_composes_action_maps_across_three_distinct_layers` | the composed `action_map` across a clean three-layer chain |
| `refine_chain_reports_the_intermediate_link_that_fails` | the exact `failed_link`, including which link failed |
| `refine_chain_rejects_an_unpaired_final_operand` | the CLI's pre-dispatch exit-2 diagnostic |

Fixtures use distinct enum and type names per layer — `ImplPhase`, `MiddlePhase`, `TopPhase`. This
matters: `refine` merges layer types by name, so identical names across layers silently drop members and
would have produced passing tests that proved nothing.

## Mutation-kill evidence

Each mutation was applied to `main.rs`, the failure captured with its actual output, then reverted and
the revert proven with `git diff origin/main -- rust/fslc/src/main.rs` returning empty.

| mutation | observed |
|---|---|
| break the `action_map` composition | actual map `{"advance":"advance_middle","ping":"ping_middle"}` against expected `{"advance":"advance_top","ping":"stutter"}` — failed |
| `failed_link.from` → `abs_name` | actual `{"from":"TopLayer","to":"TopLayer","kind":"abs_state_mismatch"}` against expected `MiddleLayer → TopLayer` — failed |
| bypass the odd-operand guard | exit 0 with a truncated two-layer `refines` envelope — failed |

Each names the wrong value it produced, not merely that a test failed. A test that fails on a mutation
for an unrelated reason is not a calibrated control.

**Scope note on the third row, stated rather than glossed:** that control covers the CLI operand guard
*before* `run_refine_chain`, not malformed-pair behaviour inside it. It is worth having, but it is not
chain-path coverage and should not be read as such.

## Test evidence

- `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --locked` — exit 0, 133 suites, 898 passed,
  0 failed
- all three `refine_chain_cli` tests pass against unmodified `main`, which is the expected result now
  that no defect is claimed
- `cargo fmt --check`, workspace Clippy with `--keep-going` and `-D warnings` — passed
- `./tools/aggregate_changelog.sh check` — PASS

Closes #850
