### PR TITLE
test(release): calibrate the Linux ABI guards and correct the linkage explanation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,11 +90,6 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          for binary in rust/target/release/fslc rust/target/release/fslc-lsp; do
-            required=$(readelf --version-info "$binary" | grep -o 'GLIBC_[0-9.]*' | sort -V | tail -1)
-            test -n "$required"
-            test "$(printf '%s\n' GLIBC_2.39 "$required" | sort -V | tail -1)" = GLIBC_2.39
-          done
           ./tools/check-release-binary-linkage.sh rust/target/release/fslc rust/target/release/fslc-lsp
 
       - name: Smoke test (Windows)

--- a/changelog.d/865-release-glibc-behavior.required.md
+++ b/changelog.d/865-release-glibc-behavior.required.md
@@ -1,0 +1,3 @@
+Required (#865): Added accepting and rejecting fixture controls for the Linux
+release GLIBC ABI guard. The required product gate now exercises the deployed
+guard with compliant GLIBC_2.39 and rejecting GLIBC_2.40 `readelf` fixtures.

--- a/changelog.d/871-linkage-calibration-cause.fixed.md
+++ b/changelog.d/871-linkage-calibration-cause.fixed.md
@@ -1,0 +1,3 @@
+Fixed (#871): Corrected the release-linkage calibration to name both conditions
+behind the former hole: `!` exempted the failing pipeline from `errexit`, and
+the final clean iteration then supplied the loop's status.

--- a/rust/fslc/tests/native_integration.rs
+++ b/rust/fslc/tests/native_integration.rs
@@ -420,7 +420,13 @@ fn native_release_unit_is_atomic_pinned_and_platform_closed() {
         assert!(workflow.contains(&format!("target: {target}")));
     }
     assert!(workflow.contains("os: ubuntu-24.04\n            target: linux-x64"));
-    assert!(workflow.contains("GLIBC_2.39"));
+    assert!(workflow.contains(
+        "./tools/check-release-binary-linkage.sh rust/target/release/fslc rust/target/release/fslc-lsp"
+    ));
+    let release_abi = std::fs::read_to_string(root.join("tools/check-release-binary-linkage.sh"))
+        .expect("release ABI guard");
+    assert!(release_abi.contains("readelf --version-info"));
+    assert!(release_abi.contains("GLIBC_2.39"));
     assert!(!workflow.contains("target: macos-x64"));
     assert!(workflow.contains("\"fslc ${GITHUB_REF_NAME#v}\""));
     assert_windows_release_smoke(&workflow);

--- a/tools/check-release-binary-linkage.sh
+++ b/tools/check-release-binary-linkage.sh
@@ -13,9 +13,25 @@ check_binary() {
   fi
 }
 
+check_glibc() {
+  local binary="$1" required
+
+  required="$(readelf --version-info "$binary" | grep -o 'GLIBC_[0-9.]*' | sort -V | tail -1)"
+  if ! test -n "$required"; then
+    printf 'release ABI check failed: %s has no GLIBC requirement\n' "$binary" >&2
+    return 1
+  fi
+  if ! test "$(printf '%s\n' GLIBC_2.39 "$required" | sort -V | tail -1)" = GLIBC_2.39; then
+    printf 'release ABI check failed: %s requires %s; maximum supported GLIBC version is GLIBC_2.39\n' \
+      "$binary" "$required" >&2
+    return 1
+  fi
+}
+
 run_check() {
   local binary
   for binary in "$@"; do
+    check_glibc "$binary"
     check_binary "$binary"
   done
 }
@@ -28,6 +44,7 @@ run_self_test() {
   : >"$fixture/fslc"
   : >"$fixture/fslc-lsp"
   : >"$fixture/fslc-with-libz3"
+  : >"$fixture/fslc-with-new-glibc"
 
   # This PATH stub stands in for Linux ldd so the shell control can run on
   # any host; it does not claim to inspect a real release artifact.
@@ -39,6 +56,17 @@ run_self_test() {
     'esac' \
     >"$fixture/bin/ldd"
   chmod +x "$fixture/bin/ldd"
+
+  # This PATH stub controls only the GLIBC tokens the guard parses. It does
+  # not claim that these fixtures reproduce real Linux readelf output.
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    "case \"\$2\" in" \
+    '  *with-new-glibc) printf "Version needs section:\\n  Name: GLIBC_2.40\\n" ;;' \
+    '  *) printf "Version needs section:\\n  Name: GLIBC_2.39\\n" ;;' \
+    'esac' \
+    >"$fixture/bin/readelf"
+  chmod +x "$fixture/bin/readelf"
 
   # Calibration: this is the pre-fix loop. `!` exempts the failing pipeline
   # from errexit, so a bad non-final binary does not abort; the final clean
@@ -61,13 +89,20 @@ run_self_test() {
 
   if [ "$mode" = accept ]; then
     PATH="$fixture/bin:$PATH" "$0" "$fixture/fslc" "$fixture/fslc-lsp"
-    echo "release linkage self-test: clean ldd fixture accepted"
+    echo "release linkage self-test: clean ldd and compliant readelf fixtures accepted"
     return 0
   fi
 
   if [ "$mode" = reject ]; then
     PATH="$fixture/bin:$PATH" "$0" "$fixture/fslc-with-libz3" "$fixture/fslc-lsp"
     return 0
+  fi
+
+  if output="$(PATH="$fixture/bin:$PATH" "$0" "$fixture/fslc" 2>&1)"; then
+    echo "release linkage self-test: compliant readelf fixture accepted (GLIBC_2.39)"
+  else
+    printf 'release linkage self-test: compliant readelf fixture was rejected:\n%s\n' "$output" >&2
+    return 1
   fi
 
   if ! PATH="$fixture/bin:$PATH" "$0" "$fixture/fslc" "$fixture/fslc-lsp"; then
@@ -85,6 +120,16 @@ run_self_test() {
     return 1
   fi
   echo "release linkage self-test: libz3 ldd fixture rejected"
+
+  if output="$(PATH="$fixture/bin:$PATH" "$0" "$fixture/fslc-with-new-glibc" 2>&1)"; then
+    echo "release linkage self-test: too-new readelf fixture unexpectedly passed" >&2
+    return 1
+  fi
+  if ! grep -Fq 'requires GLIBC_2.40; maximum supported GLIBC version is GLIBC_2.39' <<<"$output"; then
+    printf 'release linkage self-test: GLIBC rejection did not show required and maximum versions:\n%s\n' "$output" >&2
+    return 1
+  fi
+  echo "release linkage self-test: too-new readelf fixture rejected (GLIBC_2.40 > GLIBC_2.39)"
 }
 
 if [ "${1:-}" = "--self-test" ]; then

--- a/tools/check-release-binary-linkage.sh
+++ b/tools/check-release-binary-linkage.sh
@@ -40,8 +40,9 @@ run_self_test() {
     >"$fixture/bin/ldd"
   chmod +x "$fixture/bin/ldd"
 
-  # Calibration: this is the pre-fix loop. A bad non-final binary is accepted
-  # because the final clean iteration supplies the loop's successful status.
+  # Calibration: this is the pre-fix loop. `!` exempts the failing pipeline
+  # from errexit, so a bad non-final binary does not abort; the final clean
+  # iteration then supplies the loop's successful status.
   unfixed="$fixture/unfixed-guard.sh"
   printf '%s\n' \
     '#!/usr/bin/env bash' \


### PR DESCRIPTION
Two issues in one PR because they touch the same region of `release.yml`'s Linux ABI step and splitting
them would put two PRs on the same lines.

## #871 — correct a wrong causal explanation, which was mine

`tools/check-release-binary-linkage.sh` documented the defect it exists to catch as:

```
# Calibration: this is the pre-fix loop. A bad non-final binary is accepted
# because the final clean iteration supplies the loop's successful status.
```

That names the loop's exit status as the sole cause. It is half of it. Reproduced locally, both rows
executed rather than reasoned about:

| reproduction | result |
|---|---|
| the pre-fix loop `! ldd "$binary" \| grep -q libz3`, dirty binary then clean | **exit 0**, loop completed |
| the same loop with a bare failing `test` on a non-final iteration | **exit 1**, aborted before completion |

The second row is decisive. Under `set -e` a bare non-final failure does not reach the end of the loop, so
final-iteration status cannot by itself explain the hole. The `!` prefix is the necessary condition — it
suppresses the abort — and only then does the last iteration's status mask the earlier failure. The
comment now says both, in that order.

The wording was mine. The implementer's original framing was `!` exempting the line from `errexit`, which
was correct; I judged the loop-status framing "more precise", directed it into `46ce2db`'s commit body,
and asserted that from reading rather than from the two-line probe that settles it. `46ce2db`'s body is
immutable; PR #867's body is corrected, and this fixes the copy that lives in code, which is the one a
future reader will use. Generalising from the old wording to "non-final loop failures are ignored under
`set -e`" would lead someone to write the unsafe pattern believing it safe — the exact failure this script
prevents.

## #865 — the GLIBC assertions had no behavioural control

The same step enforced a non-empty GLIBC requirement and a `GLIBC_2.39` maximum with two bare `test`
lines. Their only repository control was `rust/fslc/tests/native_integration.rs`, asserting the workflow
**text** contains `GLIBC_2.39` — a presence check on a string, not evidence the guard can reject a too-new
binary.

Both checks move into `tools/check-release-binary-linkage.sh`, already exercised by the required native
integration gate. **The threshold and the release artifact contract are unchanged**, as #865 requires. Two
side effects worth naming: the bare `test` lines become diagnostics that name the values
(`%s requires %s; maximum supported GLIBC version is %s`), and the self-test asserts the **message
content** rather than only a non-zero exit, so it establishes the rejection happened for the right reason.

`--self-test` now prints five edges, verified by me on this head:

```
release linkage self-test: unfixed guard accepts a libz3-linked non-final binary
release linkage self-test: compliant readelf fixture accepted (GLIBC_2.39)
release linkage self-test: clean ldd fixture accepted
release linkage self-test: libz3 ldd fixture rejected
release linkage self-test: too-new readelf fixture rejected (GLIBC_2.40 > GLIBC_2.39)
```

Two accepting and two rejecting, one pair per guard, plus the pre-fix reproduction. Each line means one
thing — which it did not at first. The GLIBC accepting case was initially covered only implicitly: the
`fslc`/`fslc-lsp` fixtures hit the stub's default arm and so passed the GLIBC guard too, under a line
labelled `clean ldd fixture accepted`. That detects a broken GLIBC accepting path, but attributes the
coverage to `ldd`, so someone editing the ldd fixtures could remove it while the label still read as
intact. It now has its own named assertion.

Calibrated in both directions rather than asserted:

- rejecting: `GLIBC_2.40` exits 1 with `requires GLIBC_2.40; maximum supported GLIBC version is GLIBC_2.39`
- accepting: a temporary `GLIBC_2.38` threshold made the named `GLIBC_2.39` acceptance **fail**, with the
  produced value and the erroneous maximum beside it

The second is what separates the accepting line from a preservation control that would keep passing under
any change.

## Coverage check

Verified directly, not assumed: `release.yml`'s diff removes exactly the two `test` lines and the `for`
loop that held them, the script carries both checks, and the invocation passes the same two binaries the
loop covered — `rust/target/release/fslc` and `fslc-lsp`. No Windows or macOS binary previously received
either check.

## Stated limits

The self-test stubs `readelf` and `ldd` on PATH. It controls only the GLIBC tokens the guard parses, and
**real Linux `readelf` and `ldd` output was not verified** — this is macOS. The stubs stand in for them and
do not claim to inspect a real release artifact; the first release build after merge is the first
observation of the real thing. This is the same disclosure #867 made for `ldd`, repeated because a guard
that works only against its own stub reads as covered while covering nothing.

`actionlint .github/workflows/release.yml` exits 0. `./tools/aggregate_changelog.sh check` passes.

Closes #865
Closes #871
