### PR TITLE
fix(compat): honor explicit implements overrides in requirements auto action maps

### DIFF
--- a/changelog.d/786-conformance-harness-failures.fixed.md
+++ b/changelog.d/786-conformance-harness-failures.fixed.md
@@ -1,0 +1,4 @@
+Fixed (#786): the frozen Python compatibility reference now lets an explicit
+inline `implements` action correspondence override the same requirements-process
+auto map, so the manual dialect-conformance corpus no longer rejects a valid
+arity-changing refinement mapping.

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -924,6 +924,7 @@ def _expand_requirements_with_display(ast, base_dir, bounds_overrides=None):
     out = []
     display_names = {}
     action_maps = []
+    process_action_maps = []
     auto_state_maps = []
     action_aliases = {}
     implements = None
@@ -1006,7 +1007,7 @@ def _expand_requirements_with_display(ast, base_dir, bounds_overrides=None):
             )
             out.extend(expanded)
             auto_state_maps.extend(state_maps)
-            action_maps.extend(maps)
+            process_action_maps.extend(maps)
             for action in maps:
                 action_aliases.setdefault(action[1], []).append(action[1])
         elif tag == "acceptance":
@@ -1043,6 +1044,16 @@ def _expand_requirements_with_display(ast, base_dir, bounds_overrides=None):
         mapping_items.extend(implements["maps"])
         mapping_items.extend(auto_state_maps)
         mapping_items.extend(action_maps)
+        explicit_action_names = {
+            item[1] for item in implements["maps"] if item[0] == "action_map"
+        }
+        # Process transitions synthesize same-name correspondences. An explicit
+        # inline entry is the override for cases such as an arity-changing lower
+        # action; retaining both would turn a valid override into a duplicate.
+        mapping_items.extend(
+            action for action in process_action_maps
+            if action[1] not in explicit_action_names
+        )
         implements["mapping_ast"] = ("refinement", f"{name}Implements{implements['abs']}", mapping_items)
         out.append(("__implements", implements))
     if display_names:

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -758,13 +758,15 @@ def _business_action_actor_map(abs_ast):
     return actors
 
 
-def _check_auto_mapped_process_actors(processes, abs_ast):
+def _check_auto_mapped_process_actors(processes, abs_ast, explicit_action_names):
     business_actors = _business_action_actor_map(abs_ast)
     if not business_actors:
         return
     for proc in processes:
         for tr in proc["transitions"]:
             name = tr["name"]
+            if name in explicit_action_names:
+                continue
             biz_actor = business_actors.get(name)
             if biz_actor is None:
                 continue
@@ -1039,14 +1041,18 @@ def _expand_requirements_with_display(ast, base_dir, bounds_overrides=None):
     )
 
     if implements is not None:
-        _check_auto_mapped_process_actors(processes, implements["abs_ast"])
+        explicit_action_names = {
+            item[1] for item in implements["maps"] if item[0] == "action_map"
+        }
+        _check_auto_mapped_process_actors(
+            processes,
+            implements["abs_ast"],
+            explicit_action_names,
+        )
         mapping_items = [("impl", name), ("abs", implements["abs"])]
         mapping_items.extend(implements["maps"])
         mapping_items.extend(auto_state_maps)
         mapping_items.extend(action_maps)
-        explicit_action_names = {
-            item[1] for item in implements["maps"] if item[0] == "action_map"
-        }
         # Process transitions synthesize same-name correspondences. An explicit
         # inline entry is the override for cases such as an arity-changing lower
         # action; retaining both would turn a valid override into a duplicate.

--- a/tests/test_inline_implements_action.py
+++ b/tests/test_inline_implements_action.py
@@ -210,6 +210,54 @@ def test_inline_action_map_overrides_process_auto_map_only():
     ]
 
 
