### PR TITLE
fix(mutation): derive cargo-mutants exclusions from the scope anchors instead of hand-copied line numbers

### DIFF
--- a/changelog.d/873-derived-mutants-exclusions.fixed.md
+++ b/changelog.d/873-derived-mutants-exclusions.fixed.md
@@ -1,0 +1,3 @@
+Fixed (#873): generated cargo-mutants liveness exclusions now derive their
+line-scoped expressions from the maintained source anchors instead of requiring
+hand-copied line numbers.

--- a/docs/DESIGN-semantic-mutation-gate.md
+++ b/docs/DESIGN-semantic-mutation-gate.md
@@ -38,10 +38,12 @@ maps a mutant back to the nearest containing decision region. A bare function
 name is never emitted as a substitute for decision traceability.
 
 Line-scoped generic exclusions are allowed only for a uniquely anchored
-decision that is explicitly outside the pilot. The manifest validator derives
-the cargo-mutants line expression from that anchor and requires the TOML set to
-match exactly, so source movement fails before a stale line exclusion can hide
-a mutant. Such exclusions are scope declarations, not equivalent mutants.
+decision that is explicitly outside the pilot. The generator derives the
+cargo-mutants line expression from that anchor into
+`rust/.cargo/mutants.toml`; its freshness check refuses a stale generated file
+with the regeneration command, so source movement cannot leave a hand-copied
+line exclusion behind. Such exclusions are scope declarations, not equivalent
+mutants.
 
 The P2 pilot covers:
 

--- a/docs/DESIGN-semantic-mutation-gate.md
+++ b/docs/DESIGN-semantic-mutation-gate.md
@@ -38,12 +38,15 @@ maps a mutant back to the nearest containing decision region. A bare function
 name is never emitted as a substitute for decision traceability.
 
 Line-scoped generic exclusions are allowed only for a uniquely anchored
-decision that is explicitly outside the pilot. The generator derives the
-cargo-mutants line expression from that anchor into
-`rust/.cargo/mutants.toml`; its freshness check refuses a stale generated file
-with the regeneration command, so source movement cannot leave a hand-copied
-line exclusion behind. Such exclusions are scope declarations, not equivalent
-mutants.
+decision that is explicitly outside the pilot. An exclusion records its
+selected `occurrence` and the anchor's `expected_occurrences` total; generation
+refuses any source whose actual total differs, so a comment or code duplicate
+cannot silently rebind a positional occurrence. The generator derives the
+cargo-mutants line expression from that checked anchor into
+`rust/.cargo/mutants.toml`; its freshness check reports the first differing
+generated line and the regeneration command, so source movement cannot leave a
+hand-copied line exclusion behind. Such exclusions are scope declarations, not
+equivalent mutants.
 
 The P2 pilot covers:
 

--- a/rust/.cargo/mutants.toml
+++ b/rust/.cargo/mutants.toml
@@ -26,6 +26,9 @@ examine_re = [
 # These line-scoped exclusions are coupled to unique source anchors. Liveness
 # is deliberately outside the initial P2 symbolic-witness pilot rather than
 # being treated as equivalent. The generated file contains their current lines.
+# cargo-mutants 27.1.0 emits both `replace && with || in verify_bounded_config`
+# and `delete ! in verify_bounded_config` at each of the first two anchors, so
+# line-free exclude_re patterns cannot preserve this exact three-exclusion scope.
 exclude_re = [
   "^fsl-verifier/src/bmc\\.rs:429:.* in verify_bounded_config$",
   "^fsl-verifier/src/bmc\\.rs:436:.* in verify_bounded_config$",

--- a/rust/.cargo/mutants.toml.in
+++ b/rust/.cargo/mutants.toml.in
@@ -26,6 +26,9 @@ examine_re = [
 # These line-scoped exclusions are coupled to unique source anchors. Liveness
 # is deliberately outside the initial P2 symbolic-witness pilot rather than
 # being treated as equivalent. The generated file contains their current lines.
+# cargo-mutants 27.1.0 emits both `replace && with || in verify_bounded_config`
+# and `delete ! in verify_bounded_config` at each of the first two anchors, so
+# line-free exclude_re patterns cannot preserve this exact three-exclusion scope.
 exclude_re = [
 {{GENERATED_EXCLUDE_RE}}
 ]

--- a/rust/.cargo/mutants.toml.in
+++ b/rust/.cargo/mutants.toml.in
@@ -27,9 +27,7 @@ examine_re = [
 # is deliberately outside the initial P2 symbolic-witness pilot rather than
 # being treated as equivalent. The generated file contains their current lines.
 exclude_re = [
-  "^fsl-verifier/src/bmc\\.rs:429:.* in verify_bounded_config$",
-  "^fsl-verifier/src/bmc\\.rs:436:.* in verify_bounded_config$",
-  "^fsl-verifier/src/bmc\\.rs:460:.* in verify_bounded_config$",
+{{GENERATED_EXCLUDE_RE}}
 ]
 
 # Changed-mode diff filtering may select only fsl-verifier as the mutated

--- a/rust/fslc/examples/generate_mutants_config.rs
+++ b/rust/fslc/examples/generate_mutants_config.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+fn main() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root");
+    fslc_rust::mutants_config::regenerate(root)
+        .unwrap_or_else(|error| panic!("mutants-config: FAIL -- {error}"));
+    println!("mutants-config: regenerated rust/.cargo/mutants.toml");
+}

--- a/rust/fslc/src/lib.rs
+++ b/rust/fslc/src/lib.rs
@@ -16,6 +16,10 @@ pub mod frontend_output;
 #[cfg(feature = "native-cli")]
 pub mod literate_access;
 pub mod migration;
+// Repository-local cargo-mutants configuration generation has no Worker or
+// LSP surface, so keep it out of the default-features-disabled consumers.
+#[cfg(feature = "native-cli")]
+pub mod mutants_config;
 pub mod origin_coverage;
 // The one definition of the success/failure classes (issue #537 C2). It is
 // declared on the library side rather than as a `main.rs` bin module so the

--- a/rust/fslc/src/mutants_config.rs
+++ b/rust/fslc/src/mutants_config.rs
@@ -60,11 +60,26 @@ fn generic_exclusions(root: &Path) -> Result<Vec<String>, String> {
             .and_then(Value::as_u64)
             .filter(|occurrence| *occurrence > 0)
             .ok_or_else(|| format!("generic exclusion '{id}' has no positive occurrence"))?;
+        let expected_occurrences = exclusion
+            .get("expected_occurrences")
+            .and_then(Value::as_u64)
+            .filter(|count| *count > 0)
+            .ok_or_else(|| {
+                format!("generic exclusion '{id}' has no positive expected_occurrences")
+            })?;
         let matching_lines = read_source(&root.join(path))?
             .lines()
             .enumerate()
             .filter_map(|(index, line)| line.contains(anchor).then_some(index + 1))
             .collect::<Vec<_>>();
+        if u64::try_from(matching_lines.len()).map_err(|error| error.to_string())?
+            != expected_occurrences
+        {
+            return Err(format!(
+                "generic exclusion '{id}' anchor occurrence count changed in {path}: expected {expected_occurrences}, actual {}; update the scope anchor/count, then regenerate",
+                matching_lines.len()
+            ));
+        }
         let line = matching_lines
             .get(usize::try_from(occurrence - 1).map_err(|error| error.to_string())?)
             .copied()
@@ -82,6 +97,28 @@ fn generic_exclusions(root: &Path) -> Result<Vec<String>, String> {
 
 fn toml_string(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn first_difference(actual: &str, expected: &str) -> (usize, String, String) {
+    let actual = actual.split_inclusive('\n').collect::<Vec<_>>();
+    let expected = expected.split_inclusive('\n').collect::<Vec<_>>();
+    let line = actual
+        .iter()
+        .zip(expected.iter())
+        .position(|(actual, expected)| actual != expected)
+        .unwrap_or(actual.len().min(expected.len()));
+
+    let render = |value: Option<&&str>| match value {
+        Some(value) if value.ends_with('\n') => value.trim_end_matches('\n').to_owned(),
+        Some(value) => format!("{value}\n\\ No newline at end of file"),
+        None => "<end of file>".to_owned(),
+    };
+
+    (
+        line + 1,
+        render(actual.get(line)),
+        render(expected.get(line)),
+    )
 }
 
 /// Render `rust/.cargo/mutants.toml` from the source template and scope manifest.
@@ -122,8 +159,9 @@ pub fn check(root: &Path) -> Result<(), String> {
     if actual == expected {
         return Ok(());
     }
+    let (line, actual_line, expected_line) = first_difference(&actual, &expected);
     Err(format!(
-        "generated mutation runner configuration is stale; run `{REGENERATE_COMMAND}` to regenerate {CONFIG_PATH}\n--- {CONFIG_PATH}\n+++ generated"
+        "generated mutation runner configuration is stale; run `{REGENERATE_COMMAND}` to regenerate {CONFIG_PATH}\n--- {CONFIG_PATH}\n+++ generated\n@@ line {line} @@\n-{actual_line}\n+{expected_line}"
     ))
 }
 

--- a/rust/fslc/src/mutants_config.rs
+++ b/rust/fslc/src/mutants_config.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Render and validate the generated cargo-mutants configuration.
+//!
+//! The scope manifest's anchors are the sole authority for the line-addressed
+//! liveness exclusions. This module is shared by the explicit generator and
+//! the manifest freshness check so they cannot carry separate derivations.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use serde_json::Value;
+
+const TEMPLATE_PATH: &str = "rust/.cargo/mutants.toml.in";
+const CONFIG_PATH: &str = "rust/.cargo/mutants.toml";
+const SCOPE_PATH: &str = "rust/fslc/tests/implementation_mutation/scope.v1.json";
+const EXCLUSIONS_MARKER: &str = "{{GENERATED_EXCLUDE_RE}}";
+const REGENERATE_COMMAND: &str =
+    "cargo run --manifest-path rust/Cargo.toml -p fslc-rust --example generate_mutants_config";
+
+fn required_string<'a>(value: &'a Value, key: &str) -> Result<&'a str, String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("missing non-empty string '{key}'"))
+}
+
+fn read_source(path: &Path) -> Result<String, String> {
+    std::fs::read_to_string(path)
+        .map(|source| source.replace("\r\n", "\n").replace('\r', "\n"))
+        .map_err(|error| format!("cannot read {}: {error}", path.display()))
+}
+
+fn generic_exclusions(root: &Path) -> Result<Vec<String>, String> {
+    let scope_path = root.join(SCOPE_PATH);
+    let scope: Value = serde_json::from_slice(
+        &std::fs::read(&scope_path)
+            .map_err(|error| format!("cannot read {}: {error}", scope_path.display()))?,
+    )
+    .map_err(|error| format!("cannot parse {}: {error}", scope_path.display()))?;
+    let exclusions = scope
+        .get("generic_exclusions")
+        .and_then(Value::as_array)
+        .filter(|entries| !entries.is_empty())
+        .ok_or_else(|| "scope declares no generic mutation exclusions".to_owned())?;
+    let mut exclusion_ids = BTreeSet::new();
+    let mut rendered = Vec::new();
+    for exclusion in exclusions {
+        let id = required_string(exclusion, "id")?;
+        if !exclusion_ids.insert(id) {
+            return Err(format!("duplicate generic exclusion id '{id}'"));
+        }
+        let path = required_string(exclusion, "path")?;
+        let function = required_string(exclusion, "function")?;
+        let anchor = required_string(exclusion, "anchor")?;
+        required_string(exclusion, "reason")?;
+        let occurrence = exclusion
+            .get("occurrence")
+            .and_then(Value::as_u64)
+            .filter(|occurrence| *occurrence > 0)
+            .ok_or_else(|| format!("generic exclusion '{id}' has no positive occurrence"))?;
+        let matching_lines = read_source(&root.join(path))?
+            .lines()
+            .enumerate()
+            .filter_map(|(index, line)| line.contains(anchor).then_some(index + 1))
+            .collect::<Vec<_>>();
+        let line = matching_lines
+            .get(usize::try_from(occurrence - 1).map_err(|error| error.to_string())?)
+            .copied()
+            .ok_or_else(|| {
+                format!(
+                    "generic exclusion '{id}' anchor occurrence {occurrence} is stale in {path}; update the scope anchor, then regenerate"
+                )
+            })?;
+        let runner_path = path.strip_prefix("rust/").unwrap_or(path);
+        let escaped_path = runner_path.replace('.', "\\.");
+        rendered.push(format!("^{escaped_path}:{line}:.* in {function}$"));
+    }
+    Ok(rendered)
+}
+
+fn toml_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Render `rust/.cargo/mutants.toml` from the source template and scope manifest.
+///
+/// # Errors
+///
+/// Returns an error if the template, scope manifest, or an anchored source file
+/// is unreadable, malformed, or cannot yield one requested anchor occurrence.
+pub fn render(root: &Path) -> Result<String, String> {
+    let template_path = root.join(TEMPLATE_PATH);
+    let template = std::fs::read_to_string(&template_path)
+        .map_err(|error| format!("cannot read {}: {error}", template_path.display()))?;
+    if template.matches(EXCLUSIONS_MARKER).count() != 1 {
+        return Err(format!(
+            "{} must contain exactly one {EXCLUSIONS_MARKER}",
+            template_path.display()
+        ));
+    }
+    let exclusions = generic_exclusions(root)?
+        .iter()
+        .map(|exclusion| format!("  \"{}\",", toml_string(exclusion)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(template.replace(EXCLUSIONS_MARKER, &exclusions))
+}
+
+/// Fail with an actionable regeneration command when the committed config is stale.
+///
+/// # Errors
+///
+/// Returns an error if rendering fails, the committed configuration is
+/// unreadable, or it differs from the rendered configuration.
+pub fn check(root: &Path) -> Result<(), String> {
+    let config_path = root.join(CONFIG_PATH);
+    let actual = std::fs::read_to_string(&config_path)
+        .map_err(|error| format!("cannot read {}: {error}", config_path.display()))?;
+    let expected = render(root)?;
+    if actual == expected {
+        return Ok(());
+    }
+    Err(format!(
+        "generated mutation runner configuration is stale; run `{REGENERATE_COMMAND}` to regenerate {CONFIG_PATH}\n--- {CONFIG_PATH}\n+++ generated"
+    ))
+}
+
+/// Regenerate the committed cargo-mutants configuration from its source authority.
+///
+/// # Errors
+///
+/// Returns an error if rendering fails or the generated configuration cannot
+/// be written.
+pub fn regenerate(root: &Path) -> Result<(), String> {
+    std::fs::write(root.join(CONFIG_PATH), render(root)?)
+        .map_err(|error| format!("cannot write {CONFIG_PATH}: {error}"))
+}
+
+/// The command developers run to regenerate the configuration.
+#[must_use]
+pub const fn regenerate_command() -> &'static str {
+    REGENERATE_COMMAND
+}

--- a/rust/fslc/tests/implementation_mutation/scope.v1.json
+++ b/rust/fslc/tests/implementation_mutation/scope.v1.json
@@ -25,6 +25,7 @@
       "function": "verify_bounded_config",
       "anchor": "if result.leadsto_violation.is_none() && !model.leadstos.is_empty() {",
       "occurrence": 1,
+      "expected_occurrences": 2,
       "reason": "Leadsto/liveness semantics are outside the initial P2 symbolic-witness pilot."
     },
     {
@@ -33,6 +34,7 @@
       "function": "verify_bounded_config",
       "anchor": "if result.leadsto_violation.is_none() && !model.leadstos.is_empty() {",
       "occurrence": 2,
+      "expected_occurrences": 2,
       "reason": "Leadsto/liveness semantics are outside the initial P2 symbolic-witness pilot."
     },
     {
@@ -41,6 +43,7 @@
       "function": "verify_bounded_config",
       "anchor": "let unrolled_depth = states.len() - 1;",
       "occurrence": 1,
+      "expected_occurrences": 1,
       "reason": "Leadsto/liveness semantics are outside the initial P2 symbolic-witness pilot."
     }
   ],

--- a/rust/fslc/tests/implementation_mutation_manifest.rs
+++ b/rust/fslc/tests/implementation_mutation_manifest.rs
@@ -388,6 +388,7 @@ fn generated_mutants_config_rejects_line_drift_and_stale_anchor() {
             "function": "verify_bounded_config",
             "anchor": "let anchor = true;",
             "occurrence": 1,
+            "expected_occurrences": 1,
             "reason": "calibration exclusion"
         }]
     });
@@ -412,13 +413,42 @@ fn generated_mutants_config_rejects_line_drift_and_stale_anchor() {
 
     std::fs::write(
         &source_path,
+        "let anchor = true;\nbefore\nlet anchor = true;\nafter\n",
+    )
+    .expect("insert duplicate anchor before selected anchor");
+    let duplicate =
+        mutants_config::check(&root).expect_err("duplicate anchor must fail generation");
+    assert!(duplicate.contains("anchor occurrence count changed"));
+    assert!(duplicate.contains("expected 1, actual 2"));
+
+    std::fs::write(
+        &source_path,
         "before\ninserted line\nlet anchor = true;\nafter\n",
     )
     .expect("shift source anchor");
     let drift = mutants_config::check(&root).expect_err("line drift must stale generated config");
     assert!(drift.contains("generated mutation runner configuration is stale"));
     assert!(drift.contains(mutants_config::regenerate_command()));
-    assert!(drift.contains("--- rust/.cargo/mutants.toml\n+++ generated"));
+    assert!(drift.contains("@@ line 2 @@"));
+    assert!(drift.contains("-  \"^fsl-verifier/src/bmc\\\\.rs:2:.* in verify_bounded_config$\","));
+    assert!(drift.contains("+  \"^fsl-verifier/src/bmc\\\\.rs:3:.* in verify_bounded_config$\","));
+
+    std::fs::write(&source_path, "before\nlet anchor = true;\nafter\n")
+        .expect("restore source fixture");
+    mutants_config::check(&root).expect("restored generated fixture");
+    let config_path = root.join("rust/.cargo/mutants.toml");
+    let config = std::fs::read_to_string(&config_path).expect("read generated fixture");
+    std::fs::write(
+        &config_path,
+        config
+            .strip_suffix('\n')
+            .expect("generated fixture has trailing newline"),
+    )
+    .expect("remove generated fixture trailing newline");
+    let eof = mutants_config::check(&root).expect_err("missing final newline must stale config");
+    assert!(eof.contains("\\ No newline at end of file"));
+    assert!(eof.contains("-]\n\\ No newline at end of file"));
+    assert!(eof.contains("+]"));
 
     scope["generic_exclusions"][0]["anchor"] = serde_json::Value::String("stale anchor".to_owned());
     std::fs::write(
@@ -427,7 +457,8 @@ fn generated_mutants_config_rejects_line_drift_and_stale_anchor() {
     )
     .expect("write stale scope fixture");
     let stale_anchor = mutants_config::check(&root).expect_err("stale anchor must fail generation");
-    assert!(stale_anchor.contains("anchor occurrence 1 is stale"));
+    assert!(stale_anchor.contains("anchor occurrence count changed"));
+    assert!(stale_anchor.contains("expected 1, actual 0"));
 
     std::fs::remove_dir_all(&root).expect("remove temporary generator fixture");
 }

--- a/rust/fslc/tests/implementation_mutation_manifest.rs
+++ b/rust/fslc/tests/implementation_mutation_manifest.rs
@@ -2,7 +2,9 @@
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use fslc_rust::mutants_config;
 use serde_json::Value;
 
 const REQUIRED_P2_FAULT_CLASSES: &[&str] = &[
@@ -48,70 +50,6 @@ fn required_string<'a>(value: &'a Value, key: &str) -> Result<&'a str, String> {
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty())
         .ok_or_else(|| format!("missing non-empty string '{key}'"))
-}
-
-fn validate_generic_exclusions(root: &Path, manifest: &Value, config: &str) -> Result<(), String> {
-    let exclude_block = config
-        .split_once("exclude_re = [")
-        .and_then(|(_, tail)| tail.split_once(']'))
-        .map(|(block, _)| block)
-        .ok_or_else(|| "mutation runner config has no closed exclude_re list".to_owned())?;
-    let actual_exclusions = exclude_block
-        .lines()
-        .map(str::trim)
-        .filter(|line| line.starts_with('"'))
-        .map(|line| {
-            line.trim_end_matches(',')
-                .trim_matches('"')
-                .replace("\\\\", "\\")
-        })
-        .collect::<BTreeSet<_>>();
-    let exclusions = manifest
-        .get("generic_exclusions")
-        .and_then(Value::as_array)
-        .filter(|entries| !entries.is_empty())
-        .ok_or_else(|| "scope declares no generic mutation exclusions".to_owned())?;
-    let mut expected_exclusions = BTreeSet::new();
-    let mut exclusion_ids = BTreeSet::new();
-    for exclusion in exclusions {
-        let id = required_string(exclusion, "id")?;
-        if !exclusion_ids.insert(id) {
-            return Err(format!("duplicate generic exclusion id '{id}'"));
-        }
-        let path = required_string(exclusion, "path")?;
-        let function = required_string(exclusion, "function")?;
-        let anchor = required_string(exclusion, "anchor")?;
-        let occurrence = exclusion
-            .get("occurrence")
-            .and_then(Value::as_u64)
-            .filter(|occurrence| *occurrence > 0)
-            .ok_or_else(|| format!("generic exclusion '{id}' has no positive occurrence"))?;
-        required_string(exclusion, "reason")?;
-        let source = read_source(&root.join(path))
-            .map_err(|error| format!("generic exclusion '{id}' cannot read '{path}': {error}"))?;
-        let matching_lines = source
-            .lines()
-            .enumerate()
-            .filter_map(|(index, line)| line.contains(anchor).then_some(index + 1))
-            .collect::<Vec<_>>();
-        let line = matching_lines
-            .get(usize::try_from(occurrence - 1).map_err(|error| error.to_string())?)
-            .copied()
-            .ok_or_else(|| {
-                format!(
-                    "generic exclusion '{id}' anchor occurrence {occurrence} is stale in {path}"
-                )
-            })?;
-        let runner_path = path.strip_prefix("rust/").unwrap_or(path);
-        let escaped_path = runner_path.replace('.', "\\.");
-        expected_exclusions.insert(format!("^{escaped_path}:{line}:.* in {function}$"));
-    }
-    if actual_exclusions != expected_exclusions {
-        return Err(format!(
-            "generic mutation exclusions drifted from scope: expected={expected_exclusions:?} actual={actual_exclusions:?}"
-        ));
-    }
-    Ok(())
 }
 
 fn validate_generic_functions(manifest: &Value, config: &str) -> Result<(), String> {
@@ -185,8 +123,8 @@ fn validate_scope(root: &Path, manifest: &Value) -> Result<(), String> {
         .ok_or_else(|| "runner has no config path".to_owned())?;
     let config = std::fs::read_to_string(root.join(config_path))
         .map_err(|error| format!("cannot read mutation runner config '{config_path}': {error}"))?;
+    mutants_config::check(root)?;
     validate_generic_functions(manifest, &config)?;
-    validate_generic_exclusions(root, manifest, &config)?;
     validate_detector_selection(&config)?;
 
     let decisions = manifest
@@ -391,6 +329,19 @@ fn gate_classification(outcome: &str, reviewed_equivalent: bool) -> Result<&'sta
     }
 }
 
