### PR TITLE
test(cli): bind corpus verify envelopes to exits and pin dialect induction contracts

### DIFF
--- a/changelog.d/761-native-owners-f1-f2.required.md
+++ b/changelog.d/761-native-owners-f1-f2.required.md
@@ -1,1 +1,1 @@
-Required (#761): native Rust tests now bind every corpus `verify` result class to its process exit and pin the business, requirements, and governance induction CLI contracts before the Python parity harnesses are retired.
+Required (#761): native Rust tests now bind every corpus `verify` result class to its exact public process exit code and pin the business, requirements, and governance induction CLI contracts before the Python parity harnesses are retired.

--- a/changelog.d/761-native-owners-f1-f2.required.md
+++ b/changelog.d/761-native-owners-f1-f2.required.md
@@ -1,0 +1,1 @@
+Required (#761): native Rust tests now bind every corpus `verify` result class to its process exit and pin the business, requirements, and governance induction CLI contracts before the Python parity harnesses are retired.

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -322,7 +322,7 @@ test:
 |---|---|
 | kernel/dialect spec, bare `check` | `corpus_check_sweep.rs::every_corpus_spec_checks_ok_or_declares_its_error` |
 | `check` envelope/exit conservation law | `corpus_check_sweep.rs::check_result_and_exit_status_never_contradict` |
-| `verify` envelope/exit conservation law | `corpus_check_sweep.rs::verify_result_and_exit_status_never_contradict` |
+| `verify` envelope/exact-exit conservation law | `corpus_check_sweep.rs::verify_result_and_exit_status_never_contradict` |
 | `ledger` vs its `verify` baseline | `corpus_check_sweep.rs::ledger_exit_status_agrees_with_its_verify_baseline` |
 | refinement mapping | `refine_corpus_parity.rs` (this section, above) |
 | declared `examples/gallery/{valid,errors,adversarial}` fixture | `corpus_expectation_manifest.rs` |

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -321,7 +321,8 @@ test:
 | Category | Owning test |
 |---|---|
 | kernel/dialect spec, bare `check` | `corpus_check_sweep.rs::every_corpus_spec_checks_ok_or_declares_its_error` |
-| `check`/`verify`/exit conservation law | `corpus_check_sweep.rs::check_result_and_exit_status_never_contradict` |
+| `check` envelope/exit conservation law | `corpus_check_sweep.rs::check_result_and_exit_status_never_contradict` |
+| `verify` envelope/exit conservation law | `corpus_check_sweep.rs::verify_result_and_exit_status_never_contradict` |
 | `ledger` vs its `verify` baseline | `corpus_check_sweep.rs::ledger_exit_status_agrees_with_its_verify_baseline` |
 | refinement mapping | `refine_corpus_parity.rs` (this section, above) |
 | declared `examples/gallery/{valid,errors,adversarial}` fixture | `corpus_expectation_manifest.rs` |

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -32,7 +32,9 @@
 //! per-file rule remains deliberately narrower than an oracle: a file that
 //! declares no error anywhere must not fail `check` unexpectedly. The
 //! independent `check` and `verify` Verdict Conservation Laws below bind
-//! their envelopes to process exits without declaring a per-file result.
+//! their envelopes to process exits without declaring a per-file result; the
+//! verify owner checks the exact public 0/1/2/3 mapping, not only zero versus
+//! non-zero.
 //! Splitting these properties prevents a gap, not a hole:
 //! `corpus_expectation_manifest.rs`'s roster is derived from the same header
 //! convention this sweep reads, so a `check`-targeted declared fixture cannot
@@ -149,6 +151,21 @@ fn run_verify(path: &Path) -> (Value, i32) {
         )
     });
     (value, status)
+}
+
+/// Exact public exit contract for a top-level `fslc verify` envelope.
+/// Keep this independent from the CLI's final process-status normalization so
+/// a production mapping mutation cannot change both produced and expected.
+fn expected_verify_exit(envelope: &Value) -> i32 {
+    match envelope.get("result").and_then(Value::as_str) {
+        Some("verified" | "proved") => 0,
+        Some("violated" | "reachable_failed" | "unknown_cti" | "unknown_budget") => 1,
+        Some("error") if envelope.get("kind").and_then(Value::as_str) == Some("internal") => 3,
+        Some("error") => 2,
+        result => panic!(
+            "unregistered `fslc verify` result {result:?}; update the public exact-exit contract"
+        ),
+    }
 }
 
 #[test]