+BUSINESS_PROCESS_ACTOR_OVERRIDE = '''business ActorOverrideBiz {
+  actor Employee, Manager
+  entity Claim
+
+  process Claim {
+    stages Draft, Submitted
+    initial Draft
+    transition submit Draft -> Submitted by Employee
+    transition review Draft -> Submitted by Manager
+  }
+}
+verify {
+  instances Claim = 1
+}
+'''
+
+REQUIREMENTS_PROCESS_ACTOR_OVERRIDE = '''requirements ActorOverrideReq {
+  implements ActorOverrideBiz from "biz.fsl" {
+    action submit(c) -> review(c)
+  }
+
+  process Claim {
+    stages Draft, Submitted
+    initial Draft
+    transition submit Draft -> Submitted by Manager
+  }
+}
+verify {
+  instances Claim = 1
+}
+'''
+
+
+def test_inline_action_map_override_skips_auto_map_actor_validation(tmp_path):
+    _write(tmp_path, {
+        "biz.fsl": BUSINESS_PROCESS_ACTOR_OVERRIDE,
+        "req.fsl": REQUIREMENTS_PROCESS_ACTOR_OVERRIDE,
+    })
+
+    checked = run_check(str(tmp_path / "req.fsl"))
+
+    assert checked["result"] == "ok", checked
+    assert checked["implements"] == {
+        "abs": "ActorOverrideBiz",
+        "result": "refines",
+    }
+
+
 ABS_BRANCH = '''spec AbsBranch73 {
   type CaseId = 0..1
   state { done: Map<CaseId, Bool> }

--- a/tests/test_inline_implements_action.py
+++ b/tests/test_inline_implements_action.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Inline `implements { }` action correspondence (#73).
+"""Inline `implements { }` action correspondence (#73, #786).
 
 Confirms `refinement_action` can appear inside the requirements-dialect
 inline `implements { }` block (grammar.py `?implements_item`), including
@@ -11,7 +11,10 @@ refinement file + `fslc refine`. The inline desugar (dialects.py
 same `("refinement", ..., mapping_items)` AST that the separate-file path
 parses, so `refine.py` needs no changes.
 """
+from pathlib import Path
+
 from fslc.cli import run_check, run_refine, run_verify
+from fslc.dialects import _parse_file
 
 
 def _write(tmp_path, files):
@@ -178,6 +181,33 @@ def test_inline_action_map_conflicts_with_requirement_maps_clause_is_an_error(tm
     assert checked["result"] == "error"
     assert checked["kind"] == "type"
     assert "duplicate action map for 'pay'" in checked["message"]
+
+
+def test_inline_action_map_overrides_process_auto_map_only():
+    root = Path(__file__).resolve().parents[1]
+    requirements = root / "examples/e2e/2_requirements.fsl"
+
+    checked = run_check(str(requirements))
+    assert checked["result"] == "ok", checked
+    assert checked["implements"] == {"abs": "ExpenseToBe", "result": "refines"}
+
+    ast, _display_names = _parse_file(requirements)
+    implements = next(item[1] for item in ast[2] if item[0] == "__implements")
+    action_maps = [
+        item for item in implements["mapping_ast"][2] if item[0] == "action_map"
+    ]
+
+    assert [(item[1], item[2], item[3]) for item in action_maps] == [
+        (
+            "submit",
+            [("refinement_param", "c", None), ("refinement_param", "a", None)],
+            ("action", "submit", [("var", "c")]),
+        ),
+        ("auto_approve", ["c"], ("action", "auto_approve", [("var", "c")])),
+        ("mgr_approve", ["c"], ("action", "mgr_approve", [("var", "c")])),
+        ("reject", ["c"], ("action", "reject", [("var", "c")])),
+        ("pay", ["c"], ("action", "pay", [("var", "c")])),
+    ]
 
 
 ABS_BRANCH = '''spec AbsBranch73 {


### PR DESCRIPTION
## Problem

`tests/test_dialect_conformance.py` — the harness AGENTS.md/CONTRIBUTING.md cite for dialect registration — had been silently red on 2 of 217 cases because nothing runs it (#786). Finding 2 (native-only `enum abstraction` corpus exemption) was already resolved on main by `5501a5a` (#837). Finding 1 remained: the frozen Python reference's `_expand_requirements_process` auto-generates an `action_map` entry for every process transition and concatenates it with an explicit `implements { action submit(c, a) -> submit(c) }` override, so `build_refinement` reports `duplicate action map for 'submit'` on `examples/e2e/2_requirements.fsl` — while native `fslc check` agrees with the file's documented `refines` intent.

## Change (frozen Python reference — justified compatibility fix)

This is a genuine evaluator divergence on a corpus file both evaluators must accept (the corpus and native are correct per #494), which is the explicit condition AGENTS.md sets for touching the frozen reference. Two commits:

- `81cb64e`: suppress auto action-map generation for an action name that has an explicit `implements` override.
- `dd1191d` (review round): also skip the auto-map **actor validation** for overridden actions — the independent reviewer reproduced a legitimate override still being rejected by the auto-map's actor check (produced `error/type actor mismatch` vs expected `ok/refines`).

Focused regression tests added in `tests/test_inline_implements_action.py` (13 cases), including an accepting control proving non-overridden actions keep full auto-map generation and actor validation.

## Evidence

- Before: `test_dialect_conformance.py` 1 failed / 222 passed (×2, produced `duplicate action map for 'submit'`); after: **223 passed** (×2). Focused tests 13 passed (×2). Changelog check exit 0.
- Detector mutations (isolated, restores proven by empty diff): 3 by the implementer + reviewer's over-suppression mutation (accepting control fails when suppression over-reaches) + reviewer's override fixture (before: exit 2 `error/type`; after: exit 0 `ok/refines`) and non-override contrast (still exit 2 as expected), each ×2.
- Independent review (separate codex session), two rounds: round 1 found the P2 actor-validation gap, fixed and re-verified; final findings 0 (Approve), full review attached as a comment.

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)