+fn temporary_mutants_config_root() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after Unix epoch")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "fsl-mutants-config-test-{}-{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&root).expect("create temporary generator fixture");
+    root
+}
+
 #[test]
 fn multiline_anchor_matching_is_line_ending_independent() {
     let anchor = "if let Some(violation) = &result.violation {\n    replay(&violation.trace)?;\n}";
@@ -417,6 +368,68 @@ fn p2_critical_scope_and_equivalence_manifests_are_current() {
             .expect("read operator inventory"),
     )
     .expect("valid semantic operator inventory");
+}
+
+#[test]
+fn generated_mutants_config_rejects_line_drift_and_stale_anchor() {
+    let root = temporary_mutants_config_root();
+    let source_path = root.join("rust/fsl-verifier/src/bmc.rs");
+    std::fs::create_dir_all(source_path.parent().expect("source parent"))
+        .expect("create source fixture parent");
+    std::fs::write(&source_path, "before\nlet anchor = true;\nafter\n")
+        .expect("write source fixture");
+    let scope_path = root.join("rust/fslc/tests/implementation_mutation/scope.v1.json");
+    std::fs::create_dir_all(scope_path.parent().expect("scope parent"))
+        .expect("create scope fixture parent");
+    let mut scope = serde_json::json!({
+        "generic_exclusions": [{
+            "id": "calibration.anchor",
+            "path": "rust/fsl-verifier/src/bmc.rs",
+            "function": "verify_bounded_config",
+            "anchor": "let anchor = true;",
+            "occurrence": 1,
+            "reason": "calibration exclusion"
+        }]
+    });
+    std::fs::write(
+        &scope_path,
+        serde_json::to_vec(&scope).expect("serialize scope fixture"),
+    )
+    .expect("write scope fixture");
+    let template_path = root.join("rust/.cargo/mutants.toml.in");
+    std::fs::create_dir_all(template_path.parent().expect("template parent"))
+        .expect("create template fixture parent");
+    std::fs::write(
+        &template_path,
+        "exclude_re = [\n{{GENERATED_EXCLUDE_RE}}\n]\n",
+    )
+    .expect("write template fixture");
+    let rendered = mutants_config::render(&root).expect("render fresh fixture");
+    assert!(rendered.contains(r"fsl-verifier/src/bmc\\.rs:2:"));
+    std::fs::write(root.join("rust/.cargo/mutants.toml"), rendered)
+        .expect("write generated fixture");
+    mutants_config::check(&root).expect("fresh generated fixture");
+
+    std::fs::write(
+        &source_path,
+        "before\ninserted line\nlet anchor = true;\nafter\n",
+    )
+    .expect("shift source anchor");
+    let drift = mutants_config::check(&root).expect_err("line drift must stale generated config");
+    assert!(drift.contains("generated mutation runner configuration is stale"));
+    assert!(drift.contains(mutants_config::regenerate_command()));
+    assert!(drift.contains("--- rust/.cargo/mutants.toml\n+++ generated"));
+
+    scope["generic_exclusions"][0]["anchor"] = serde_json::Value::String("stale anchor".to_owned());
+    std::fs::write(
+        &scope_path,
+        serde_json::to_vec(&scope).expect("serialize stale scope fixture"),
+    )
+    .expect("write stale scope fixture");
+    let stale_anchor = mutants_config::check(&root).expect_err("stale anchor must fail generation");
+    assert!(stale_anchor.contains("anchor occurrence 1 is stale"));
+
+    std::fs::remove_dir_all(&root).expect("remove temporary generator fixture");
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`rust/.cargo/mutants.toml`'s `exclude_re` pinned **line numbers** in `fsl-verifier/src/bmc.rs` by hand, while
`validate_generic_exclusions` in `rust/fslc/tests/implementation_mutation_manifest.rs` **already computed the
same numbers at run time** from the anchor strings in `scope.v1.json`.

So the anchors were the authority and the committed numbers were a hand-transcribed derived value. That is
the defect: a human copying a number a program already knows. It is not a maintenance annoyance — the rate is
measured. **PR #866 broke it twice inside one PR**: `420/427/451` became `425/432/456` after five
`#[must_use]` annotations, then moved again for `LeadsToViolation`. Each break surfaced as an opaque
expected-versus-actual set mismatch with no statement of what to do about it, which is what cost those two
cycles.

## Option 2 was closed by measurement, not by preference

The instruction was to prefer removing the derived value over automating its maintenance — line-free
exclusions naming the mutants by function and content alone — and to fall back to generation only on
evidence that it cannot work.

**It cannot.** With the pinned `cargo-mutants 27.1.0`, `exclude_re` matches the names `--list` emits, and the
no-config listing shows the two first liveness anchors emitting **identical rendered mutation names** —
`replace && with ||` and `delete !` in `verify_bounded_config`. A line-free regex therefore cannot
distinguish them, so it cannot preserve the three-exclusion scope. Widening the scope was not an option: the
three exclusions exist because liveness is deliberately outside the P2 symbolic-witness pilot, and widening a
guard to dodge a problem is the allowlist-expansion this repository forbids.

That measurement is the reason this PR generates rather than eliminates.

## Fix: exactly one derivation

`rust/fslc/src/mutants_config.rs` holds the single derivation — `generic_exclusions` reads the anchors and
resolves them against the source. Both consumers call it:

- `render`/`regenerate` produce `rust/.cargo/mutants.toml` from the new template `rust/.cargo/mutants.toml.in`
  (`rust/fslc/examples/generate_mutants_config.rs` is the entry point);
- `check` is the freshness gate, and the manifest test now calls `mutants_config::check(root)?` instead of
  deriving the numbers a second time.

**`validate_generic_exclusions` is gone**, and that is the point of the change rather than a side effect.
Confirmed by reading the committed tree rather than from the report: the test file's only reference is
`mutants_config::check(root)?`, and `mutants_config.rs` exposes one `generic_exclusions`. Before this PR there
were two derivations — the anchors and the hand-copy. A Python generator alongside the surviving Rust test
would also have been two, in two languages, which relocates the drift surface instead of removing it. There
is now one.

The stale failure names its **regeneration command**, so the next person who moves a line in `bmc.rs` is told
what to run.

## Two findings from the independent review, both fixed rather than reworded

Reviewed by an agent that neither implemented this nor orchestrates the session. Both findings were confirmed
by reading the committed source before being accepted, and both are fixed in `1cd330a8`.

### The anchor match was positional and nothing enforced it

`generic_exclusions` collected **every** line whose text `contains(anchor)` and indexed that list by
`occurrence - 1`. So a second occurrence of the anchor text anywhere above the intended one — **including
inside a comment** — silently rebound which line `occurrence: 1` meant. Regeneration then produced a
different exclusion line and `check` passed: the gate's scope would change with nothing failing. No crash, no
warning, just a quietly different answer.

`scope.v1.json` now declares each anchor's **expected total occurrence count**, and generation fails when the
actual total differs, naming both numbers. Documenting positional anchoring was necessary but would have left
the failure silent, so it is not the fix on its own.

Calibrated: inserting the literal leadsto anchor above its selected occurrence made the P2 manifest test exit
**101** with `expected 2, actual 3`. The temporary `bmc.rs` comment was removed and
`git diff --exit-code 84b6cee2 -- rust/fsl-verifier/src/bmc.rs` exited **0**.

### The "generated-file diff" did not exist, and I repeated the claim

An earlier revision of this body said the stale failure "shows the generated-file diff". It did not. `check`
emitted the regeneration command followed by exactly two header lines — `--- rust/.cargo/mutants.toml` and
`+++ generated` — with no differing content and no actual-versus-expected values, and the test asserted only
those headers, so **every kind of drift produced an identical message**. I wrote that claim from the
implementer's report without opening the format string; the overclaim is mine as much as anyone's.

The actionable command was always real and is the half that stood. But #873 exists because #866 lost two
cycles to an *opaque* expected-versus-actual mismatch, and a header-only diff is still opaque — so this is
fixed, not reworded. `first_difference` now reports the first differing line with both the actual and the
generated content, and the test asserts that content rather than only the headers.

## Controls, calibrated

| control | result |
|---|---|
| rejecting: private source-line shift above an anchor | **exit 1**, diagnostic carries `regenerate_command()` plus the first differing line with actual and generated values |
| rejecting: a duplicate anchor occurrence above the selected one | **exit 101**, `expected 2, actual 3` |
| rejecting: anchor string made stale | **exit 1**, the native test asserts anchor occurrence 1 is stale |
| accepting: unmodified tree | `implementation_mutation_manifest` **8 passed**, exit 0 |
| generator | exit 0, regenerates `rust/.cargo/mutants.toml` |

Both rejecting controls run against a **private fixture root**, not the repository tree, so calibrating them
cannot leave the real `bmc.rs` mutated. The temporary calibration comment that was inserted into
`rust/fsl-verifier/src/bmc.rs` while exploring is proven removed by
`git diff --exit-code 72ccb59 -- rust/fsl-verifier/src/bmc.rs`, **exit 0**.

A note on that proof, because the mechanism was wrong at first: the check was initially written as
`git diff <sha> -- <file>` inside an `&&` chain. `git diff` exits 0 whether or not there are differences, so
that chain could not fail — it printed a diff and continued. `--exit-code` makes it load-bearing. A check that
cannot fail is not a check, and the same shape is what #861/#871 were about.

## Verification

`cargo fmt --check` exit 0; workspace Clippy with `--keep-going -D warnings` exit 0 (a plain run stops at the
first failing crate and reports a partial list); `./tools/aggregate_changelog.sh check` PASS;
`git diff --check` exit 0; `git diff --exit-code 72ccb59 -- .github/ruleset-contract.json` exit 0, so the
ruleset contract is untouched and no CI context was made required.

`docs/DESIGN-semantic-mutation-gate.md` updated to describe the generated configuration.

Changelog category `fixed` rather than `required`: this corrects a derived-data drift defect; it does not make
a new check mandatory.

Closes #873
