### PR TITLE
fix(ci): make the cache-audit uniqueness check able to block a merge

### DIFF
--- a/.github/workflows/cache-budget-audit-wiring.yml
+++ b/.github/workflows/cache-budget-audit-wiring.yml
@@ -3,20 +3,19 @@
 name: cache budget audit wiring
 
 # This is configuration-conformance evidence for cache-budget-audit.yml, not
-# product verification in docs/DESIGN-ci.md's Rust/WASM/native-Z3 sense.  It
-# uses PyYAML, a third-party repository-tooling dependency, so it deliberately
-# runs in its own workflow rather than in merge-readiness.yml's stdlib-only
-# automation-contracts lane (see tools/check-merge-readiness.sh).
+# product verification in docs/DESIGN-ci.md's Rust/WASM/native-Z3 sense. It
+# remains an unfiltered corroborating check for pull requests outside
+# merge-readiness.yml's main-branch scope; merge readiness now supplies the
+# required blocking property for main-bound changes (see issue #845).
 #
 # The install step defers to pyproject.toml's unpinned dev extra, just as
 # site-reference-freshness.yml does for pytest and markdown.  That declaration
 # is the dependency authority: installing the whole extra prevents a
 # hand-maintained package list from silently becoming stale.
 #
-# This context is intentionally not required yet.  Making it required needs a
-# coordinated, separate rollout through the ruleset contract, fixtures, design
-# record, and live ruleset; this workflow is unfiltered so that future rollout
-# can be evaluated without a path-filter reporting gap.  See issue #845.
+# This context remains non-required. Its pytest control is intentionally
+# duplicated in merge readiness, where the live parser-backed audit makes a
+# workflow-name collision block a main merge without changing the ruleset.
 
 on:
   pull_request:

--- a/changelog.d/845-cache-audit-uniqueness.required.md
+++ b/changelog.d/845-cache-audit-uniqueness.required.md
@@ -1,0 +1,2 @@
+Required (#845): cache-budget audit workflow-name uniqueness now blocks main
+merges through merge readiness.

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -46,6 +46,12 @@ check_automation() {
   # the live parser-backed audit.
   python3 -m pytest tests/test_toolchain_pin.py -v
   python3 .github/scripts/validate_toolchain_pin.py
+  # The cache-budget reporter subscribes by workflow display name. Its
+  # parser-backed uniqueness control must be able to block a merge, not merely
+  # report red in a non-required workflow, so run its calibrated controls and
+  # live audit in this required lane.
+  python3 -m pytest tests/test_cache_budget_audit_workflow.py -v
+  python3 .github/scripts/validate-cache-budget-audit-workflow.py
   # The cache-budget reporter owns a separate issue lifecycle from the
   # read-only audit. Keep its reconciliation controls in this pre-merge lane,
   # alongside the established post-merge reporter controls.


### PR DESCRIPTION
## Residual risk

`validate-cache-budget-audit-workflow.py`'s workflow-name uniqueness check ran **only** through
`tests/test_cache_budget_audit_workflow.py`, which ran **only** in the non-required
`cache budget audit wiring` workflow. Verified: `grep -rn 'validate-cache-budget-audit-workflow'` across
`.yml`/`.sh`/`.py` found no other invocation.

So a PR adding a default-branch workflow named `cache budget audit` could merge with the uniqueness check
**visibly red**, because every required context stayed green. Post-merge, GitHub's name-based
`workflow_run` subscription triggers the reporter against the impostor's `workflow_id`, letting unrelated
health open or close the canonical issue. The residual risk was never silence — it was that a visible red
could be pushed past.

## Why this is not the rollout #845 asked for

#845 specifies a four-part ruleset rollout — add the context to `.github/ruleset-contract.json`, sync the
live ruleset, update the drift fixtures, update `docs/DESIGN-ci.md` — on the grounds that the audit depends
on PyYAML and therefore cannot live in the stdlib-only automation-contracts lane.

**That premise no longer holds.** PR #863 put PyYAML-dependent validators into
`tools/check-merge-readiness.sh` — `validate_post_merge_reporter_workflow.py` at `:42` and
`validate_toolchain_pin.py` at `:48`, each with its pytest file — and that lane installs PyYAML. And
`merge readiness` is already a **required** context with **no path filter**: `pull_request: branches: [main]`
plus `merge_group`, so it runs on every main-bound PR.

The property #845 wants is therefore reachable from a lane that is already required.
**`.github/ruleset-contract.json` is not touched, the live ruleset is unchanged, and no drift fixture
moves.** Six lines in `check_automation()` do it.

## Controls

**Rejecting, and this is the one that matters:** a private fixture — the whole repository copied to
`/private/tmp` with an added `impostor-cache-budget-audit.yml` also named `cache budget audit` — made the
automation phase **exit 1**, with the validator naming both `cache-budget-audit.yml` and
`impostor-cache-budget-audit.yml`. The fixture was built outside the repository deliberately: adding a real
second workflow with that name to `.github/workflows/` would have made this branch's own CI the collision.

**Accepting:** `./tools/check-merge-readiness.sh` automation exits 0 in 51.30s on the unmodified tree, with
the cache-audit controls passing 146 tests and the live audit passing.

**Lane cost:** the addition measures 2.29s for pytest and 0.12s for the validator. That matters because
`check-merge-readiness.sh` documents itself as the sub-minute fail-fast signal rather than the gate, and
folding work into it could quietly change that. It does not.

## The separate workflow keeps a distinct purpose

Its comment is rewritten rather than left claiming a boundary that no longer exists, and the stated reason
is verified rather than asserted:

    remains an unfiltered corroborating check for pull requests outside merge-readiness.yml's
    main-branch scope; merge readiness now supplies the required blocking property for main-bound changes

Checked directly: `cache-budget-audit-wiring.yml` triggers on bare `pull_request:` with no branches filter,
while `merge-readiness.yml` filters `branches: [main]`. So a PR targeting a non-main branch gets the
corroborating check and not the required one. That is a real difference, not a rationalisation for keeping
the file.

The workflow is **not deleted** here. Removing a workflow is a separate decision with its own blast radius.

`./tools/aggregate_changelog.sh check` and `git diff --check` exit 0. No Rust or frozen-Python files
changed; no cargo command was needed.

Closes #845
