### PR TITLE
fix(ci): stabilize shard artifact names and fail closed on cohort drift

### DIFF
--- a/.github/scripts/validate-shard-artifact-workflow.py
+++ b/.github/scripts/validate-shard-artifact-workflow.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser-backed contract audit for stable sharded artifact cohorts."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+PROVENANCE_SCHEMA = "fslc.shard-artifact-provenance.v1"
+HELPER = "./tools/check-shard-artifact-cohort.sh"
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """Reject duplicate YAML keys so an audited value cannot be shadowed."""
+
+
+def _construct_mapping(loader: UniqueKeyLoader, node: yaml.MappingNode, deep: bool = False) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping", node.start_mark, f"duplicate key {key!r}", key_node.start_mark
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping
+)
+
+
+def load_workflow(path: Path) -> Mapping[str, Any]:
+    document = yaml.load(path.read_text(encoding="utf-8"), Loader=UniqueKeyLoader)
+    if not isinstance(document, Mapping):
+        raise ValueError("workflow document must be a mapping")
+    return document
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _steps(job: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    value = job.get("steps")
+    if not isinstance(value, list):
+        return []
+    return [step for step in value if isinstance(step, Mapping)]
+
+
+def _named_step(job: Mapping[str, Any], name: str) -> Mapping[str, Any] | None:
+    matches = [step for step in _steps(job) if step.get("name") == name]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _require_scalar(errors: list[str], owner: str, actual: Any, expected: str) -> None:
+    if actual != expected:
+        errors.append(f"{owner}: expected {expected!r}, actual {actual!r}")
+
+
+def audit_workflow(document: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    jobs = _mapping(document.get("jobs"))
+    lanes = (
+        {
+            "producer": "rust-tests",
+            "aggregator": "rust-workspace",
+            "upload": "Preserve test-shard inventory",
+            "provenance": "Record test-shard provenance",
+            "download": "Download rust test-shard inventories",
+            "verify": "Verify shard completeness",
+            "artifact": "rust-test-shard-${{ matrix.shard }}-${{ github.run_id }}",
+            "path": "rust/target/test-shards/*",
+            "pattern": "rust-test-shard-*-${{ github.run_id }}",
+            "mode": "rust",
+            "lane": "rust-tests",
+            "guard": "Require complete rust-checks and rust-tests evidence",
+            "guard_tokens": ("RUST_CHECKS", "RUST_TESTS"),
+        },
+        {
+            "producer": "semantic-mutation-operators",
+            "aggregator": "semantic-mutation",
+            "upload": "Preserve operator shard evidence",
+            "provenance": "Record operator-shard provenance",
+            "download": "Download operator shard manifests",
+            "verify": "Verify operator shard completeness",
+            "artifact": "semantic-mutation-operators-${{ matrix.shard }}-${{ github.run_id }}",
+            "path": "rust/target/fault-operators/logs/**",
+            "pattern": "semantic-mutation-operators-*-${{ github.run_id }}",
+            "mode": "semantic",
+            "lane": "semantic-mutation-operators",
+            "guard": "Require complete operator-shard and mutants-lane evidence",
+            "guard_tokens": ("SEMANTIC_MUTATION_OPERATORS", "SEMANTIC_MUTATION_MUTANTS"),
+        },
+    )
+
+    for lane in lanes:
+        producer = _mapping(jobs.get(lane["producer"]))
+        aggregator = _mapping(jobs.get(lane["aggregator"]))
+        if not producer:
+            errors.append(f"jobs.{lane['producer']}: required producer job is absent")
+            continue
+        if not aggregator:
+            errors.append(f"jobs.{lane['aggregator']}: required aggregator job is absent")
+            continue
+
+        upload = _named_step(producer, lane["upload"])
+        provenance = _named_step(producer, lane["provenance"])
+        download = _named_step(aggregator, lane["download"])
+        verify = _named_step(aggregator, lane["verify"])
+        guard = _named_step(aggregator, lane["guard"])
+        for label, step in (("upload", upload), ("provenance", provenance), ("download", download), ("verify", verify), ("dependency guard", guard)):
+            if step is None:
+                errors.append(f"{lane['producer']}->{lane['aggregator']}: expected exactly one {label} step")
+
+        if upload is not None:
+            with_inputs = _mapping(upload.get("with"))
+            _require_scalar(errors, f"{lane['producer']} upload name", with_inputs.get("name"), lane["artifact"])
+            _require_scalar(errors, f"{lane['producer']} upload path", with_inputs.get("path"), lane["path"])
+            if with_inputs.get("overwrite") is not True:
+                errors.append(f"{lane['producer']} upload overwrite: expected True, actual {with_inputs.get('overwrite')!r}")
+            _require_scalar(errors, f"{lane['producer']} upload if", upload.get("if"), "always() && steps.scope.outputs.run == 'true'")
+
+        if provenance is not None:
+            run = provenance.get("run")
+            if not isinstance(run, str):
+                errors.append(f"{lane['producer']} provenance run: expected script scalar, actual {run!r}")
+            else:
+                for token in (PROVENANCE_SCHEMA, lane["lane"], "full_sha256", "shard_sha256", "git rev-parse HEAD"):
+                    if token not in run:
+                        errors.append(f"{lane['producer']} provenance run: expected token {token!r}, actual script omitted it")
+
+        if download is not None:
+            _require_scalar(errors, f"{lane['aggregator']} download pattern", _mapping(download.get("with")).get("pattern"), lane["pattern"])
+
+        if verify is not None:
+            expected_run = (
+                f'{HELPER} {lane["mode"]} '
+                f'{"rust-test-shards" if lane["mode"] == "rust" else "semantic-mutation-operators"} '
+                '"${{ github.run_id }}" "${{ github.run_attempt }}" "$(git rev-parse HEAD)" 3'
+            )
+            _require_scalar(errors, f"{lane['aggregator']} verifier", verify.get("run"), expected_run)
+
+        _require_scalar(errors, f"jobs.{lane['aggregator']}.if", aggregator.get("if"), "always()")
+        if guard is not None:
+            run = guard.get("run")
+            env = _mapping(guard.get("env"))
+            for token in lane["guard_tokens"]:
+                if token not in env:
+                    errors.append(f"{lane['aggregator']} dependency guard env: expected {token!r}, actual keys {sorted(env)}")
+                if not isinstance(run, str) or token not in run:
+                    errors.append(f"{lane['aggregator']} dependency guard run: expected token {token!r}, actual {run!r}")
+
+    # These unsharded artifacts are intentionally attempt-scoped and guard the
+    # audit against an indiscriminate global replacement.
+    mutants = _named_step(_mapping(jobs.get("semantic-mutation-mutants")), "Preserve mutation evidence")
+    if mutants is None:
+        errors.append("semantic-mutation-mutants: expected unsharded upload step")
+    else:
+        _require_scalar(
+            errors,
+            "semantic-mutation-mutants upload name",
+            _mapping(mutants.get("with")).get("name"),
+            "semantic-mutation-mutants-${{ github.run_id }}-${{ github.run_attempt }}",
+        )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("workflow", nargs="?", type=Path, default=WORKFLOW)
+    args = parser.parse_args()
+    try:
+        errors = audit_workflow(load_workflow(args.workflow))
+    except (OSError, ValueError, yaml.YAMLError) as error:
+        print(f"shard artifact workflow audit: ERROR: {error}")
+        return 2
+    if errors:
+        for error in errors:
+            print(f"shard artifact workflow audit: FAIL: {error}")
+        return 1
+    print("shard artifact workflow audit: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/validate-shard-artifact-workflow.py
+++ b/.github/scripts/validate-shard-artifact-workflow.py
@@ -162,16 +162,29 @@ def audit_workflow(document: Mapping[str, Any]) -> list[str]:
 
     # These unsharded artifacts are intentionally attempt-scoped and guard the
     # audit against an indiscriminate global replacement.
-    mutants = _named_step(_mapping(jobs.get("semantic-mutation-mutants")), "Preserve mutation evidence")
-    if mutants is None:
-        errors.append("semantic-mutation-mutants: expected unsharded upload step")
-    else:
-        _require_scalar(
-            errors,
-            "semantic-mutation-mutants upload name",
-            _mapping(mutants.get("with")).get("name"),
+    unsharded_uploads = (
+        (
+            "semantic-mutation-mutants",
+            "Preserve mutation evidence",
             "semantic-mutation-mutants-${{ github.run_id }}-${{ github.run_attempt }}",
-        )
+        ),
+        (
+            "fsl-logic",
+            "Preserve FSL Logic evidence",
+            "fsl-logic-${{ github.run_id }}-${{ github.run_attempt }}",
+        ),
+    )
+    for job_name, step_name, expected_name in unsharded_uploads:
+        upload = _named_step(_mapping(jobs.get(job_name)), step_name)
+        if upload is None:
+            errors.append(f"{job_name}: expected unsharded upload step")
+        else:
+            _require_scalar(
+                errors,
+                f"{job_name} upload name",
+                _mapping(upload.get("with")).get("name"),
+                expected_name,
+            )
     return errors
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,10 @@ jobs:
           retention-days: 14
           overwrite: true
 
+      - name: Controlled partial-rerun probe after test-shard upload
+        if: matrix.shard == 2 && github.run_attempt == 1
+        run: exit 1
+
   rust-workspace:
     name: rust workspace
     if: always()
@@ -533,6 +537,10 @@ jobs:
           if-no-files-found: error
           retention-days: 14
           overwrite: true
+
+      - name: Controlled partial-rerun probe after operator-shard upload
+        if: matrix.shard == 2 && github.run_attempt == 1
+        run: exit 1
 
   semantic-mutation-mutants:
     name: mutation mutants

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,12 +178,34 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         run: ./tools/check-native-integration.sh rust-tests ${{ matrix.shard }}/3
 
+      - name: Record test-shard provenance
+        if: steps.scope.outputs.run == 'true'
+        env:
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SHARD_INDEX: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          evidence=rust/target/test-shards
+          jq -n \
+            --arg lane rust-tests \
+            --arg run_id "$RUN_ID" \
+            --argjson run_attempt "$RUN_ATTEMPT" \
+            --arg head_revision "$(git rev-parse HEAD)" \
+            --argjson shard_index "$SHARD_INDEX" \
+            --arg full_sha256 "$(sha256sum "$evidence/full.txt" | awk '{print $1}')" \
+            --arg shard_sha256 "$(sha256sum "$evidence/shard.txt" | awk '{print $1}')" \
+            '{schema:"fslc.shard-artifact-provenance.v1", lane:$lane,
+              run_id:$run_id, run_attempt:$run_attempt, head_revision:$head_revision,
+              shard:{index:$shard_index,total:3}, full_sha256:$full_sha256,
+              shard_sha256:$shard_sha256}' >"$evidence/artifact-provenance.v1.json"
+
       - name: Preserve test-shard inventory
         if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: rust-test-shard-${{ matrix.shard }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: rust/target/test-shards/*.txt
+          name: rust-test-shard-${{ matrix.shard }}-${{ github.run_id }}
+          path: rust/target/test-shards/*
           if-no-files-found: error
           retention-days: 14
           overwrite: true
@@ -234,28 +256,12 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         uses: actions/download-artifact@v4
         with:
-          pattern: rust-test-shard-*-${{ github.run_id }}-${{ github.run_attempt }}
+          pattern: rust-test-shard-*-${{ github.run_id }}
           path: rust-test-shards
 
       - name: Verify shard completeness
         if: steps.scope.outputs.run == 'true'
-        run: |
-          set -euo pipefail
-          mapfile -t fulls < <(find rust-test-shards -name full.txt | sort)
-          mapfile -t shards < <(find rust-test-shards -name shard.txt | sort)
-          if [ "${#fulls[@]}" -ne 3 ] || [ "${#shards[@]}" -ne 3 ]; then
-            echo "rust workspace: expected 3 shard inventories, found ${#fulls[@]} full.txt and ${#shards[@]} shard.txt" >&2
-            exit 1
-          fi
-          # Three independently computed listings must agree exactly -- a
-          # divergence means the shards did not see the same workspace.
-          if ! cmp -s "${fulls[0]}" "${fulls[1]}" || ! cmp -s "${fulls[1]}" "${fulls[2]}"; then
-            echo "rust workspace: the three shards computed different full test listings" >&2
-            diff "${fulls[0]}" "${fulls[1]}" || true
-            diff "${fulls[1]}" "${fulls[2]}" || true
-            exit 1
-          fi
-          ./tools/check-shard-union.sh "${fulls[0]}" "${shards[@]}"
+        run: ./tools/check-shard-artifact-cohort.sh rust rust-test-shards "${{ github.run_id }}" "${{ github.run_attempt }}" "$(git rev-parse HEAD)" 3
 
   wasm:
     name: WASM
@@ -492,11 +498,37 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         run: ./tools/run-semantic-mutation-gate.sh "${{ (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.base_ref != 'production')) && 'changed' || 'complete' }}" --lane operators --shard ${{ matrix.shard }}/3
 
+      - name: Record operator-shard provenance
+        if: steps.scope.outputs.run == 'true'
+        env:
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SHARD_INDEX: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          evidence=rust/target/fault-operators/logs
+          manifest="$evidence/shard-manifest.v1.json"
+          work="$(mktemp -d)"
+          jq -r '.table_operators[]' "$manifest" | sort -u >"$work/full.txt"
+          jq -r '.executed_operators[]' "$manifest" | sort -u >"$work/shard.txt"
+          jq -n \
+            --arg lane semantic-mutation-operators \
+            --arg run_id "$RUN_ID" \
+            --argjson run_attempt "$RUN_ATTEMPT" \
+            --arg head_revision "$(git rev-parse HEAD)" \
+            --argjson shard_index "$SHARD_INDEX" \
+            --arg full_sha256 "$(sha256sum "$work/full.txt" | awk '{print $1}')" \
+            --arg shard_sha256 "$(sha256sum "$work/shard.txt" | awk '{print $1}')" \
+            '{schema:"fslc.shard-artifact-provenance.v1", lane:$lane,
+              run_id:$run_id, run_attempt:$run_attempt, head_revision:$head_revision,
+              shard:{index:$shard_index,total:3}, full_sha256:$full_sha256,
+              shard_sha256:$shard_sha256}' >"$evidence/artifact-provenance.v1.json"
+
       - name: Preserve operator shard evidence
         if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: semantic-mutation-operators-${{ matrix.shard }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: semantic-mutation-operators-${{ matrix.shard }}-${{ github.run_id }}
           path: rust/target/fault-operators/logs/**
           if-no-files-found: error
           retention-days: 14
@@ -620,35 +652,12 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         uses: actions/download-artifact@v4
         with:
-          pattern: semantic-mutation-operators-*-${{ github.run_id }}-${{ github.run_attempt }}
+          pattern: semantic-mutation-operators-*-${{ github.run_id }}
           path: semantic-mutation-operators
 
       - name: Verify operator shard completeness
         if: steps.scope.outputs.run == 'true'
-        run: |
-          set -euo pipefail
-          mapfile -t manifests < <(find semantic-mutation-operators -name shard-manifest.v1.json | sort)
-          if [ "${#manifests[@]}" -ne 3 ]; then
-            echo "semantic mutation: expected 3 operator shard manifests, found ${#manifests[@]}" >&2
-            exit 1
-          fi
-          base_revision="$(jq -r '.base_revision' "${manifests[0]}")"
-          table_operators="$(jq -c '.table_operators' "${manifests[0]}")"
-          work="$(mktemp -d)"
-          for index in "${!manifests[@]}"; do
-            manifest="${manifests[$index]}"
-            if [ "$(jq -r '.base_revision' "$manifest")" != "$base_revision" ]; then
-              echo "semantic mutation: $manifest disagrees with ${manifests[0]} on base_revision" >&2
-              exit 1
-            fi
-            if [ "$(jq -c '.table_operators' "$manifest")" != "$table_operators" ]; then
-              echo "semantic mutation: $manifest disagrees with ${manifests[0]} on table_operators" >&2
-              exit 1
-            fi
-            jq -r '.executed_operators[]' "$manifest" | sort -u >"$work/shard-$index.txt"
-          done
-          jq -r '.[]' <<<"$table_operators" | sort -u >"$work/full.txt"
-          ./tools/check-shard-union.sh "$work/full.txt" "$work"/shard-*.txt
+        run: ./tools/check-shard-artifact-cohort.sh semantic semantic-mutation-operators "${{ github.run_id }}" "${{ github.run_attempt }}" "$(git rev-parse HEAD)" 3
 
   # M13 deterministic finite-model agreement (#673). The report begins
   # incomplete and becomes complete only after every selected case and edge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,10 +210,6 @@ jobs:
           retention-days: 14
           overwrite: true
 
-      - name: Controlled partial-rerun probe after test-shard upload
-        if: matrix.shard == 2 && github.run_attempt == 1
-        run: exit 1
-
   rust-workspace:
     name: rust workspace
     if: always()
@@ -537,10 +533,6 @@ jobs:
           if-no-files-found: error
           retention-days: 14
           overwrite: true
-
-      - name: Controlled partial-rerun probe after operator-shard upload
-        if: matrix.shard == 2 && github.run_attempt == 1
-        run: exit 1
 
   semantic-mutation-mutants:
     name: mutation mutants

--- a/changelog.d/757-artifact-run-attempt.fixed.md
+++ b/changelog.d/757-artifact-run-attempt.fixed.md
@@ -1,0 +1,3 @@
+Fixed (#757): sharded Rust and semantic-mutation artifacts now use stable logical names so a failed
+shard can be rerun without discarding successful peers. Provenance, checksums, shard identity, and
+exact-union controls reject incomplete or incompatible mixed-attempt cohorts.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -365,6 +365,22 @@ recorded here. If the probe contradicts stable-slot semantics, this design is no
 it must return to the bounded same-run resolver alternative rather than interpreting ambiguity as
 green.
 
+**Controlled probe observation (recorded 2026-08-25, run `32798975136` on PR #891).** Attempt 1
+failed exactly the two probe steps ("Controlled partial-rerun probe after test-shard upload" /
+"... after operator-shard upload") on shard 2 of both lanes, after their uploads; the two aggregator
+failures were their dependent evidence guards. `gh run rerun --failed` produced attempt 2 in which
+only shard 2 of each lane re-ran, and the run completed `success`. The artifact inventory after
+attempt 2 held exactly one artifact per stable logical name: `rust-test-shard-{1,2,3}-32798975136`
+(ids 9546136831 / 9546640389 / 9546005874; shard 2 created 02:28:37Z by attempt 2, shards 1/3
+keeping their attempt-1 timestamps 02:03:52Z / 01:57:24Z) and
+`semantic-mutation-operators-{1,2,3}-32798975136` (ids 9545933248 / 9546534454 / 9546403892; shard 2
+created 02:23:50Z by attempt 2). The unsharded `semantic-mutation-mutants-32798975136-1` and
+`fsl-logic-32798975136-1` stayed attempt-scoped. Both aggregators accepted the mixed cohort with the
+expected diagnostics: `check-shard-artifact-cohort: PASS -- lane=rust-tests run_id=32798975136
+attempts=1,2,1 shards=1,2,3` and `check-shard-artifact-cohort: PASS --
+lane=semantic-mutation-operators run_id=32798975136 attempts=1,2,1 shards=1,2,3`. This satisfies the
+probe precondition above; the probe commit itself was then removed from the branch.
+
 **Agent-configuration-exempt pull requests still work.** Every shard job runs
 `check-product-gate-scope.sh` itself and early-exits its own later steps when `run=false`, so the
 shard's job result is still `success` and no artifact is ever uploaded. Both aggregators therefore

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -311,7 +311,8 @@ the first boundary against treating that upload as successful evidence.
 schema/types, lane, run id, head revision, shard total, unique indices `{1,2,3}`, stable artifact
 directory names, bounded attempts, payload checksums, and full-universe digests agree. It then
 preserves the prior lane-specific guarantees: Rust full inventories are byte-identical; semantic
-manifests share `base_revision` and canonical `table_operators`; and both lanes call
+manifests share `base_revision` and raw JSON-array-exact `table_operators` (the canonical form is
+used only for payload checksums and set-union input); and both lanes call
 `tools/check-shard-union.sh` for exact subset/disjoint/union equality. A checksum is an artifact
 identity control, not a replacement for these content-completeness controls. An older attempt with
 identical compatible content is valid by policy; an incompatible older payload is rejected by its
@@ -344,13 +345,15 @@ no longer has, and one binary pinned to two shards). It is wired into
 `check-product-gate-scope.sh selftest`.
 
 The cohort helper's selftest calibrates compatible partial/all-current cohorts and isolated
-rejecting mutations for missing shards, unchanged-sidecar payload edits, incompatible universes,
-foreign lane/run/revision/index provenance, future attempts, and semantic base-revision drift. Each
+rejecting mutations for missing shards, nested foreign artifact names, unchanged-sidecar payload
+edits, incompatible universes, foreign lane/run/revision/index provenance, future attempts,
+semantic base-revision drift, and raw-array `table_operators` drift. Each
 rejection asserts the produced value beside the expected diagnostic. The parser-backed
 `.github/scripts/validate-shard-artifact-workflow.py` and
 `tests/test_shard_artifact_workflow.py` additionally reject one-sided name/pattern drift, lost
 overwrite/provenance/helper wiring, lost aggregator/dependency guards, and accidental changes to
-unsharded attempt-scoped artifacts. All are required by `check-merge-readiness.sh automation`.
+both unsharded attempt-scoped artifacts (`semantic-mutation-mutants` and `fsl-logic`). All are
+required by `check-merge-readiness.sh automation`.
 
 This local evidence does not establish GitHub's cross-attempt `upload-artifact@v4` overwrite scope,
 the visibility of an unchanged attempt-N artifact to an attempt-N+1 download, or duplicate-name

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -291,9 +291,35 @@ one failed, so it can fail loudly instead of disappearing. The aggregator job **
 required-context set (`rust workspace`, `semantic mutation (changed)`) both keep working without
 their own edit.
 
-**Union-completeness guards.** A scheduling change must not be able to silently narrow what runs, so
-each aggregator downloads its shards' inventories and proves the split is a true partition of the
-unsharded set before trusting a `success` result:
+**Stable shard artifacts and cohort guards.** Each sharded artifact has a stable logical name scoped
+to its run and shard (`rust-test-shard-<K>-<run_id>` or
+`semantic-mutation-operators-<K>-<run_id>`), with `overwrite: true`. The name intentionally omits
+`run_attempt`: after `rerun --failed`, an unchanged successful shard may remain from attempt N while
+the rerun shard is replaced by attempt N+1. The aggregator therefore admits a mixed cohort such as
+`[N,N+1,N]`; it does not require all attempts to match, but requires every recorded attempt to be an
+integer in `1..github.run_attempt`. It never searches another run id or chooses a "newest" artifact
+from an ambiguous set.
+
+Each successful producer writes `artifact-provenance.v1.json` before its `if: always()` upload. The
+sidecar schema `fslc.shard-artifact-provenance.v1` records the fixed lane, string `run_id`, integer
+`run_attempt`, producer checkout's `head_revision`, integer shard index/total, and SHA-256 digests of
+the canonical full and shard payloads. A failed shard can still upload diagnostic files, but cannot
+create complete provenance after its test/operator step failed; the dependency-result guard remains
+the first boundary against treating that upload as successful evidence.
+
+`tools/check-shard-artifact-cohort.sh` fails closed unless exactly three sidecars exist and their
+schema/types, lane, run id, head revision, shard total, unique indices `{1,2,3}`, stable artifact
+directory names, bounded attempts, payload checksums, and full-universe digests agree. It then
+preserves the prior lane-specific guarantees: Rust full inventories are byte-identical; semantic
+manifests share `base_revision` and canonical `table_operators`; and both lanes call
+`tools/check-shard-union.sh` for exact subset/disjoint/union equality. A checksum is an artifact
+identity control, not a replacement for these content-completeness controls. An older attempt with
+identical compatible content is valid by policy; an incompatible older payload is rejected by its
+checksum, universe, manifest, or exact-union diagnostic.
+
+A scheduling change must not be able to silently narrow what runs, so each aggregator downloads its
+shards' inventories and proves the split is a true partition of the unsharded set before trusting a
+`success` result:
 
 - `rust-workspace` downloads the three `rust-tests` shards' `full.txt`/`shard.txt` (written by
   `check_rust_tests` in `tools/check-native-integration.sh` *before* the shard's tests run, so the
@@ -316,6 +342,25 @@ shard entry, an empty shard list, and an entire binary's tests dropped from ever
 no longer has, and one binary pinned to two shards). It is wired into
 `tools/check-merge-readiness.sh`'s `check_automation`, alongside
 `check-product-gate-scope.sh selftest`.
+
+The cohort helper's selftest calibrates compatible partial/all-current cohorts and isolated
+rejecting mutations for missing shards, unchanged-sidecar payload edits, incompatible universes,
+foreign lane/run/revision/index provenance, future attempts, and semantic base-revision drift. Each
+rejection asserts the produced value beside the expected diagnostic. The parser-backed
+`.github/scripts/validate-shard-artifact-workflow.py` and
+`tests/test_shard_artifact_workflow.py` additionally reject one-sided name/pattern drift, lost
+overwrite/provenance/helper wiring, lost aggregator/dependency guards, and accidental changes to
+unsharded attempt-scoped artifacts. All are required by `check-merge-readiness.sh automation`.
+
+This local evidence does not establish GitHub's cross-attempt `upload-artifact@v4` overwrite scope,
+the visibility of an unchanged attempt-N artifact to an attempt-N+1 download, or duplicate-name
+selection behavior. The implementation must not merge until a controlled Actions probe has observed
+one shard failing only after its attempt-1 upload, `rerun --failed` producing attempts `[1,2,1]`, one
+artifact per stable logical name, and successful aggregation in both directory shapes. The run id,
+attempts, artifact ids/names/timestamps, sidecar attempts, and aggregator diagnostics must then be
+recorded here. If the probe contradicts stable-slot semantics, this design is not accepted for merge;
+it must return to the bounded same-run resolver alternative rather than interpreting ambiguity as
+green.
 
 **Agent-configuration-exempt pull requests still work.** Every shard job runs
 `check-product-gate-scope.sh` itself and early-exits its own later steps when `run=false`, so the

--- a/docs/DESIGN-semantic-mutation-gate.md
+++ b/docs/DESIGN-semantic-mutation-gate.md
@@ -163,8 +163,9 @@ tier (`changed`/`complete`), with the same classifications and the same evidence
   rerun may validly aggregate compatible attempts such as `[N,N+1,N]`. Before content completeness,
   `tools/check-shard-artifact-cohort.sh semantic` requires exactly one provenance sidecar for each
   logical shard and validates its schema, lane/run/revision/shard identity, bounded attempt, and
-  canonical payload checksums. It then enforces identical `base_revision` and canonical
-  `table_operators` across all three manifests, and the disjoint union of their
+  canonical payload checksums. It then enforces identical `base_revision` and raw JSON-array-exact
+  `table_operators` across all three manifests (canonicalization is only for checksums and set-union
+  input), and the disjoint union of their
   `executed_operators` equal to `table_operators` exactly (via `tools/check-shard-union.sh`, the same
   fail-closed subset/disjoint/union-equality primitive used by the `rust workspace` split). A shard
   writes its manifest and provenance only after it succeeds, so a failed shard cannot contribute

--- a/docs/DESIGN-semantic-mutation-gate.md
+++ b/docs/DESIGN-semantic-mutation-gate.md
@@ -159,12 +159,16 @@ tier (`changed`/`complete`), with the same classifications and the same evidence
   equivalents check) would add real risk for no measured wall-clock gain.
 - The `semantic-mutation` aggregator requires both lanes to report `success` (`if: always()`, so a
   failing shard cannot be masked by a GitHub-treated-as-satisfied *skip* of the aggregator), then
-  downloads every operator shard's `shard-manifest.v1.json` and enforces completeness: identical
-  `base_revision` and `table_operators` across all three manifests, and the disjoint union of their
+  downloads every stable-name operator shard artifact. The names omit `run_attempt`, so a partial
+  rerun may validly aggregate compatible attempts such as `[N,N+1,N]`. Before content completeness,
+  `tools/check-shard-artifact-cohort.sh semantic` requires exactly one provenance sidecar for each
+  logical shard and validates its schema, lane/run/revision/shard identity, bounded attempt, and
+  canonical payload checksums. It then enforces identical `base_revision` and canonical
+  `table_operators` across all three manifests, and the disjoint union of their
   `executed_operators` equal to `table_operators` exactly (via `tools/check-shard-union.sh`, the same
   fail-closed subset/disjoint/union-equality primitive used by the `rust workspace` split). A shard
-  writes its manifest only after it succeeds, so a failed shard cannot contribute a manifest that
-  reads as complete.
+  writes its manifest and provenance only after it succeeds, so a failed shard cannot contribute
+  evidence that reads as complete; its `if: always()` upload remains diagnostic only.
 
 With no `--lane` flag, `tools/run-semantic-mutation-gate.sh`'s behavior is unchanged from before this
 split: the same manifest test, the same unsharded `run-fault-operators.sh` call, and the same

--- a/tests/test_shard_artifact_workflow.py
+++ b/tests/test_shard_artifact_workflow.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Calibrated controls for the parser-backed shard artifact workflow audit."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "validate-shard-artifact-workflow.py"
+SPEC = importlib.util.spec_from_file_location("validate_shard_artifact_workflow", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+validator = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = validator
+SPEC.loader.exec_module(validator)
+
+
+@pytest.fixture()
+def workflow() -> dict:
+    return copy.deepcopy(validator.load_workflow(validator.WORKFLOW))
+
+
+def step(document: dict, job: str, name: str) -> dict:
+    return next(item for item in document["jobs"][job]["steps"] if item.get("name") == name)
+
+
+def assert_rejected(document: dict, diagnostic: str) -> None:
+    errors = validator.audit_workflow(document)
+    assert errors, "the isolated mutation must not pass silently"
+    assert any(diagnostic in error for error in errors), f"produced={errors!r}; expected={diagnostic!r}"
+
+
+def test_live_workflow_is_accepted() -> None:
+    errors = validator.audit_workflow(validator.load_workflow(validator.WORKFLOW))
+    assert errors == []
+
+
+@pytest.mark.parametrize(
+    ("job", "name", "diagnostic"),
+    [
+        ("rust-tests", "Preserve test-shard inventory", "rust-tests upload name"),
+        ("semantic-mutation-operators", "Preserve operator shard evidence", "semantic-mutation-operators upload name"),
+    ],
+)
+def test_one_sided_run_attempt_reintroduction_is_rejected(
+    workflow: dict, job: str, name: str, diagnostic: str
+) -> None:
+    upload = step(workflow, job, name)
+    upload["with"]["name"] += "-${{ github.run_attempt }}"
+    assert_rejected(workflow, diagnostic)
+
+
+def test_download_pattern_run_attempt_reintroduction_is_rejected(workflow: dict) -> None:
+    download = step(workflow, "rust-workspace", "Download rust test-shard inventories")
+    download["with"]["pattern"] += "-${{ github.run_attempt }}"
+    assert_rejected(workflow, "rust-workspace download pattern")
+
+
+def test_overwrite_removal_is_rejected(workflow: dict) -> None:
+    upload = step(workflow, "semantic-mutation-operators", "Preserve operator shard evidence")
+    upload["with"]["overwrite"] = False
+    assert_rejected(workflow, "upload overwrite: expected True, actual False")
+
+
+def test_provenance_step_removal_is_rejected(workflow: dict) -> None:
+    steps = workflow["jobs"]["rust-tests"]["steps"]
+    steps.remove(step(workflow, "rust-tests", "Record test-shard provenance"))
+    assert_rejected(workflow, "expected exactly one provenance step")
+
+
+def test_common_helper_bypass_is_rejected(workflow: dict) -> None:
+    verify = step(workflow, "semantic-mutation", "Verify operator shard completeness")
+    verify["run"] = "./tools/check-shard-union.sh full.txt shard-*.txt"
+    assert_rejected(workflow, "semantic-mutation verifier")
+
+
+def test_aggregator_always_guard_removal_is_rejected(workflow: dict) -> None:
+    workflow["jobs"]["rust-workspace"]["if"] = "success()"
+    assert_rejected(workflow, "jobs.rust-workspace.if")
+
+
+def test_dependency_result_guard_removal_is_rejected(workflow: dict) -> None:
+    guard = step(workflow, "semantic-mutation", "Require complete operator-shard and mutants-lane evidence")
+    del guard["env"]["SEMANTIC_MUTATION_OPERATORS"]
+    assert_rejected(workflow, "dependency guard env: expected 'SEMANTIC_MUTATION_OPERATORS'")
+
+
+def test_unsharded_artifact_attempt_scope_is_preserved(workflow: dict) -> None:
+    upload = step(workflow, "semantic-mutation-mutants", "Preserve mutation evidence")
+    upload["with"]["name"] = "semantic-mutation-mutants-${{ github.run_id }}"
+    assert_rejected(workflow, "semantic-mutation-mutants upload name")

--- a/tests/test_shard_artifact_workflow.py
+++ b/tests/test_shard_artifact_workflow.py
@@ -89,7 +89,26 @@ def test_dependency_result_guard_removal_is_rejected(workflow: dict) -> None:
     assert_rejected(workflow, "dependency guard env: expected 'SEMANTIC_MUTATION_OPERATORS'")
 
 
-def test_unsharded_artifact_attempt_scope_is_preserved(workflow: dict) -> None:
-    upload = step(workflow, "semantic-mutation-mutants", "Preserve mutation evidence")
-    upload["with"]["name"] = "semantic-mutation-mutants-${{ github.run_id }}"
-    assert_rejected(workflow, "semantic-mutation-mutants upload name")
+@pytest.mark.parametrize(
+    ("job", "step_name", "mutated_name", "diagnostic"),
+    [
+        (
+            "semantic-mutation-mutants",
+            "Preserve mutation evidence",
+            "semantic-mutation-mutants-${{ github.run_id }}",
+            "semantic-mutation-mutants upload name",
+        ),
+        (
+            "fsl-logic",
+            "Preserve FSL Logic evidence",
+            "fsl-logic-${{ github.run_id }}",
+            "fsl-logic upload name",
+        ),
+    ],
+)
+def test_unsharded_artifact_attempt_scope_is_preserved(
+    workflow: dict, job: str, step_name: str, mutated_name: str, diagnostic: str
+) -> None:
+    upload = step(workflow, job, step_name)
+    upload["with"]["name"] = mutated_name
+    assert_rejected(workflow, diagnostic)

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -67,6 +67,13 @@ check_automation() {
   # `rust workspace` and `semantic mutation` aggregators depend on
   # (docs/DESIGN-ci.md, "Sharded pre-merge Linux evidence").
   ./tools/check-shard-union.sh selftest
+  # Stable logical shard artifacts deliberately admit a compatible mixed-
+  # attempt cohort after a partial rerun. Calibrate the provenance/checksum/
+  # identity policy, then audit the live workflow through its parsed YAML
+  # structure so one producer or aggregator cannot drift independently.
+  ./tools/check-shard-artifact-cohort.sh selftest
+  python3 -m pytest tests/test_shard_artifact_workflow.py -v
+  python3 .github/scripts/validate-shard-artifact-workflow.py
   # Accepting/rejecting controls for the ruleset drift audit's compareRuleset/
   # validateContract classifier (docs/DESIGN-ci.md, "Ruleset drift audit").
   node --test .github/scripts/audit-ruleset-drift.test.mjs

--- a/tools/check-shard-artifact-cohort.sh
+++ b/tools/check-shard-artifact-cohort.sh
@@ -52,10 +52,14 @@ check_cohort() {
     prefix="semantic-mutation-operators"
   fi
 
-  local -a artifact_dirs=() provenances=()
+  local -a artifact_dirs=() recursive_provenances=() provenances=()
   mapfile -t artifact_dirs < <(find "$cohort" -mindepth 1 -maxdepth 1 -type d | sort)
   if [ "${#artifact_dirs[@]}" -ne "$expected_total" ]; then
     fail "$expected_lane: expected $expected_total artifact directories, found ${#artifact_dirs[@]}"
+  fi
+  mapfile -t recursive_provenances < <(find "$cohort" -type f -name artifact-provenance.v1.json | sort)
+  if [ "${#recursive_provenances[@]}" -ne "$expected_total" ]; then
+    fail "$expected_lane: expected $expected_total provenance sidecars, found ${#recursive_provenances[@]}"
   fi
 
   local work
@@ -152,6 +156,12 @@ check_cohort() {
     expect_equal full_sha256 "$expected_full_hash" "$actual_full_hash" "$artifact_name"
     expect_equal shard_sha256 "$expected_shard_hash" "$actual_shard_hash" "$artifact_name"
   done
+
+  if ! cmp -s \
+    <(printf '%s\n' "${recursive_provenances[@]}") \
+    <(printf '%s\n' "${provenances[@]}" | sort); then
+    fail "$expected_lane: provenance sidecar set mismatch: recursive cohort set must equal selected direct sidecar set"
+  fi
 
   local sorted_indices
   sorted_indices="$(printf '%s\n' "${seen[@]}" | sort -n | paste -sd, -)"
@@ -321,6 +331,15 @@ selftest() {
   expect_rejected nested-foreign-artifact-name \
     "artifact_name mismatch: expected 'rust-test-shard-<shard.index>-77', actual 'rust-test-shard-foreign-1-77'" \
     check_cohort rust "$tmp/nested-foreign" 77 2 rev-good 3
+
+  cp -R "$tmp/partial" "$tmp/surplus-nested-provenance"
+  mkdir -p "$tmp/surplus-nested-provenance/rust-test-shard-1-77/nested"
+  jq '.run_id = "88"' \
+    "$tmp/surplus-nested-provenance/rust-test-shard-1-77/artifact-provenance.v1.json" \
+    >"$tmp/surplus-nested-provenance/rust-test-shard-1-77/nested/artifact-provenance.v1.json"
+  expect_rejected surplus-nested-provenance \
+    "expected 3 provenance sidecars, found 4" \
+    check_cohort rust "$tmp/surplus-nested-provenance" 77 2 rev-good 3
 
   cp -R "$tmp/partial" "$tmp/future"
   jq '.run_attempt = 3' "$tmp/future/rust-test-shard-2-77/artifact-provenance.v1.json" >"$tmp/mutated.json"

--- a/tools/check-shard-artifact-cohort.sh
+++ b/tools/check-shard-artifact-cohort.sh
@@ -35,6 +35,14 @@ expect_equal() {
   [ "$actual" = "$expected" ] || fail "$artifact: $label mismatch: expected '$expected', actual '$actual'"
 }
 
+enumerate_sorted_paths() {
+  local destination="$1" label="$2"
+  shift 2
+  local unsorted="$destination.unsorted"
+  find "$@" -print0 >"$unsorted" || fail "$label enumeration failed"
+  sort -z "$unsorted" >"$destination" || fail "$label sorting failed"
+}
+
 check_cohort() {
   local mode="$1" cohort="$2" expected_run_id="$3" current_attempt="$4" expected_revision="$5" expected_total="$6"
   [[ "$mode" = rust || "$mode" = semantic ]] || fail "mode must be 'rust' or 'semantic', got '$mode'"
@@ -52,21 +60,28 @@ check_cohort() {
     prefix="semantic-mutation-operators"
   fi
 
+  local work
+  work="$(mktemp -d)"
   local -a artifact_dirs=() recursive_provenances=() provenances=()
-  mapfile -t artifact_dirs < <(find "$cohort" -mindepth 1 -maxdepth 1 -type d | sort)
+  enumerate_sorted_paths "$work/artifact-directories" "$expected_lane: artifact directory" \
+    "$cohort" -mindepth 1 -maxdepth 1 -type d
+  mapfile -d '' -t artifact_dirs <"$work/artifact-directories" \
+    || fail "$expected_lane: artifact directory result read failed"
   if [ "${#artifact_dirs[@]}" -ne "$expected_total" ]; then
     fail "$expected_lane: expected $expected_total artifact directories, found ${#artifact_dirs[@]}"
   fi
-  mapfile -t recursive_provenances < <(find "$cohort" -type f -name artifact-provenance.v1.json | sort)
+  enumerate_sorted_paths "$work/recursive-provenances" "$expected_lane: recursive provenance" \
+    "$cohort" -type f -name artifact-provenance.v1.json
+  mapfile -d '' -t recursive_provenances <"$work/recursive-provenances" \
+    || fail "$expected_lane: recursive provenance result read failed"
   if [ "${#recursive_provenances[@]}" -ne "$expected_total" ]; then
     fail "$expected_lane: expected $expected_total provenance sidecars, found ${#recursive_provenances[@]}"
   fi
 
-  local work
-  work="$(mktemp -d)"
   local -a seen=() attempts=() fulls=() shards=() manifests=()
-  local artifact_dir
+  local artifact_dir artifact_ordinal=0
   for artifact_dir in "${artifact_dirs[@]}"; do
+    artifact_ordinal=$((artifact_ordinal + 1))
     local artifact_name
     artifact_name="$(basename "$artifact_dir")"
     if [[ ! "$artifact_name" =~ ^${prefix}-([1-9][0-9]*)-${expected_run_id}$ ]]; then
@@ -74,7 +89,10 @@ check_cohort() {
     fi
 
     local -a direct_provenances=()
-    mapfile -t direct_provenances < <(find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -name artifact-provenance.v1.json | sort)
+    enumerate_sorted_paths "$work/direct-provenances-$artifact_ordinal" "$artifact_name: direct provenance" \
+      "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -name artifact-provenance.v1.json
+    mapfile -d '' -t direct_provenances <"$work/direct-provenances-$artifact_ordinal" \
+      || fail "$artifact_name: direct provenance result read failed"
     if [ "${#direct_provenances[@]}" -ne 1 ]; then
       fail "$artifact_name: expected exactly 1 direct provenance sidecar, found ${#direct_provenances[@]}"
     fi
@@ -276,7 +294,7 @@ expect_rejected() {
 selftest() {
   local tmp
   tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' RETURN
+  trap 'chmod u+rwx "$tmp/unreadable-nested/rust-test-shard-1-77/nested" 2>/dev/null || true; chmod -R u+rwx "$tmp" 2>/dev/null || true; rm -rf "$tmp"' RETURN
 
   make_rust_fixture "$tmp/partial" 1,2,1
   check_cohort rust "$tmp/partial" 77 2 rev-good 3 >/dev/null
@@ -340,6 +358,16 @@ selftest() {
   expect_rejected surplus-nested-provenance \
     "expected 3 provenance sidecars, found 4" \
     check_cohort rust "$tmp/surplus-nested-provenance" 77 2 rev-good 3
+
+  cp -R "$tmp/partial" "$tmp/unreadable-nested"
+  mkdir -p "$tmp/unreadable-nested/rust-test-shard-1-77/nested"
+  cp "$tmp/unreadable-nested/rust-test-shard-1-77/artifact-provenance.v1.json" \
+    "$tmp/unreadable-nested/rust-test-shard-1-77/nested/artifact-provenance.v1.json"
+  chmod 000 "$tmp/unreadable-nested/rust-test-shard-1-77/nested"
+  expect_rejected unreadable-nested-provenance \
+    "rust-tests: recursive provenance enumeration failed" \
+    check_cohort rust "$tmp/unreadable-nested" 77 2 rev-good 3
+  chmod u+rwx "$tmp/unreadable-nested/rust-test-shard-1-77/nested"
 
   cp -R "$tmp/partial" "$tmp/future"
   jq '.run_attempt = 3' "$tmp/future/rust-test-shard-2-77/artifact-provenance.v1.json" >"$tmp/mutated.json"

--- a/tools/check-shard-artifact-cohort.sh
+++ b/tools/check-shard-artifact-cohort.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+# Validate one downloaded cohort of stable-name sharded artifacts before the
+# lane-specific exact-union check. Mixed attempts are intentional: a partial
+# rerun may produce [N,N+1,N], but every artifact must belong to this run and
+# revision, identify the expected logical shard, and match its payload hashes.
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+
+fail() {
+  echo "check-shard-artifact-cohort: $*" >&2
+  exit 1
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+canonical_array() {
+  local manifest="$1" field="$2" destination="$3"
+  jq -er --arg field "$field" '.[$field] | if type == "array" and all(.[]; type == "string") then .[] else error($field + " must be an array of strings") end' \
+    "$manifest" | sort -u >"$destination" || fail "'$manifest' field '$field' must be an array of strings"
+  [ -s "$destination" ] || fail "'$manifest' field '$field' produced an empty canonical payload"
+}
+
+expect_equal() {
+  local label="$1" expected="$2" actual="$3" artifact="$4"
+  [ "$actual" = "$expected" ] || fail "$artifact: $label mismatch: expected '$expected', actual '$actual'"
+}
+
+check_cohort() {
+  local mode="$1" cohort="$2" expected_run_id="$3" current_attempt="$4" expected_revision="$5" expected_total="$6"
+  [[ "$mode" = rust || "$mode" = semantic ]] || fail "mode must be 'rust' or 'semantic', got '$mode'"
+  [ -d "$cohort" ] || fail "cohort directory '$cohort' does not exist"
+  [[ "$expected_run_id" =~ ^[1-9][0-9]*$ ]] || fail "expected run_id must be a positive integer, got '$expected_run_id'"
+  [[ "$current_attempt" =~ ^[1-9][0-9]*$ ]] || fail "current attempt must be a positive integer, got '$current_attempt'"
+  [[ "$expected_total" =~ ^[1-9][0-9]*$ ]] || fail "expected shard total must be a positive integer, got '$expected_total'"
+
+  local expected_lane prefix
+  if [ "$mode" = rust ]; then
+    expected_lane="rust-tests"
+    prefix="rust-test-shard"
+  else
+    expected_lane="semantic-mutation-operators"
+    prefix="semantic-mutation-operators"
+  fi
+
+  local -a artifact_dirs=() provenances=()
+  mapfile -t artifact_dirs < <(find "$cohort" -mindepth 1 -maxdepth 1 -type d | sort)
+  if [ "${#artifact_dirs[@]}" -ne "$expected_total" ]; then
+    fail "$expected_lane: expected $expected_total artifact directories, found ${#artifact_dirs[@]}"
+  fi
+  mapfile -t provenances < <(find "$cohort" -name artifact-provenance.v1.json -type f | sort)
+  if [ "${#provenances[@]}" -ne "$expected_total" ]; then
+    fail "$expected_lane: expected $expected_total provenance sidecars, found ${#provenances[@]}"
+  fi
+
+  local work
+  work="$(mktemp -d)"
+  local -a seen=() fulls=() shards=() manifests=()
+  local provenance
+  for provenance in "${provenances[@]}"; do
+    jq -e '
+      type == "object" and
+      .schema == "fslc.shard-artifact-provenance.v1" and
+      (.lane | type == "string") and
+      (.run_id | type == "string" and test("^[1-9][0-9]*$")) and
+      (.run_attempt | type == "number" and floor == .) and
+      (.head_revision | type == "string" and length > 0) and
+      (.shard | type == "object") and
+      (.shard.index | type == "number" and floor == .) and
+      (.shard.total | type == "number" and floor == .) and
+      (.full_sha256 | type == "string" and test("^[0-9a-f]{64}$")) and
+      (.shard_sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+    ' "$provenance" >/dev/null || fail "'$provenance' does not match provenance schema fslc.shard-artifact-provenance.v1"
+
+    local artifact_dir artifact_name lane run_id attempt revision index total expected_name
+    artifact_dir="$(dirname "$provenance")"
+    artifact_name="$(basename "$artifact_dir")"
+    lane="$(jq -r '.lane' "$provenance")"
+    run_id="$(jq -r '.run_id' "$provenance")"
+    attempt="$(jq -r '.run_attempt' "$provenance")"
+    revision="$(jq -r '.head_revision' "$provenance")"
+    index="$(jq -r '.shard.index' "$provenance")"
+    total="$(jq -r '.shard.total' "$provenance")"
+    expected_name="$prefix-$index-$expected_run_id"
+
+    expect_equal lane "$expected_lane" "$lane" "$artifact_name"
+    expect_equal run_id "$expected_run_id" "$run_id" "$artifact_name"
+    expect_equal head_revision "$expected_revision" "$revision" "$artifact_name"
+    expect_equal shard.total "$expected_total" "$total" "$artifact_name"
+    [[ "$index" =~ ^[1-9][0-9]*$ ]] && [ "$index" -le "$expected_total" ] \
+      || fail "$artifact_name: shard.index out of range: expected '1..$expected_total', actual '$index'"
+    expect_equal artifact_name "$expected_name" "$artifact_name" "$artifact_name"
+    [ "$attempt" -ge 1 ] && [ "$attempt" -le "$current_attempt" ] \
+      || fail "$artifact_name: run_attempt out of range: expected '1..$current_attempt', actual '$attempt'"
+    if [[ " ${seen[*]-} " = *" $index "* ]]; then
+      fail "$artifact_name: duplicate shard.index: expected unique '1..$expected_total', actual '$index'"
+    fi
+    seen+=("$index")
+
+    local full_payload shard_payload
+    if [ "$mode" = rust ]; then
+      full_payload="$artifact_dir/full.txt"
+      shard_payload="$artifact_dir/shard.txt"
+      [ -s "$full_payload" ] || fail "$artifact_name: expected non-empty payload '$full_payload'"
+      [ -s "$shard_payload" ] || fail "$artifact_name: expected non-empty payload '$shard_payload'"
+      fulls+=("$full_payload")
+      shards+=("$shard_payload")
+    else
+      local manifest="$artifact_dir/shard-manifest.v1.json"
+      [ -s "$manifest" ] || fail "$artifact_name: expected non-empty payload '$manifest'"
+      jq -e '
+        type == "object" and
+        .schema == "fslc.fault-operator-shard-manifest.v1" and
+        (.base_revision | type == "string" and length > 0) and
+        (.shard.index | type == "number" and floor == .) and
+        (.shard.total | type == "number" and floor == .) and
+        (.table_operators | type == "array" and length > 0 and all(.[]; type == "string")) and
+        (.executed_operators | type == "array" and length > 0 and all(.[]; type == "string"))
+      ' "$manifest" >/dev/null || fail "'$manifest' does not match semantic shard-manifest schema"
+      expect_equal manifest.shard.index "$index" "$(jq -r '.shard.index' "$manifest")" "$artifact_name"
+      expect_equal manifest.shard.total "$total" "$(jq -r '.shard.total' "$manifest")" "$artifact_name"
+      full_payload="$work/full-$index.txt"
+      shard_payload="$work/shard-$index.txt"
+      canonical_array "$manifest" table_operators "$full_payload"
+      canonical_array "$manifest" executed_operators "$shard_payload"
+      fulls+=("$full_payload")
+      shards+=("$shard_payload")
+      manifests+=("$manifest")
+    fi
+
+    local expected_full_hash actual_full_hash expected_shard_hash actual_shard_hash
+    expected_full_hash="$(jq -r '.full_sha256' "$provenance")"
+    actual_full_hash="$(sha256_file "$full_payload")"
+    expected_shard_hash="$(jq -r '.shard_sha256' "$provenance")"
+    actual_shard_hash="$(sha256_file "$shard_payload")"
+    expect_equal full_sha256 "$expected_full_hash" "$actual_full_hash" "$artifact_name"
+    expect_equal shard_sha256 "$expected_shard_hash" "$actual_shard_hash" "$artifact_name"
+  done
+
+  local sorted_indices
+  sorted_indices="$(printf '%s\n' "${seen[@]}" | sort -n | paste -sd, -)"
+  local expected_indices
+  expected_indices="$(seq 1 "$expected_total" | paste -sd, -)"
+  expect_equal shard.indices "$expected_indices" "$sorted_indices" "$expected_lane"
+
+  local first_full_hash index
+  first_full_hash="$(sha256_file "${fulls[0]}")"
+  for index in "${!fulls[@]}"; do
+    expect_equal full_universe_sha256 "$first_full_hash" "$(sha256_file "${fulls[$index]}")" "$(basename "$(dirname "${fulls[$index]}")")"
+  done
+
+  if [ "$mode" = rust ]; then
+    for index in 1 2; do
+      if ! cmp -s "${fulls[0]}" "${fulls[$index]}"; then
+        fail "rust-tests: full payload byte mismatch: expected '${fulls[0]}', actual '${fulls[$index]}'"
+      fi
+    done
+  else
+    local expected_base
+    expected_base="$(jq -er '.base_revision | select(type == "string" and length > 0)' "${manifests[0]}")" \
+      || fail "'${manifests[0]}' has invalid base_revision"
+    for index in "${!manifests[@]}"; do
+      local actual_base
+      actual_base="$(jq -er '.base_revision | select(type == "string" and length > 0)' "${manifests[$index]}")" \
+        || fail "'${manifests[$index]}' has invalid base_revision"
+      expect_equal base_revision "$expected_base" "$actual_base" "$(basename "$(dirname "${manifests[$index]}")")"
+    done
+  fi
+
+  "$root/tools/check-shard-union.sh" "${fulls[0]}" "${shards[@]}"
+  echo "check-shard-artifact-cohort: PASS -- lane=$expected_lane run_id=$expected_run_id attempts=$(for provenance in "${provenances[@]}"; do jq -r '.run_attempt' "$provenance"; done | paste -sd, -) shards=$expected_indices"
+  rm -rf "$work"
+}
+
+write_provenance() {
+  local artifact="$1" lane="$2" run_id="$3" attempt="$4" revision="$5" index="$6" total="$7" full="$8" shard="$9"
+  jq -n --arg lane "$lane" --arg run_id "$run_id" --argjson attempt "$attempt" \
+    --arg revision "$revision" --argjson index "$index" --argjson total "$total" \
+    --arg full_sha256 "$(sha256_file "$full")" --arg shard_sha256 "$(sha256_file "$shard")" \
+    '{schema:"fslc.shard-artifact-provenance.v1", lane:$lane, run_id:$run_id,
+      run_attempt:$attempt, head_revision:$revision, shard:{index:$index,total:$total},
+      full_sha256:$full_sha256, shard_sha256:$shard_sha256}' >"$artifact/artifact-provenance.v1.json"
+}
+
+make_rust_fixture() {
+  local directory="$1" attempts="$2"
+  local -a attempt_values
+  IFS=, read -r -a attempt_values <<<"$attempts"
+  local index
+  for index in 1 2 3; do
+    local artifact="$directory/rust-test-shard-$index-77"
+    mkdir -p "$artifact"
+    printf 'a\nb\nc\nd\ne\nf\n' >"$artifact/full.txt"
+    case "$index" in
+      1) printf 'a\nb\n' >"$artifact/shard.txt" ;;
+      2) printf 'c\nd\n' >"$artifact/shard.txt" ;;
+      3) printf 'e\nf\n' >"$artifact/shard.txt" ;;
+    esac
+    write_provenance "$artifact" rust-tests 77 "${attempt_values[$((index - 1))]}" rev-good "$index" 3 "$artifact/full.txt" "$artifact/shard.txt"
+  done
+}
+
+make_semantic_fixture() {
+  local directory="$1" attempts="$2"
+  local -a attempt_values
+  IFS=, read -r -a attempt_values <<<"$attempts"
+  local index
+  for index in 1 2 3; do
+    local artifact="$directory/semantic-mutation-operators-$index-77"
+    mkdir -p "$artifact"
+    local executed
+    case "$index" in
+      1) executed='["op-a","op-b"]' ;;
+      2) executed='["op-c","op-d"]' ;;
+      3) executed='["op-e","op-f"]' ;;
+    esac
+    jq -n --argjson index "$index" --argjson executed "$executed" \
+      '{schema:"fslc.fault-operator-shard-manifest.v1",schema_version:1,
+        base_revision:"base-good",shard:{index:$index,total:3},
+        table_operators:["op-a","op-b","op-c","op-d","op-e","op-f"],
+        executed_operators:$executed}' >"$artifact/shard-manifest.v1.json"
+    local full="$tmp/semantic-full-$index.txt" shard="$tmp/semantic-shard-$index.txt"
+    canonical_array "$artifact/shard-manifest.v1.json" table_operators "$full"
+    canonical_array "$artifact/shard-manifest.v1.json" executed_operators "$shard"
+    write_provenance "$artifact" semantic-mutation-operators 77 "${attempt_values[$((index - 1))]}" rev-good "$index" 3 "$full" "$shard"
+  done
+}
+
+expect_rejected() {
+  local label="$1" expected="$2"
+  shift 2
+  local output status=0
+  output="$("$@" 2>&1)" || status=$?
+  if [ "$status" -eq 0 ]; then
+    echo "check-shard-artifact-cohort selftest: FAIL: $label mutation was accepted" >&2
+    return 1
+  fi
+  if [[ "$output" != *"$expected"* ]]; then
+    echo "check-shard-artifact-cohort selftest: FAIL: $label produced '$output', expected diagnostic containing '$expected'" >&2
+    return 1
+  fi
+  echo "detector $label: produced='$output'; expected_contains='$expected'"
+}
+
+selftest() {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  make_rust_fixture "$tmp/partial" 1,2,1
+  check_cohort rust "$tmp/partial" 77 2 rev-good 3 >/dev/null
+  make_rust_fixture "$tmp/current" 2,2,2
+  check_cohort rust "$tmp/current" 77 2 rev-good 3 >/dev/null
+  make_semantic_fixture "$tmp/semantic-partial" 1,2,1
+  check_cohort semantic "$tmp/semantic-partial" 77 2 rev-good 3 >/dev/null
+  make_semantic_fixture "$tmp/semantic-current" 2,2,2
+  check_cohort semantic "$tmp/semantic-current" 77 2 rev-good 3 >/dev/null
+
+  cp -R "$tmp/partial" "$tmp/missing"
+  rm -rf "$tmp/missing/rust-test-shard-3-77"
+  expect_rejected missing-shard "expected 3 artifact directories, found 2" check_cohort rust "$tmp/missing" 77 2 rev-good 3
+
+  cp -R "$tmp/partial" "$tmp/checksum"
+  printf 'changed\n' >>"$tmp/checksum/rust-test-shard-1-77/full.txt"
+  expect_rejected stale-payload-checksum "full_sha256 mismatch: expected" check_cohort rust "$tmp/checksum" 77 2 rev-good 3
+
+  cp -R "$tmp/partial" "$tmp/universe"
+  printf 'z\n' >>"$tmp/universe/rust-test-shard-1-77/full.txt"
+  write_provenance "$tmp/universe/rust-test-shard-1-77" rust-tests 77 1 rev-good 1 3 \
+    "$tmp/universe/rust-test-shard-1-77/full.txt" "$tmp/universe/rust-test-shard-1-77/shard.txt"
+  expect_rejected incompatible-stale-universe "full_universe_sha256 mismatch: expected" check_cohort rust "$tmp/universe" 77 2 rev-good 3
+
+  local field expected actual
+  for field in lane run_id head_revision; do
+    cp -R "$tmp/partial" "$tmp/foreign-$field"
+    case "$field" in
+      lane) expected="lane mismatch: expected 'rust-tests', actual 'semantic-mutation-operators'"; actual=semantic-mutation-operators ;;
+      run_id) expected="run_id mismatch: expected '77', actual '88'"; actual=88 ;;
+      head_revision) expected="head_revision mismatch: expected 'rev-good', actual 'rev-foreign'"; actual=rev-foreign ;;
+    esac
+    jq --arg value "$actual" ".${field} = \$value" "$tmp/foreign-$field/rust-test-shard-1-77/artifact-provenance.v1.json" >"$tmp/mutated.json"
+    mv "$tmp/mutated.json" "$tmp/foreign-$field/rust-test-shard-1-77/artifact-provenance.v1.json"
+    expect_rejected "foreign-$field" "$expected" check_cohort rust "$tmp/foreign-$field" 77 2 rev-good 3
+  done
+
+  cp -R "$tmp/partial" "$tmp/foreign-index"
+  jq '.shard.index = 2' "$tmp/foreign-index/rust-test-shard-1-77/artifact-provenance.v1.json" >"$tmp/mutated.json"
+  mv "$tmp/mutated.json" "$tmp/foreign-index/rust-test-shard-1-77/artifact-provenance.v1.json"
+  expect_rejected foreign-shard-index "artifact_name mismatch: expected 'rust-test-shard-2-77', actual 'rust-test-shard-1-77'" check_cohort rust "$tmp/foreign-index" 77 2 rev-good 3
+
+  cp -R "$tmp/partial" "$tmp/future"
+  jq '.run_attempt = 3' "$tmp/future/rust-test-shard-2-77/artifact-provenance.v1.json" >"$tmp/mutated.json"
+  mv "$tmp/mutated.json" "$tmp/future/rust-test-shard-2-77/artifact-provenance.v1.json"
+  expect_rejected future-attempt "run_attempt out of range: expected '1..2', actual '3'" check_cohort rust "$tmp/future" 77 2 rev-good 3
+
+  cp -R "$tmp/semantic-partial" "$tmp/semantic-base"
+  jq '.base_revision = "base-foreign"' "$tmp/semantic-base/semantic-mutation-operators-2-77/shard-manifest.v1.json" >"$tmp/mutated.json"
+  mv "$tmp/mutated.json" "$tmp/semantic-base/semantic-mutation-operators-2-77/shard-manifest.v1.json"
+  expect_rejected semantic-base-revision "base_revision mismatch: expected 'base-good', actual 'base-foreign'" check_cohort semantic "$tmp/semantic-base" 77 2 rev-good 3
+
+  echo "check-shard-artifact-cohort selftest: all assertions passed"
+}
+
+case "${1:-}" in
+  rust|semantic)
+    [ "$#" -eq 6 ] || fail "usage: $0 {rust|semantic} <cohort-dir> <run-id> <current-attempt> <head-revision> <shard-total>"
+    check_cohort "$@"
+    ;;
+  selftest)
+    [ "$#" -eq 1 ] || fail "selftest takes no arguments"
+    selftest
+    ;;
+  *)
+    fail "usage: $0 {rust|semantic} <cohort-dir> <run-id> <current-attempt> <head-revision> <shard-total> | selftest"
+    ;;
+esac

--- a/tools/check-shard-artifact-cohort.sh
+++ b/tools/check-shard-artifact-cohort.sh
@@ -8,7 +8,14 @@
 
 set -euo pipefail
 
-root="$(cd "$(dirname "$0")/.." && pwd)"
+script_dir="$(dirname "$0")" || {
+  echo "check-shard-artifact-cohort: script directory resolution failed" >&2
+  exit 1
+}
+root="$(cd "$script_dir/.." && pwd)" || {
+  echo "check-shard-artifact-cohort: repository root resolution failed" >&2
+  exit 1
+}
 
 fail() {
   echo "check-shard-artifact-cohort: $*" >&2
@@ -43,6 +50,17 @@ enumerate_sorted_paths() {
   sort -z "$unsorted" >"$destination" || fail "$label sorting failed"
 }
 
+checked_sort_file() {
+  local source="$1" destination="$2" label="$3"
+  shift 3
+  sort "$@" "$source" >"$destination" || fail "$label sorting failed"
+}
+
+checked_join_file() {
+  local source="$1" destination="$2" delimiter="$3" label="$4"
+  paste -sd "$delimiter" "$source" >"$destination" || fail "$label joining failed"
+}
+
 check_cohort() {
   local mode="$1" cohort="$2" expected_run_id="$3" current_attempt="$4" expected_revision="$5" expected_total="$6"
   [[ "$mode" = rust || "$mode" = semantic ]] || fail "mode must be 'rust' or 'semantic', got '$mode'"
@@ -61,7 +79,7 @@ check_cohort() {
   fi
 
   local work
-  work="$(mktemp -d)"
+  work="$(mktemp -d)" || fail "$expected_lane: temporary directory creation failed"
   local -a artifact_dirs=() recursive_provenances=() provenances=()
   enumerate_sorted_paths "$work/artifact-directories" "$expected_lane: artifact directory" \
     "$cohort" -mindepth 1 -maxdepth 1 -type d
@@ -83,7 +101,8 @@ check_cohort() {
   for artifact_dir in "${artifact_dirs[@]}"; do
     artifact_ordinal=$((artifact_ordinal + 1))
     local artifact_name
-    artifact_name="$(basename "$artifact_dir")"
+    artifact_name="$(basename "$artifact_dir")" \
+      || fail "$expected_lane: artifact name extraction failed"
     if [[ ! "$artifact_name" =~ ^${prefix}-([1-9][0-9]*)-${expected_run_id}$ ]]; then
       fail "$artifact_name: artifact_name mismatch: expected '$prefix-<shard.index>-$expected_run_id', actual '$artifact_name'"
     fi
@@ -157,8 +176,13 @@ check_cohort() {
         (.table_operators | type == "array" and length > 0 and all(.[]; type == "string")) and
         (.executed_operators | type == "array" and length > 0 and all(.[]; type == "string"))
       ' "$manifest" >/dev/null || fail "'$manifest' does not match semantic shard-manifest schema"
-      expect_equal manifest.shard.index "$index" "$(jq -r '.shard.index' "$manifest")" "$artifact_name"
-      expect_equal manifest.shard.total "$total" "$(jq -r '.shard.total' "$manifest")" "$artifact_name"
+      local manifest_index manifest_total
+      manifest_index="$(jq -r '.shard.index' "$manifest")" \
+        || fail "'$manifest' shard.index extraction failed"
+      manifest_total="$(jq -r '.shard.total' "$manifest")" \
+        || fail "'$manifest' shard.total extraction failed"
+      expect_equal manifest.shard.index "$index" "$manifest_index" "$artifact_name"
+      expect_equal manifest.shard.total "$total" "$manifest_total" "$artifact_name"
       full_payload="$work/full-$index.txt"
       shard_payload="$work/shard-$index.txt"
       canonical_array "$manifest" table_operators "$full_payload"
@@ -169,28 +193,50 @@ check_cohort() {
     fi
 
     local actual_full_hash actual_shard_hash
-    actual_full_hash="$(sha256_file "$full_payload")"
-    actual_shard_hash="$(sha256_file "$shard_payload")"
+    actual_full_hash="$(sha256_file "$full_payload")" \
+      || fail "'$full_payload' hashing failed"
+    actual_shard_hash="$(sha256_file "$shard_payload")" \
+      || fail "'$shard_payload' hashing failed"
     expect_equal full_sha256 "$expected_full_hash" "$actual_full_hash" "$artifact_name"
     expect_equal shard_sha256 "$expected_shard_hash" "$actual_shard_hash" "$artifact_name"
   done
 
-  if ! cmp -s \
-    <(printf '%s\n' "${recursive_provenances[@]}") \
-    <(printf '%s\n' "${provenances[@]}" | sort); then
+  printf '%s\0' "${provenances[@]}" >"$work/selected-provenances.unsorted" \
+    || fail "$expected_lane: selected direct provenance serialization failed"
+  checked_sort_file "$work/selected-provenances.unsorted" "$work/selected-provenances" \
+    "$expected_lane: selected direct provenance" -z -u
+  if ! cmp -s "$work/recursive-provenances" "$work/selected-provenances"; then
     fail "$expected_lane: provenance sidecar set mismatch: recursive cohort set must equal selected direct sidecar set"
   fi
 
+  printf '%s\n' "${seen[@]}" >"$work/seen-indices.unsorted" \
+    || fail "$expected_lane: observed shard index serialization failed"
+  checked_sort_file "$work/seen-indices.unsorted" "$work/seen-indices" \
+    "$expected_lane: observed shard index" -n
+  checked_join_file "$work/seen-indices" "$work/seen-indices.csv" , \
+    "$expected_lane: observed shard index"
   local sorted_indices
-  sorted_indices="$(printf '%s\n' "${seen[@]}" | sort -n | paste -sd, -)"
+  IFS= read -r sorted_indices <"$work/seen-indices.csv" \
+    || fail "$expected_lane: observed shard index result read failed"
+  seq 1 "$expected_total" >"$work/expected-indices" \
+    || fail "$expected_lane: expected shard index generation failed"
+  checked_join_file "$work/expected-indices" "$work/expected-indices.csv" , \
+    "$expected_lane: expected shard index"
   local expected_indices
-  expected_indices="$(seq 1 "$expected_total" | paste -sd, -)"
+  IFS= read -r expected_indices <"$work/expected-indices.csv" \
+    || fail "$expected_lane: expected shard index result read failed"
   expect_equal shard.indices "$expected_indices" "$sorted_indices" "$expected_lane"
 
   local first_full_hash index
-  first_full_hash="$(sha256_file "${fulls[0]}")"
+  first_full_hash="$(sha256_file "${fulls[0]}")" \
+    || fail "'${fulls[0]}' baseline full-universe hashing failed"
   for index in "${!fulls[@]}"; do
-    expect_equal full_universe_sha256 "$first_full_hash" "$(sha256_file "${fulls[$index]}")" "$(basename "$(dirname "${fulls[$index]}")")"
+    local actual_universe_hash universe_parent universe_artifact
+    actual_universe_hash="$(sha256_file "${fulls[$index]}")" \
+      || fail "'${fulls[$index]}' full-universe hashing failed"
+    universe_parent="${fulls[$index]%/*}"
+    universe_artifact="${universe_parent##*/}"
+    expect_equal full_universe_sha256 "$first_full_hash" "$actual_universe_hash" "$universe_artifact"
   done
 
   if [ "$mode" = rust ]; then
@@ -211,21 +257,34 @@ check_cohort() {
         || fail "'${manifests[$index]}' has invalid base_revision"
       actual_table_operators="$(jq -ec '.table_operators' "${manifests[$index]}")" \
         || fail "'${manifests[$index]}' has invalid table_operators"
-      expect_equal base_revision "$expected_base" "$actual_base" "$(basename "$(dirname "${manifests[$index]}")")"
-      expect_equal table_operators "$expected_table_operators" "$actual_table_operators" "$(basename "$(dirname "${manifests[$index]}")")"
+      local manifest_parent manifest_artifact
+      manifest_parent="${manifests[$index]%/*}"
+      manifest_artifact="${manifest_parent##*/}"
+      expect_equal base_revision "$expected_base" "$actual_base" "$manifest_artifact"
+      expect_equal table_operators "$expected_table_operators" "$actual_table_operators" "$manifest_artifact"
     done
   fi
 
   "$root/tools/check-shard-union.sh" "${fulls[0]}" "${shards[@]}"
-  echo "check-shard-artifact-cohort: PASS -- lane=$expected_lane run_id=$expected_run_id attempts=$(printf '%s\n' "${attempts[@]}" | paste -sd, -) shards=$expected_indices"
+  printf '%s\n' "${attempts[@]}" >"$work/attempts" \
+    || fail "$expected_lane: attempt serialization failed"
+  FSL_COHORT_JOIN_CONTEXT=attempts \
+    checked_join_file "$work/attempts" "$work/attempts.csv" , "$expected_lane: attempt display"
+  local attempts_csv
+  IFS= read -r attempts_csv <"$work/attempts.csv" \
+    || fail "$expected_lane: attempt display result read failed"
+  echo "check-shard-artifact-cohort: PASS -- lane=$expected_lane run_id=$expected_run_id attempts=$attempts_csv shards=$expected_indices"
   rm -rf "$work"
 }
 
 write_provenance() {
   local artifact="$1" lane="$2" run_id="$3" attempt="$4" revision="$5" index="$6" total="$7" full="$8" shard="$9"
+  local full_sha256 shard_sha256
+  full_sha256="$(sha256_file "$full")" || fail "'$full' provenance hashing failed"
+  shard_sha256="$(sha256_file "$shard")" || fail "'$shard' provenance hashing failed"
   jq -n --arg lane "$lane" --arg run_id "$run_id" --argjson attempt "$attempt" \
     --arg revision "$revision" --argjson index "$index" --argjson total "$total" \
-    --arg full_sha256 "$(sha256_file "$full")" --arg shard_sha256 "$(sha256_file "$shard")" \
+    --arg full_sha256 "$full_sha256" --arg shard_sha256 "$shard_sha256" \
     '{schema:"fslc.shard-artifact-provenance.v1", lane:$lane, run_id:$run_id,
       run_attempt:$attempt, head_revision:$revision, shard:{index:$index,total:$total},
       full_sha256:$full_sha256, shard_sha256:$shard_sha256}' >"$artifact/artifact-provenance.v1.json"
@@ -293,7 +352,7 @@ expect_rejected() {
 
 selftest() {
   local tmp
-  tmp="$(mktemp -d)"
+  tmp="$(mktemp -d)" || fail "selftest temporary directory creation failed"
   trap 'chmod u+rwx "$tmp/unreadable-nested/rust-test-shard-1-77/nested" 2>/dev/null || true; chmod -R u+rwx "$tmp" 2>/dev/null || true; rm -rf "$tmp"' RETURN
 
   make_rust_fixture "$tmp/partial" 1,2,1
@@ -304,6 +363,40 @@ selftest() {
   check_cohort semantic "$tmp/semantic-partial" 77 2 rev-good 3 >/dev/null
   make_semantic_fixture "$tmp/semantic-current" 2,2,2
   check_cohort semantic "$tmp/semantic-current" 77 2 rev-good 3 >/dev/null
+
+  local real_sort real_paste
+  real_sort="$(command -v sort)" || fail "selftest could not resolve sort"
+  real_paste="$(command -v paste)" || fail "selftest could not resolve paste"
+  mkdir -p "$tmp/failing-sort" "$tmp/failing-paste"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'for argument in "$@"; do' \
+    '  if [ "$argument" = "-u" ]; then' \
+    '    "$REAL_SORT" "$@"' \
+    '    echo "injected comparison sort failure" >&2' \
+    '    exit 42' \
+    '  fi' \
+    'done' \
+    'exec "$REAL_SORT" "$@"' >"$tmp/failing-sort/sort" \
+    || fail "selftest comparison-sort wrapper creation failed"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'if [ "${FSL_COHORT_JOIN_CONTEXT:-}" = "attempts" ]; then' \
+    '  "$REAL_PASTE" "$@"' \
+    '  echo "injected attempt paste failure" >&2' \
+    '  exit 44' \
+    'fi' \
+    'exec "$REAL_PASTE" "$@"' >"$tmp/failing-paste/paste" \
+    || fail "selftest attempt-paste wrapper creation failed"
+  chmod +x "$tmp/failing-sort/sort" "$tmp/failing-paste/paste"
+  expect_rejected comparison-sort-failure \
+    "rust-tests: selected direct provenance sorting failed" \
+    env PATH="$tmp/failing-sort:$PATH" REAL_SORT="$real_sort" \
+    "$root/tools/check-shard-artifact-cohort.sh" rust "$tmp/partial" 77 2 rev-good 3
+  expect_rejected attempt-paste-failure \
+    "rust-tests: attempt display joining failed" \
+    env PATH="$tmp/failing-paste:$PATH" REAL_PASTE="$real_paste" \
+    "$root/tools/check-shard-artifact-cohort.sh" rust "$tmp/partial" 77 2 rev-good 3
 
   cp -R "$tmp/partial" "$tmp/missing"
   rm -rf "$tmp/missing/rust-test-shard-3-77"

--- a/tools/check-shard-artifact-cohort.sh
+++ b/tools/check-shard-artifact-cohort.sh
@@ -57,39 +57,47 @@ check_cohort() {
   if [ "${#artifact_dirs[@]}" -ne "$expected_total" ]; then
     fail "$expected_lane: expected $expected_total artifact directories, found ${#artifact_dirs[@]}"
   fi
-  mapfile -t provenances < <(find "$cohort" -name artifact-provenance.v1.json -type f | sort)
-  if [ "${#provenances[@]}" -ne "$expected_total" ]; then
-    fail "$expected_lane: expected $expected_total provenance sidecars, found ${#provenances[@]}"
-  fi
 
   local work
   work="$(mktemp -d)"
-  local -a seen=() fulls=() shards=() manifests=()
-  local provenance
-  for provenance in "${provenances[@]}"; do
-    jq -e '
-      type == "object" and
-      .schema == "fslc.shard-artifact-provenance.v1" and
-      (.lane | type == "string") and
-      (.run_id | type == "string" and test("^[1-9][0-9]*$")) and
-      (.run_attempt | type == "number" and floor == .) and
-      (.head_revision | type == "string" and length > 0) and
-      (.shard | type == "object") and
-      (.shard.index | type == "number" and floor == .) and
-      (.shard.total | type == "number" and floor == .) and
-      (.full_sha256 | type == "string" and test("^[0-9a-f]{64}$")) and
-      (.shard_sha256 | type == "string" and test("^[0-9a-f]{64}$"))
-    ' "$provenance" >/dev/null || fail "'$provenance' does not match provenance schema fslc.shard-artifact-provenance.v1"
-
-    local artifact_dir artifact_name lane run_id attempt revision index total expected_name
-    artifact_dir="$(dirname "$provenance")"
+  local -a seen=() attempts=() fulls=() shards=() manifests=()
+  local artifact_dir
+  for artifact_dir in "${artifact_dirs[@]}"; do
+    local artifact_name
     artifact_name="$(basename "$artifact_dir")"
-    lane="$(jq -r '.lane' "$provenance")"
-    run_id="$(jq -r '.run_id' "$provenance")"
-    attempt="$(jq -r '.run_attempt' "$provenance")"
-    revision="$(jq -r '.head_revision' "$provenance")"
-    index="$(jq -r '.shard.index' "$provenance")"
-    total="$(jq -r '.shard.total' "$provenance")"
+    if [[ ! "$artifact_name" =~ ^${prefix}-([1-9][0-9]*)-${expected_run_id}$ ]]; then
+      fail "$artifact_name: artifact_name mismatch: expected '$prefix-<shard.index>-$expected_run_id', actual '$artifact_name'"
+    fi
+
+    local -a direct_provenances=()
+    mapfile -t direct_provenances < <(find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -name artifact-provenance.v1.json | sort)
+    if [ "${#direct_provenances[@]}" -ne 1 ]; then
+      fail "$artifact_name: expected exactly 1 direct provenance sidecar, found ${#direct_provenances[@]}"
+    fi
+    local provenance="${direct_provenances[0]}"
+    provenances+=("$provenance")
+
+    local provenance_row
+    provenance_row="$(jq -er '
+      select(
+        type == "object" and
+        .schema == "fslc.shard-artifact-provenance.v1" and
+        (.lane | type == "string") and
+        (.run_id | type == "string" and test("^[1-9][0-9]*$")) and
+        (.run_attempt | type == "number" and floor == .) and
+        (.head_revision | type == "string" and length > 0) and
+        (.shard | type == "object") and
+        (.shard.index | type == "number" and floor == .) and
+        (.shard.total | type == "number" and floor == .) and
+        (.full_sha256 | type == "string" and test("^[0-9a-f]{64}$")) and
+        (.shard_sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+      ) |
+      [.lane, .run_id, .run_attempt, .head_revision, .shard.index, .shard.total,
+       .full_sha256, .shard_sha256] | @tsv
+    ' "$provenance")" || fail "'$provenance' does not match provenance schema fslc.shard-artifact-provenance.v1"
+
+    local lane run_id attempt revision index total expected_full_hash expected_shard_hash expected_name
+    IFS=$'\t' read -r lane run_id attempt revision index total expected_full_hash expected_shard_hash <<<"$provenance_row"
     expected_name="$prefix-$index-$expected_run_id"
 
     expect_equal lane "$expected_lane" "$lane" "$artifact_name"
@@ -105,6 +113,7 @@ check_cohort() {
       fail "$artifact_name: duplicate shard.index: expected unique '1..$expected_total', actual '$index'"
     fi
     seen+=("$index")
+    attempts+=("$attempt")
 
     local full_payload shard_payload
     if [ "$mode" = rust ]; then
@@ -137,10 +146,8 @@ check_cohort() {
       manifests+=("$manifest")
     fi
 
-    local expected_full_hash actual_full_hash expected_shard_hash actual_shard_hash
-    expected_full_hash="$(jq -r '.full_sha256' "$provenance")"
+    local actual_full_hash actual_shard_hash
     actual_full_hash="$(sha256_file "$full_payload")"
-    expected_shard_hash="$(jq -r '.shard_sha256' "$provenance")"
     actual_shard_hash="$(sha256_file "$shard_payload")"
     expect_equal full_sha256 "$expected_full_hash" "$actual_full_hash" "$artifact_name"
     expect_equal shard_sha256 "$expected_shard_hash" "$actual_shard_hash" "$artifact_name"
@@ -165,19 +172,24 @@ check_cohort() {
       fi
     done
   else
-    local expected_base
+    local expected_base expected_table_operators
     expected_base="$(jq -er '.base_revision | select(type == "string" and length > 0)' "${manifests[0]}")" \
       || fail "'${manifests[0]}' has invalid base_revision"
+    expected_table_operators="$(jq -ec '.table_operators' "${manifests[0]}")" \
+      || fail "'${manifests[0]}' has invalid table_operators"
     for index in "${!manifests[@]}"; do
-      local actual_base
+      local actual_base actual_table_operators
       actual_base="$(jq -er '.base_revision | select(type == "string" and length > 0)' "${manifests[$index]}")" \
         || fail "'${manifests[$index]}' has invalid base_revision"
+      actual_table_operators="$(jq -ec '.table_operators' "${manifests[$index]}")" \
+        || fail "'${manifests[$index]}' has invalid table_operators"
       expect_equal base_revision "$expected_base" "$actual_base" "$(basename "$(dirname "${manifests[$index]}")")"
+      expect_equal table_operators "$expected_table_operators" "$actual_table_operators" "$(basename "$(dirname "${manifests[$index]}")")"
     done
   fi
 
   "$root/tools/check-shard-union.sh" "${fulls[0]}" "${shards[@]}"
-  echo "check-shard-artifact-cohort: PASS -- lane=$expected_lane run_id=$expected_run_id attempts=$(for provenance in "${provenances[@]}"; do jq -r '.run_attempt' "$provenance"; done | paste -sd, -) shards=$expected_indices"
+  echo "check-shard-artifact-cohort: PASS -- lane=$expected_lane run_id=$expected_run_id attempts=$(printf '%s\n' "${attempts[@]}" | paste -sd, -) shards=$expected_indices"
   rm -rf "$work"
 }
 
@@ -297,6 +309,19 @@ selftest() {
   mv "$tmp/mutated.json" "$tmp/foreign-index/rust-test-shard-1-77/artifact-provenance.v1.json"
   expect_rejected foreign-shard-index "artifact_name mismatch: expected 'rust-test-shard-2-77', actual 'rust-test-shard-1-77'" check_cohort rust "$tmp/foreign-index" 77 2 rev-good 3
 
+  cp -R "$tmp/partial" "$tmp/nested-foreign"
+  local index
+  for index in 1 2 3; do
+    mv "$tmp/nested-foreign/rust-test-shard-$index-77" "$tmp/nested-foreign/rust-test-shard-foreign-$index-77"
+    mkdir -p "$tmp/nested-foreign/rust-test-shard-foreign-$index-77/rust-test-shard-$index-77"
+    find "$tmp/nested-foreign/rust-test-shard-foreign-$index-77" -mindepth 1 -maxdepth 1 \
+      ! -name "rust-test-shard-$index-77" \
+      -exec mv {} "$tmp/nested-foreign/rust-test-shard-foreign-$index-77/rust-test-shard-$index-77/" \;
+  done
+  expect_rejected nested-foreign-artifact-name \
+    "artifact_name mismatch: expected 'rust-test-shard-<shard.index>-77', actual 'rust-test-shard-foreign-1-77'" \
+    check_cohort rust "$tmp/nested-foreign" 77 2 rev-good 3
+
   cp -R "$tmp/partial" "$tmp/future"
   jq '.run_attempt = 3' "$tmp/future/rust-test-shard-2-77/artifact-provenance.v1.json" >"$tmp/mutated.json"
   mv "$tmp/mutated.json" "$tmp/future/rust-test-shard-2-77/artifact-provenance.v1.json"
@@ -306,6 +331,14 @@ selftest() {
   jq '.base_revision = "base-foreign"' "$tmp/semantic-base/semantic-mutation-operators-2-77/shard-manifest.v1.json" >"$tmp/mutated.json"
   mv "$tmp/mutated.json" "$tmp/semantic-base/semantic-mutation-operators-2-77/shard-manifest.v1.json"
   expect_rejected semantic-base-revision "base_revision mismatch: expected 'base-good', actual 'base-foreign'" check_cohort semantic "$tmp/semantic-base" 77 2 rev-good 3
+
+  cp -R "$tmp/semantic-partial" "$tmp/semantic-table-exact"
+  jq '.table_operators += ["op-a"]' \
+    "$tmp/semantic-table-exact/semantic-mutation-operators-2-77/shard-manifest.v1.json" >"$tmp/mutated.json"
+  mv "$tmp/mutated.json" "$tmp/semantic-table-exact/semantic-mutation-operators-2-77/shard-manifest.v1.json"
+  expect_rejected semantic-table-operators-exact \
+    "table_operators mismatch: expected '[\"op-a\",\"op-b\",\"op-c\",\"op-d\",\"op-e\",\"op-f\"]', actual '[\"op-a\",\"op-b\",\"op-c\",\"op-d\",\"op-e\",\"op-f\",\"op-a\"]'" \
+    check_cohort semantic "$tmp/semantic-table-exact" 77 2 rev-good 3
 
   echo "check-shard-artifact-cohort selftest: all assertions passed"
 }


### PR DESCRIPTION
## Problem

Both sharded required lanes (`rust workspace`, `semantic mutation`) embed `github.run_attempt` in artifact names **and** download patterns, so `gh run rerun --failed` can never succeed: re-run shards upload under attempt N+1 while untouched shards stay at attempt N, and the aggregator's attempt-scoped pattern finds only one shard (#757, measured on PR #743).

## Contract change

Sharded artifact names become stable logical slots (`<lane>-<shard>-<run_id>`, `overwrite: true` retained); each successful shard uploads an `artifact-provenance.v1.json` sidecar (lane, run, attempt, revision, shard index/total, payload checksums); both aggregators call a new common `tools/check-shard-artifact-cohort.sh` that accepts mixed attempts within one run while rejecting incompatible stale content, foreign provenance, surplus or unreadable sidecars, and enumeration/comparison failures — all fail-closed. Unsharded artifacts (`semantic-mutation-mutants`, `fsl-logic`) stay attempt-scoped, now guarded by the parser-backed workflow validator. Decision recorded in `docs/DESIGN-ci.md` (Sharded pre-merge Linux evidence).

## Review evidence

Independent review (separate codex session) ran 5 rounds until zero findings: F1 nested-decoy bypass of the top-level name check, F2 `table_operators` exactness weakened to set equality, F3 missing `fsl-logic` drift detector, F4 surplus nested sidecar ignored, F5/F6 enumeration and comparison pipeline failures swallowed — each proven by an isolated mutation with produced/expected values, fixed, and re-verified. 15 rejecting selftest controls + 2 accepting (mixed-attempt `[1,2,1]`, all-current `[2,2,2]`); selftests run twice per session throughout. Note: the helper requires bash ≥ 4 locally; under macOS stock bash 3.2 it fails closed with a diagnostic.

## Merge preconditions (do not merge yet)

1. **Controlled probe** (HEAD commit `probe:`): attempt 1 fails shard 2 of both lanes after artifact upload. Observe `gh run rerun --failed` → aggregators succeed on provenance attempts `[1,2,1]`; record run IDs in `docs/DESIGN-ci.md`, then drop the probe commit and re-run full CI.
2. Skip-lane confirmation before merge (`native Z3 4.16` ×2 + `product gate` expected).

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)