@@ -282,11 +299,11 @@ fn check_result_and_exit_status_never_contradict() {
     );
 }
 
-/// Verdict Conservation Law for `fslc verify` over the complete corpus.
+/// Exact Verdict Conservation Law for `fslc verify` over the complete corpus.
 /// Like the check-side owner above, this has no per-file expected verdict:
-/// it binds the production result class to the process status for every
-/// accepted, deliberately failing, and structurally inapplicable corpus
-/// file without exclusions.
+/// it derives the exact expected exit from each envelope's public result/kind
+/// class and binds it to the process status for every accepted, deliberately
+/// failing, and structurally inapplicable corpus file without exclusions.
 #[test]
 fn verify_result_and_exit_status_never_contradict() {
     let root = root();
@@ -300,7 +317,6 @@ fn verify_result_and_exit_status_never_contradict() {
 
     let mut failures = Vec::new();
     let mut observed_results = BTreeSet::new();
-    let mut saw_failure_class = false;
 
     for path in &files {
         let rel = repo_relative(&root, path);
@@ -320,28 +336,60 @@ fn verify_result_and_exit_status_never_contradict() {
         };
 
         observed_results.insert(result.to_owned());
-        let is_success = fslc_rust::outcome::outcome_class(&envelope).is_success();
-        saw_failure_class |= !is_success;
-        if is_success && exit != 0 {
+        let expected_exit = expected_verify_exit(&envelope);
+        if exit != expected_exit {
             failures.push(format!(
-                "{rel}: verify result={result:?} is success-class; produced exit={exit}, \
-                 expected exit=0 (false red)"
+                "{rel}: verify result={result:?}; produced exit={exit}, expected \
+                 exit={expected_exit} from the public exact-exit contract"
             ));
-        } else if !is_success && exit == 0 {
+        }
+
+        let produced_success_class = fslc_rust::outcome::outcome_class(&envelope).is_success();
+        let expected_success_class = expected_exit == 0;
+        if produced_success_class != expected_success_class {
             failures.push(format!(
-                "{rel}: verify result={result:?} is failure-class per \
-                 `fslc_rust::outcome::outcome_class`; produced exit=0, expected exit!=0 \
-                 (false green). If this is a new success-class result, register it there -- \
-                 not here"
+                "{rel}: verify result={result:?}; production outcome_class produced \
+                 success={produced_success_class}, expected success={expected_success_class} \
+                 from exact exit={expected_exit}"
             ));
         }
     }
 
     assert!(failures.is_empty(), "{}", failures.join("\n"));
-    assert!(
-        saw_failure_class,
-        "expected at least one failure-class verify result; got {observed_results:?} -- \
-         the false-green arm of this law is untested"
+    for required in ["verified", "violated", "reachable_failed", "error"] {
+        assert!(
+            observed_results.contains(required),
+            "expected corpus verify to exercise result={required:?}; got {observed_results:?}"
+        );
+    }
+}
+
+#[test]
+fn verify_result_classes_map_to_exact_public_exit_codes() {
+    for result in ["verified", "proved"] {
+        assert_eq!(
+            expected_verify_exit(&serde_json::json!({"result": result})),
+            0
+        );
+    }
+    for result in [
+        "violated",
+        "reachable_failed",
+        "unknown_cti",
+        "unknown_budget",
+    ] {
+        assert_eq!(
+            expected_verify_exit(&serde_json::json!({"result": result})),
+            1
+        );
+    }
+    assert_eq!(
+        expected_verify_exit(&serde_json::json!({"result": "error", "kind": "semantics"})),
+        2
+    );
+    assert_eq!(
+        expected_verify_exit(&serde_json::json!({"result": "error", "kind": "internal"})),
+        3
     );
 }
 

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -28,23 +28,25 @@
 //! fails under `check`. That assertion now belongs to
 //! `corpus_expectation_manifest.rs`, which runs every header's declared
 //! command verbatim (not just `check`) and compares `result`/`kind`/exit
-//! against the declaration (issue #645, #537 C4 residual). This file keeps
-//! exactly two properties, deliberately narrower than a per-file oracle:
-//! (i) a file that declares no error anywhere must not fail `check`
-//! unexpectedly, and (ii) the Verdict Conservation Law below. Splitting the
-//! two prevents a gap, not a hole: `corpus_expectation_manifest.rs`'s roster
-//! is derived from the same header convention this sweep reads, so a
-//! `check`-targeted declared fixture cannot lose its owner by falling
-//! between the two files.
+//! against the declaration (issue #645, #537 C4 residual). This file's
+//! per-file rule remains deliberately narrower than an oracle: a file that
+//! declares no error anywhere must not fail `check` unexpectedly. The
+//! independent `check` and `verify` Verdict Conservation Laws below bind
+//! their envelopes to process exits without declaring a per-file result.
+//! Splitting these properties prevents a gap, not a hole:
+//! `corpus_expectation_manifest.rs`'s roster is derived from the same header
+//! convention this sweep reads, so a `check`-targeted declared fixture cannot
+//! lose its owner by falling between the two files.
 //!
-//! `check_result_and_exit_status_never_contradict` below is a second,
-//! independent property over the same corpus sweep (issue #537 C2, Verdict
-//! Conservation Law). It holds no per-file oracle and needs none of the
-//! exclusions above: unlike "does this file check clean", "does the exit
-//! status agree with the result class" is a closed law that every corpus
-//! file -- including deliberately-failing fixtures and the
+//! `check_result_and_exit_status_never_contradict` and
+//! `verify_result_and_exit_status_never_contradict` are independent
+//! properties over the same corpus sweep (issue #537 C2 and issue #761 F1,
+//! Verdict Conservation Law). They hold no per-file oracle and need none of
+//! the exclusions above: unlike "does this file check clean", "does the exit
+//! status agree with the result class" is a closed law that every corpus file
+//! -- including deliberately-failing fixtures and the
 //! `refinement`/`examples/gallery/injected/` categories excluded above --
-//! must satisfy. Its class definition is production code
+//! must satisfy. Their class definition is production code
 //! (`fslc_rust::outcome::outcome_class`), not a list in this file.
 
 use std::collections::BTreeSet;
@@ -109,6 +111,40 @@ fn run_check(path: &Path) -> (Value, i32) {
     let status = output.status.code().unwrap_or_else(|| {
         panic!(
             "`fslc check {}` terminated by signal, no exit code",
+            path.display()
+        )
+    });
+    (value, status)
+}
+
+/// Runs the bounded BMC baseline used by the corpus-wide verify/exit
+/// conservation law. These arguments also match the verify side of the
+/// ledger comparison below.
+fn run_verify(path: &Path) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "verify",
+            path.to_str().expect("utf8 path"),
+            "--depth",
+            "2",
+            "--deadlock",
+            "ignore",
+            "--engine",
+            "bmc",
+        ])
+        .current_dir(root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc verify {}`: {error}; stderr={}",
+            path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let status = output.status.code().unwrap_or_else(|| {
+        panic!(
+            "`fslc verify {}` terminated by signal, no exit code",
             path.display()
         )
     });
@@ -246,6 +282,69 @@ fn check_result_and_exit_status_never_contradict() {
     );
 }
 
+/// Verdict Conservation Law for `fslc verify` over the complete corpus.
+/// Like the check-side owner above, this has no per-file expected verdict:
+/// it binds the production result class to the process status for every
+/// accepted, deliberately failing, and structurally inapplicable corpus
+/// file without exclusions.
+#[test]
+fn verify_result_and_exit_status_never_contradict() {
+    let root = root();
+    let files = corpus_files(&root);
+    assert!(
+        files.len() > 150,
+        "corpus scan floor: found only {} .fsl files under specs/+examples/, expected 150+ \
+         (the directory walk may be broken)",
+        files.len()
+    );
+
+    let mut failures = Vec::new();
+    let mut observed_results = BTreeSet::new();
+    let mut saw_failure_class = false;
+
+    for path in &files {
+        let rel = repo_relative(&root, path);
+        let (envelope, exit) = run_verify(path);
+
+        let Some(object) = envelope.as_object() else {
+            failures.push(format!(
+                "{rel}: `fslc verify` stdout is not a JSON object: {envelope}"
+            ));
+            continue;
+        };
+        let Some(result) = object.get("result").and_then(Value::as_str) else {
+            failures.push(format!(
+                "{rel}: `fslc verify` envelope has no string `result` field: {envelope}"
+            ));
+            continue;
+        };
+
+        observed_results.insert(result.to_owned());
+        let is_success = fslc_rust::outcome::outcome_class(&envelope).is_success();
+        saw_failure_class |= !is_success;
+        if is_success && exit != 0 {
+            failures.push(format!(
+                "{rel}: verify result={result:?} is success-class; produced exit={exit}, \
+                 expected exit=0 (false red)"
+            ));
+        } else if !is_success && exit == 0 {
+            failures.push(format!(
+                "{rel}: verify result={result:?} is failure-class per \
+                 `fslc_rust::outcome::outcome_class`; produced exit=0, expected exit!=0 \
+                 (false green). If this is a new success-class result, register it there -- \
+                 not here"
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+    assert!(
+        saw_failure_class,
+        "expected at least one failure-class verify result; got {observed_results:?} -- \
+         the false-green arm of this law is untested"
+    );
+}
+
 /// Runs `fslc` with `args` and returns only its exit status -- `ledger`
 /// prints rendered Markdown (not JSON) to stdout when `-o` is omitted, so
 /// unlike `run_check` there is no envelope here to parse.
@@ -292,16 +391,7 @@ fn ledger_exit_status_agrees_with_its_verify_baseline() {
     for path in &files {
         let rel = repo_relative(&root, path);
         let path_str = path.to_str().expect("utf8 path");
-        let verify_exit = run_exit_status(&[
-            "verify",
-            path_str,
-            "--depth",
-            "2",
-            "--deadlock",
-            "ignore",
-            "--engine",
-            "bmc",
-        ]);
+        let (_verify_envelope, verify_exit) = run_verify(path);
         let ledger_exit = run_exit_status(&["ledger", path_str, "--depth", "2"]);
 
         if verify_exit != 0 {

--- a/rust/fslc/tests/dialect_induction_contract.rs
+++ b/rust/fslc/tests/dialect_induction_contract.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native CLI ownership for the business, requirements, and governance
+//! induction cases previously compared only by
+//! `tools/check_rust_dialect_parity.py` (issue #761 F2).
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+struct Case {
+    path: &'static str,
+    spec: &'static str,
+    invariants: &'static [&'static str],
+}
+
+const CASES: &[Case] = &[
+    Case {
+        path: "examples/e2e/1_business.fsl",
+        spec: "ExpenseToBe",
+        invariants: &["_bounds_claim_stage"],
+    },
+    Case {
+        path: "examples/e2e/2_requirements.fsl",
+        spec: "ExpenseRequirements",
+        invariants: &["_bounds_claim_amount", "_bounds_claim_stage"],
+    },
+    Case {
+        path: "examples/consulting/governance_controls.fsl",
+        spec: "ExpenseTransformationControls",
+        invariants: &["_governance_catalog_ok"],
+    },
+];
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_induction(path: &str) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "verify",
+            path,
+            "--depth",
+            "8",
+            "--engine",
+            "induction",
+            "--k",
+            "1",
+            "--deadlock",
+            "warn",
+        ])
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for induction case {path}: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn string_set(value: &Value) -> BTreeSet<&str> {
+    value
+        .as_array()
+        .expect("expected JSON array")
+        .iter()
+        .map(|item| item.as_str().expect("expected string array item"))
+        .collect()
+}
+
+#[test]
+fn business_requirements_and_governance_pin_native_induction_contracts() {
+    for case in CASES {
+        let (output, exit) = run_induction(case.path);
+        assert_eq!(
+            exit, 0,
+            "{}: produced exit={exit}, expected=0; {output:#}",
+            case.path
+        );
+        assert_eq!(output["result"], "proved", "{}: {output:#}", case.path);
+        assert_eq!(output["spec"], case.spec, "{}: {output:#}", case.path);
+        assert_eq!(output["engine"], "induction", "{}: {output:#}", case.path);
+        assert_eq!(
+            output["completeness"], "unbounded",
+            "{}: {output:#}",
+            case.path
+        );
+        assert_eq!(output["checked_to_depth"], 8, "{}: {output:#}", case.path);
+        assert_eq!(output["base_depth"], 8, "{}: {output:#}", case.path);
+        assert_eq!(
+            string_set(&output["invariants_checked"]),
+            case.invariants.iter().copied().collect(),
+            "{}: {output:#}",
+            case.path
+        );
+
+        let k_used = output["k_used"]
+            .as_object()
+            .unwrap_or_else(|| panic!("{}: expected k_used object; {output:#}", case.path));
+        assert_eq!(
+            k_used.len(),
+            case.invariants.len(),
+            "{}: {output:#}",
+            case.path
+        );
+        for invariant in case.invariants {
+            assert_eq!(
+                k_used.get(*invariant),
+                Some(&Value::from(1)),
+                "{}: invariant={invariant}; {output:#}",
+                case.path
+            );
+        }
+
+        match case.path {
+            "examples/e2e/1_business.fsl" => {
+                assert_eq!(
+                    output["leads_to"]["CTRL-1"]["checked_to_depth"], 8,
+                    "{output:#}"
+                );
+                assert_eq!(
+                    output["leads_to"]["CTRL-2"]["checked_to_depth"], 8,
+                    "{output:#}"
+                );
+                assert_eq!(
+                    output["reachables"]["CanPay"]["witnessed_at_step"], 3,
+                    "{output:#}"
+                );
+            }
+            "examples/e2e/2_requirements.fsl" => {
+                assert_eq!(output["implements"]["abs"], "ExpenseToBe", "{output:#}");
+                assert_eq!(output["implements"]["result"], "refines", "{output:#}");
+            }
+            "examples/consulting/governance_controls.fsl" => {
+                assert_eq!(
+                    output["action_coverage"]["_governance_noop"]["covered"], false,
+                    "{output:#}"
+                );
+                assert_eq!(
+                    output["action_coverage"]["_governance_noop"]["requirement"]["id"], "GOV",
+                    "{output:#}"
+                );
+            }
+            _ => unreachable!("unregistered dialect induction case"),
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Two of the seven native-owner gaps recorded in #896 (REVIEW-761 F1/F2) that block retiring the corresponding Python parity harnesses (#761):

- **F1**: nothing bound the corpus-wide `fslc verify` JSON envelope's result class to its process exit (`corpus_check_sweep.rs` bound `check` only; the verify-adjacent test compared verify exit to ledger exit).
- **F2**: no native test owned the `verify --engine induction` output contract for the three dialect cases (business / requirements / governance) that `tools/check_rust_dialect_parity.py` compared; the cited P3 test scopes itself to `check`/dispatch.

## Change

- `corpus_check_sweep.rs::verify_result_and_exit_status_never_contradict`: walks the corpus and binds each verify envelope's result class to its **exact** exit code (verified/proved→0, violated & unknown classes→1, spec error→2, internal error→3 — unknown classes verified against the live CLI), fail-closed with no exclusions.
- `dialect_induction_contract.rs::business_requirements_and_governance_pin_native_induction_contracts`: pins the induction envelopes and exits for the three dialect cases (expectations taken from observed behavior first; all three proved at depth 8, requirements additionally asserts `implements.result=refines`).
- Ownership table in `docs/DESIGN-conformance-harness.md` updated (check/verify rows split, verify owner registered); `changelog.d/761-native-owners-f1-f2.required.md`.

## Evidence

- Detector proofs (isolated mutations, restores proven by empty diff): F1 exit-map mutation (produced exit 0 accepted → after round 2, violated→exit-2 mutation produced 2 / expected 1, test exit 101); F2 per-case mutations (e.g. produced `ExpenseRequirements` vs expected `...Mutant`, exit 101) — reviewer independently re-ran all and added one novel mutation per area.
- Independent review (separate codex session), two rounds: round 1 found a High — the exit binding was only 0/nonzero, so a violated→exit-2 mutation passed; fixed in `7d8c470` with exact per-class codes and re-verified. Final findings 0 (approve), full review attached.
- Focused tests ×2, fmt, clippy `-D warnings`, changelog check: all exit 0.

Refs #761 (two of seven owner preconditions from #896 now satisfied; the corresponding harness retirements come separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)