### PR TITLE
fix(causal): report a liveness violation found in the initial state instead of a false pass

### DIFF
--- a/changelog.d/875-causal-initial-liveness.fixed.md
+++ b/changelog.d/875-causal-initial-liveness.fixed.md
@@ -1,0 +1,2 @@
+Fixed (#875): causal expectation replay now reports a `within 0` liveness
+violation found in the initial state instead of returning a false `pass`.

--- a/rust/fslc/src/causal.rs
+++ b/rust/fslc/src/causal.rs
@@ -841,6 +841,9 @@ fn run_causal_observe_expectations(
         }
     }
 
+    // Track per-expectation verdicts and violation step.
+    let mut verdicts: Vec<Option<usize>> = vec![None; compiled.len()];
+
     // Observe initial state (step 0).
     let init_state = monitor.state.clone();
     for (index, (expectation, liveness)) in compiled
@@ -849,22 +852,26 @@ fn run_causal_observe_expectations(
         .enumerate()
     {
         let extended = extend_with_ghost(&init_state, expectation, "", &spec_model);
-        if let Err(error) = liveness.observe(&extended, 0) {
-            return (
-                error_output(
-                    "internal",
-                    &format!(
-                        "liveness observe init for '{}': {error}",
-                        compiled[index].id
+        match liveness.observe(&extended, 0) {
+            Ok(Some(_violation)) => {
+                verdicts[index] = Some(0);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                return (
+                    error_output(
+                        "internal",
+                        &format!(
+                            "liveness observe init for '{}': {error}",
+                            compiled[index].id
+                        ),
                     ),
-                ),
-                3,
-            );
+                    3,
+                );
+            }
         }
     }
 
-    // Track per-expectation verdicts and violation step.
-    let mut verdicts: Vec<Option<usize>> = vec![None; compiled.len()];
     let mut events_observed = 0_usize;
     let events_unmapped = 0_usize;
 

--- a/rust/fslc/tests/causal_cli.rs
+++ b/rust/fslc/tests/causal_cli.rs
@@ -730,6 +730,90 @@ fn run_observe(extra: &[&str]) -> (Value, i32) {
     run_cli(&args)
 }
 
+const INITIAL_LIVENESS_EXPECTATION: &str = r#"causal ImmediateLiveness {
+  uses ops from "incident_system.fsl"
+
+  timebase day
+  horizon 1
+
+  clock ops_clock {
+    kernel ops
+    1 tick = 1 day
+  }
+
+  expectation E_Immediate {
+    trigger predicate ops { guardrails >= 1 }
+    response predicate ops { alert_precision >= 4 }
+    within 0
+    clock ops_clock
+  }
+}
+"#;
+
+fn observe_initial_liveness(initial_guardrails: u8, log: &Path) -> (Value, i32) {
+    let scratch = tempfile_dir();
+    let model = scratch.join("immediate_liveness.causal.fsl");
+    let companion = scratch.join("incident_system.fsl");
+    std::fs::write(&model, INITIAL_LIVENESS_EXPECTATION).expect("write causal model");
+    let kernel =
+        std::fs::read_to_string(repository_root().join("examples/causal/incident_system.fsl"))
+            .expect("read companion kernel")
+            .replace(
+                "guardrails = 0",
+                &format!("guardrails = {initial_guardrails}"),
+            );
+    std::fs::write(&companion, kernel).expect("write companion kernel");
+
+    run_cli(&[
+        "causal",
+        "observe-expectations",
+        model.to_str().expect("utf-8 model path"),
+        "--from-log",
+        log.to_str().expect("utf-8 log path"),
+        "--mapping",
+        OBS_MAPPING,
+        "--scope",
+        OBS_SCOPE,
+        "--period-start",
+        "2026-01-01",
+        "--period-end",
+        "2026-03-31",
+    ])
+}
+
+fn empty_observation_log() -> PathBuf {
+    let log = tempfile_dir().join("empty.jsonl");
+    std::fs::write(&log, "").expect("write empty observation log");
+    log
+}
+
+fn later_enabled_observation_log() -> PathBuf {
+    let log = tempfile_dir().join("later.jsonl");
+    std::fs::write(
+        &log,
+        r#"{"action":"tune_alerts","params":{},"state":{"guardrails":1,"alert_precision":4,"mttr_hours":24}}
+"#,
+    )
+    .expect("write later observation log");
+    log
+}
+
+fn remove_observed_event_counts(envelope: &mut Value) {
+    envelope
+        .as_object_mut()
+        .expect("observation envelope")
+        .remove("events_observed");
+    for expectation in envelope["expectations"]
+        .as_array_mut()
+        .expect("expectations")
+    {
+        expectation["event_counts"]
+            .as_object_mut()
+            .expect("event counts")
+            .remove("observed");
+    }
+}
+
 fn generated_evidence_paths(directory: &Path) -> (Vec<PathBuf>, Vec<PathBuf>) {
     let mut evidence = Vec::new();
     let mut lifecycle = Vec::new();
@@ -813,6 +897,66 @@ fn observe_expectations_pass_and_violated_golden() {
             "must include temporal co-occurrence caveat"
         );
     }
+}
+
+#[test]
+fn observe_expectations_reports_initial_liveness_violation() {
+    let log = empty_observation_log();
+    let (output, status) = observe_initial_liveness(1, &log);
+
+    assert_eq!(status, 0, "{output}");
+    assert_eq!(output["result"], "causal_expectations_observed");
+    assert_eq!(output["expectations"][0]["verdict"], "violated");
+}
+
+#[test]
+fn observe_expectations_keeps_clean_initial_liveness_pass() {
+    let log = empty_observation_log();
+    let (output, status) = observe_initial_liveness(0, &log);
+
+    assert_eq!(status, 0, "{output}");
+    assert_eq!(output["result"], "causal_expectations_observed");
+    assert_eq!(output["expectations"][0]["verdict"], "pass");
+}
+
+#[test]
+fn observe_expectations_initial_liveness_violation_skips_later_events() {
+    let log = later_enabled_observation_log();
+    let (output, status) = observe_initial_liveness(1, &log);
+
+    assert_eq!(status, 0, "{output}");
+    assert_eq!(output["result"], "causal_expectations_observed");
+    assert_eq!(output["expectations"][0]["verdict"], "violated");
+}
+
+#[test]
+fn observe_expectations_initial_and_later_liveness_violations_have_matching_envelopes() {
+    let initial_log = empty_observation_log();
+    let (initial, initial_status) = observe_initial_liveness(1, &initial_log);
+    let (later, later_status) = observe_initial_liveness(0, &repository_root().join(OBS_LOG));
+
+    assert_eq!(initial_status, 0, "{initial}");
+    assert_eq!(later_status, 0, "{later}");
+    assert_eq!(initial["expectations"][0]["verdict"], "violated");
+    assert_eq!(later["expectations"][0]["verdict"], "violated");
+    assert_eq!(initial["events_observed"], 0);
+    assert!(
+        later["events_observed"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
+    assert_eq!(initial["expectations"][0]["event_counts"]["observed"], 0);
+    assert!(
+        later["expectations"][0]["event_counts"]["observed"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
+
+    let mut comparable_initial = initial;
+    let mut comparable_later = later;
+    remove_observed_event_counts(&mut comparable_initial);
+    remove_observed_event_counts(&mut comparable_later);
+    assert_eq!(comparable_initial, comparable_later);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`rust/fslc/src/causal.rs` handled only the `Err` arm of `BoundedLivenessMonitor::observe` while observing
the initial state, so an `Ok(Some(BoundedLivenessViolation))` at step 0 was discarded. The dropped
violation left `verdicts[index]` unset, and result construction reports an unset verdict as `"pass"`.

**A liveness violation detected at the initial state was reported as a passing expectation.** Nothing
crashed and nothing warned. `AGENTS.md` names this class as more dangerous than a crash.

## Fix

`verdicts` moves above the initial-state loop, and the `if let Err` becomes an exhaustive `match` with no
wildcard:

```rust
match liveness.observe(&extended, 0) {
    Ok(Some(_violation)) => { verdicts[index] = Some(0); }
    Ok(None) => {}
    Err(error) => { return (error_output("internal", ...), 3); }
}
```

This is **the same shape the later-event path already used** — `Ok(Some(_violation)) => verdicts[index] = Some(step)`
at `causal.rs:1145` — rather than a parallel recording path. I checked that specifically, because two
parallel recorders can drift and the envelope-parity control would then be the only thing holding them
together. They are identical, so that control is confirmatory rather than load-bearing.

The exhaustive match matters beyond this fix: a future variant of the return type forces a decision
instead of falling into a wildcard, which is what `AGENTS.md` asks for.

## Why no lint could have caught it

`observe` returns `Result<Option<BoundedLivenessViolation>, RuntimeError>`. `#[must_use]` on the inner
type does not propagate through `Option`, and `Option` is not itself `#[must_use]`. PR #866 annotated the
outcome-carrying types and closed that class for directly-returned values; this shape is the residue and
is invisible to the mechanism that fix installs. **No `#[must_use]` is added here** — it would be
ineffective rather than merely unnecessary, and adding it would read as a fix while changing nothing. The
mechanism gap is #868.

This defect was found by auditing for that gap, which is the argument for having filed #868 as an
abstract mechanism issue rather than closing it as theoretical.

## End-to-end reproduction, which closes the limit #875 was filed with

#875 recorded the external JSON reporting `pass` as **source-traced, not CLI-executed**, and held that
distinction deliberately. It is now executed:

- before the fix, the end-to-end empty-log reproduction **exited 0 and emitted verdict `pass`**; the
  rejecting CLI test failed with `actual String("pass") versus expected violated`, test exit 101
- before the fix, an enabled subsequent event after the same initial violation produced **exit 3**:
  `bounded liveness expected step 0, got 1` — the second failure shape #875 predicted, because a violation
  returns before advancing `next_step`

Both shapes are covered, not just the one that was easiest to reach.

## Controls

Four, in `rust/fslc/tests/causal_cli.rs`:

| control | role |
|---|---|
| `observe_expectations_reports_initial_liveness_violation` | detector |
| `observe_expectations_initial_liveness_violation_skips_later_events` | detector, subsequent-event shape |
| `observe_expectations_initial_and_later_liveness_violations_have_matching_envelopes` | envelope parity |
| `observe_expectations_keeps_clean_initial_liveness_pass` | accepting |

Envelope parity excludes **only** the observed event counts, which measured `0` versus `6` in the two runs
— the values are reported rather than the field being waved off as "run-dependent". Everything else is
compared. That wording is deliberate: PR #866 shipped an exclusion list transcribed from a struct's field
names in which seven of eight entries named fields absent from both envelopes, weakening nothing while
manufacturing the appearance of a considered decision.

## Calibration, re-run by me rather than taken from the report

Reverted the fix to `Ok(Some(_violation)) => {}` and ran the four controls. Independently reproduced by a
reviewer in a separate worktree against this head:

| | |
|---|---|
| unmodified `causal_cli` | exit 0, 45 passed |
| initial-arm mutation | exit 101, 42 passed / 3 failed |
| — two detectors | `left: String("pass"), right: "violated"` |
| — subsequent-event detector | `left: 3, right: 0`, non-consecutive-step error |
| — accepting control | **passed** |
| restored | full diff exit 0; `causal_cli` exit 0, 45 passed |

**The three detectors do not fail identically, and that is the point.** Two fail on the verdict; the
subsequent-event one fails with `exit 3` and `bounded liveness expected step 0, got 1`. Those are the two
failure modes #875 predicted, so reporting them as one shape would hide that the second control exercises a
different path rather than the first one twice. My first draft of this section did exactly that — I saw
three FAILED lines, read one assertion's detail, and generalised it across all three.

The accepting control **kept passing**, which is right: a clean initial observation should report `pass`
with or without the fix. That asymmetry is what distinguishes the three detectors from the preservation
control, and it is observable only by running the mutation rather than by reading the labels.

Also reported by the implementer and not re-run by me: the complete `causal_cli` target passed 45/45,
`cargo fmt --check`, workspace Clippy with `--keep-going` and `-D warnings`, and
`./tools/aggregate_changelog.sh check`.

Closes #875
