### PR TITLE
fix(tests): normalize result-option census paths on Windows

### DIFF
--- a/changelog.d/617-windows-result-option-paths.fixed.md
+++ b/changelog.d/617-windows-result-option-paths.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#617): Normalize Windows source-path separators in the optional-verdict census so classifications and consumer checks remain live across platforms.

--- a/rust/fslc/tests/issue_868_result_option_verdict_census.rs
+++ b/rust/fslc/tests/issue_868_result_option_verdict_census.rs
@@ -1022,16 +1022,18 @@ fn discover_signatures(path: &str, source: &str) -> BTreeSet<FoundSignature> {
     discover_signatures_with_aliases(path, source, &aliases)
 }
 
+fn repository_relative_identity(relative: &Path) -> String {
+    relative.to_string_lossy().replace('\\', "/")
+}
+
 fn rust_source_contents() -> Vec<(String, String)> {
     let root = repository_root();
     rust_sources()
         .into_iter()
         .map(|path| {
-            let relative = path
-                .strip_prefix(&root)
-                .expect("source below repository")
-                .to_string_lossy()
-                .into_owned();
+            let relative = repository_relative_identity(
+                path.strip_prefix(&root).expect("source below repository"),
+            );
             let source = std::fs::read_to_string(path).expect("read Rust source");
             (relative, source)
         })
@@ -1220,11 +1222,9 @@ fn live_consumer_findings() -> Vec<ConsumerFinding> {
     rust_sources()
         .into_iter()
         .flat_map(|path| {
-            let relative = path
-                .strip_prefix(&root)
-                .expect("source below repository")
-                .to_string_lossy()
-                .into_owned();
+            let relative = repository_relative_identity(
+                path.strip_prefix(&root).expect("source below repository"),
+            );
             let source = std::fs::read_to_string(&path).expect("read Rust source");
             consumer_findings(&relative, &source, &verdict_definitions)
         })
@@ -1507,5 +1507,77 @@ fn stale_classification_entry_is_detected() {
     assert_eq!(
         classification_drift(&discovered, &configured),
         (Vec::new(), vec![stale])
+    );
+}
+
+#[test]
+fn repository_relative_identity_normalizes_windows_and_preserves_forward_slashes() {
+    assert_eq!(
+        repository_relative_identity(Path::new(r"rust\fsl-runtime\src\lib.rs")),
+        "rust/fsl-runtime/src/lib.rs"
+    );
+    assert_eq!(
+        repository_relative_identity(Path::new("rust/fsl-runtime/src/lib.rs")),
+        "rust/fsl-runtime/src/lib.rs"
+    );
+}
+
+#[test]
+fn unnormalized_windows_path_identity_reports_missing_and_stale_classifications() {
+    let unnormalized = SignatureIdentity {
+        path: r"rust\fsl-runtime\src\lib.rs".to_owned(),
+        function: "probe".to_owned(),
+        shape: Shape::Direct,
+    };
+    let normalized = SignatureIdentity {
+        path: "rust/fsl-runtime/src/lib.rs".to_owned(),
+        function: "probe".to_owned(),
+        shape: Shape::Direct,
+    };
+    assert_eq!(
+        classification_drift(
+            &BTreeSet::from([unnormalized.clone()]),
+            &BTreeSet::from([normalized.clone()]),
+        ),
+        (vec![unnormalized], vec![normalized])
+    );
+}
+
+#[test]
+fn normalized_windows_path_identity_resolves_classification_drift() {
+    let normalized_path = repository_relative_identity(Path::new(r"rust\fsl-runtime\src\lib.rs"));
+    let discovered = BTreeSet::from([SignatureIdentity {
+        path: normalized_path,
+        function: "probe".to_owned(),
+        shape: Shape::Direct,
+    }]);
+    let configured = BTreeSet::from([SignatureIdentity {
+        path: "rust/fsl-runtime/src/lib.rs".to_owned(),
+        function: "probe".to_owned(),
+        shape: Shape::Direct,
+    }]);
+    assert_eq!(
+        classification_drift(&discovered, &configured),
+        (Vec::new(), Vec::new())
+    );
+}
+
+#[test]
+fn normalized_windows_consumer_path_detects_a_discarded_verdict() {
+    let path = repository_relative_identity(Path::new(r"rust\fsl-runtime\src\lib.rs"));
+    let source = "fn synthetic_probe() -> Result<Option<Signal>, Error> { Ok(None) }\n\
+                  fn consumer() -> Result<(), Error> { synthetic_probe()?; Ok(()) }\n";
+    let verdict_definitions = BTreeMap::from([(
+        "synthetic_probe".to_owned(),
+        BTreeSet::from(["rust/fsl-runtime/src/lib.rs".to_owned()]),
+    )]);
+    assert_eq!(
+        consumer_findings(&path, source, &verdict_definitions),
+        vec![ConsumerFinding {
+            path: "rust/fsl-runtime/src/lib.rs".to_owned(),
+            line: 2,
+            function: "synthetic_probe".to_owned(),
+            kind: ConsumerFindingKind::DiscardedStatement,
+        }]
     );
 }


### PR DESCRIPTION
## Summary

- Fix the Windows-only failure in the result/option verdict census exposed by post-merge product-gate run 32668479766.
- Normalize repository-relative Rust source identities to forward slashes before classification and consumer analysis.
- Keep the change limited to the #868 census control; no product semantics, public API, or CI gate shape changes.

## Changes

- Add one repository-relative path identity helper and use it in both signature discovery and live consumer scanning.
- Add accepting controls for Windows-style normalization, portable-path stability, classification agreement, and discarded-verdict detection.
- Add a rejecting control proving unnormalized Windows identities produce missing/stale classification drift.
- Add a new changelog fragment linked to canonical post-merge issue #617.

## Verification

- `cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test issue_868_result_option_verdict_census` — 12 passed
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `./tools/aggregate_changelog.sh check`
- `BASE_SHA=eeb6ccd62cec926484385ee224918349e08fc435 HEAD_SHA=024d2b55dcb82b84fb00e5de82a5788069c1eb7f ./tools/aggregate_changelog.sh check-pr`
- `git diff --check eeb6ccd62cec926484385ee224918349e08fc435..HEAD`
- Independent final review: no actionable findings

## Risk / Review Notes

- The normalizer runs only after `strip_prefix` has produced repository-relative paths.
- Both the discovery and consumer-analysis paths use the same identity conversion.
- No tracked repository path contains a literal backslash.
- Fixes #617 only after a later trusted Windows product-gate run proves recovery on `main`.

## Follow-Up / Post-Merge Checks

- The PR gate intentionally does not run the native Windows Z3 lane. After merge, confirm the trusted product gate passes `native Z3 4.16 (windows-latest)` before closing #617.
