### PR TITLE
test(meta): wire shellcheck and a bash-version guard lint into merge readiness

### DIFF
--- a/changelog.d/898-shellcheck-wiring.required.md
+++ b/changelog.d/898-shellcheck-wiring.required.md
@@ -1,1 +1,1 @@
-Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and a calibrated Bash-version guard lint over repository shell tooling.
+Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and fail-closed tracked-script enumeration, plus a calibrated token-aware Bash-version guard lint over repository shell tooling.

--- a/changelog.d/898-shellcheck-wiring.required.md
+++ b/changelog.d/898-shellcheck-wiring.required.md
@@ -1,1 +1,1 @@
-Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and fail-closed tracked-script enumeration, plus a calibrated direct-syntax Bash-version guard lint that excludes heredoc data and documents its dynamic-execution boundary.
+Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and fail-closed tracked-script enumeration, plus a calibrated direct-syntax Bash-version guard lint that scans expansions in unquoted heredocs, ignores literal heredoc data, and documents its dynamic-execution boundary.

--- a/changelog.d/898-shellcheck-wiring.required.md
+++ b/changelog.d/898-shellcheck-wiring.required.md
@@ -1,0 +1,1 @@
+Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and a calibrated Bash-version guard lint over repository shell tooling.

--- a/changelog.d/898-shellcheck-wiring.required.md
+++ b/changelog.d/898-shellcheck-wiring.required.md
@@ -1,1 +1,1 @@
-Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and fail-closed tracked-script enumeration, plus a calibrated token-aware Bash-version guard lint over repository shell tooling.
+Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and fail-closed tracked-script enumeration, plus a calibrated direct-syntax Bash-version guard lint that excludes heredoc data and documents its dynamic-execution boundary.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -100,11 +100,26 @@ independent lanes succeed:
    tracked citation.
    The lane also runs ShellCheck over every `tools/*.sh` and `.github/scripts/*.sh`, explicitly
    enabling `check-extra-masked-returns` (SC2312), and rejects suppressions without an inline reason.
+   Discovery must contain every Git-tracked direct `*.sh` child of both directories and must be
+   non-empty; untracked matching additions are also checked. A separate fixture contains
+   `check-*.sh`, `run-*.sh`, and `.github/scripts/report-*.sh` canaries, so narrowing either glob or
+   dropping either directory fails the inventory selftest before ShellCheck runs.
    A standard-library Python lint first asks Bash to parse each script, then requires scripts using
    `mapfile`/`readarray`, associative arrays, or array expansion under `set -u` to put a fail-closed
-   Bash-4+ guard immediately after the shebang. The checker has accepting, missing-guard,
-   late-guard, and quoted-decoy fixtures. Local macOS development requires `brew install shellcheck`;
-   a missing executable fails the lane instead of skipping it.
+   Bash-4+ guard immediately after the shebang. Its token classifier follows this executable-context
+   table; indentation never changes a result:
+
+   | Feature class | Executable token form | Quoted command word | Argument literal | Comment |
+   | --- | --- | --- | --- | --- |
+   | map input | exact simple-command word `mapfile` or `readarray`, including through `builtin` | detected | single- or double-quoted text is ignored | ignored |
+   | associative array | simple-command word `declare`, `typeset`, or `local` plus an option token containing `A`, including combined flags | detected | single- or double-quoted text is ignored | ignored |
+   | nounset array expansion | executable `set -u`, combined `-euo`, or `set -o nounset` plus executable `${name[@]}` | detected; `${name[@]}` inside double quotes still expands | plain `"set -u"` and single-quoted `${name[@]}` are ignored | ignored |
+   | nested execution | command substitutions and backticks are recursively tokenized, even inside double quotes | detected | outer literal text remains ignored | ignored |
+
+   Thirty-four parser-accepted table cases plus accepting, missing-guard, late-guard, indented-declare,
+   local-associative, and single/double-quoted-decoy fixtures calibrate both bypass and false-positive
+   directions. Local macOS development requires `brew install shellcheck`; a missing executable
+   fails the lane instead of skipping it.
    Repository-root `CHANGELOG.md` is deliberately outside that scope because it is an immutable
    historical record whose old section names must not make current automation fail.
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -98,6 +98,13 @@ independent lanes succeed:
    source location, and fails closed on unreadable input, a missing document, or a citation target
    outside the same Git-tracked input set. An untracked worktree document therefore cannot satisfy a
    tracked citation.
+   The lane also runs ShellCheck over every `tools/*.sh` and `.github/scripts/*.sh`, explicitly
+   enabling `check-extra-masked-returns` (SC2312), and rejects suppressions without an inline reason.
+   A standard-library Python lint first asks Bash to parse each script, then requires scripts using
+   `mapfile`/`readarray`, associative arrays, or array expansion under `set -u` to put a fail-closed
+   Bash-4+ guard immediately after the shebang. The checker has accepting, missing-guard,
+   late-guard, and quoted-decoy fixtures. Local macOS development requires `brew install shellcheck`;
+   a missing executable fails the lane instead of skipping it.
    Repository-root `CHANGELOG.md` is deliberately outside that scope because it is an immutable
    historical record whose old section names must not make current automation fail.
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -116,10 +116,18 @@ independent lanes succeed:
    | nounset array expansion | executable `set -u`, combined `-euo`, or `set -o nounset` plus executable `${name[@]}` | detected; `${name[@]}` inside double quotes still expands | plain `"set -u"` and single-quoted `${name[@]}` are ignored | ignored |
    | nested execution | command substitutions and backticks are recursively tokenized, even inside double quotes | detected | outer literal text remains ignored | ignored |
 
-   Thirty-four parser-accepted table cases plus accepting, missing-guard, late-guard, indented-declare,
-   local-associative, and single/double-quoted-decoy fixtures calibrate both bypass and false-positive
-   directions. Local macOS development requires `brew install shellcheck`; a missing executable
-   fails the lane instead of skipping it.
+   Thirty-nine parser-accepted table cases plus accepting, missing-guard, late-guard,
+   indented-declare, local-associative, heredoc, and single/double-quoted-decoy fixtures calibrate
+   both bypass and false-positive directions. Heredoc data bodies are excluded from token
+   classification; executable code after a heredoc remains in scope and has both accepting and
+   rejecting fixture coverage.
+
+   This lint's detection claim is deliberately limited to direct syntactic feature use. Dynamic
+   execution through `eval` or a variable-expanded command word is outside the static-detection
+   boundary and is not included in the detection claim. Selftests pin literal `eval` and variable
+   command examples as expected non-detections so this boundary cannot be mistaken for implicit
+   coverage. Local macOS development requires `brew install shellcheck`; a missing executable fails
+   the lane instead of skipping it.
    Repository-root `CHANGELOG.md` is deliberately outside that scope because it is an immutable
    historical record whose old section names must not make current automation fail.
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -136,7 +136,8 @@ independent lanes succeed:
    boundary and is not included in the detection claim. Selftests pin literal `eval` and variable
    command examples as expected non-detections so this boundary cannot be mistaken for implicit
    coverage. Local macOS development requires `brew install shellcheck`; a missing executable fails
-   the lane instead of skipping it.
+   the lane instead of skipping it. CI's ShellCheck version is authoritative; CI detects findings
+   that a different local version does not report, and the checker records the version it used.
    Repository-root `CHANGELOG.md` is deliberately outside that scope because it is an immutable
    historical record whose old section names must not make current automation fail.
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -116,11 +116,20 @@ independent lanes succeed:
    | nounset array expansion | executable `set -u`, combined `-euo`, or `set -o nounset` plus executable `${name[@]}` | detected; `${name[@]}` inside double quotes still expands | plain `"set -u"` and single-quoted `${name[@]}` are ignored | ignored |
    | nested execution | command substitutions and backticks are recursively tokenized, even inside double quotes | detected | outer literal text remains ignored | ignored |
 
-   Thirty-nine parser-accepted table cases plus accepting, missing-guard, late-guard,
+   Forty-six parser-accepted table cases plus accepting, missing-guard, late-guard,
    indented-declare, local-associative, heredoc, and single/double-quoted-decoy fixtures calibrate
-   both bypass and false-positive directions. Heredoc data bodies are excluded from token
-   classification; executable code after a heredoc remains in scope and has both accepting and
-   rejecting fixture coverage.
+   both bypass and false-positive directions. Heredoc classification is deliberately quantified by
+   delimiter and body-pattern class:
+
+   | Delimiter class | Literal command-position text | Expansion syntax |
+   | --- | --- | --- |
+   | quoted (`<<'EOF'`, `<<-"EOF"`, or any partially quoted word) | ignored | ignored because Bash does not expand the body |
+   | unquoted (`<<EOF` or `<<-EOF`) | ignored as data | parameter, command, backtick, and arithmetic expansions are scanned |
+
+   Each of these four cells has separate accepting and rejecting fixtures (eight fixtures total).
+   The rejecting controls also establish that executable code immediately after a terminator remains
+   visible. Thus heredoc exclusion applies to literal data, not to expansions Bash executes in an
+   unquoted body.
 
    This lint's detection claim is deliberately limited to direct syntactic feature use. Dynamic
    execution through `eval` or a variable-expanded command word is outside the static-detection

--- a/tests/fixtures/bash-version-guards/accepting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/accepting/fixture.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "fixture requires Bash 4 or newer" >&2; exit 1; }
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+declare -A labels=()
+mapfile -t values </dev/null
+printf '%s\n' "${values[@]}"

--- a/tests/fixtures/bash-version-guards/double-quoted-decoy/fixture.sh
+++ b/tests/fixtures/bash-version-guards/double-quoted-decoy/fixture.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+printf '%s\n' "mapfile -t values" "local -A labels=()"

--- a/tests/fixtures/bash-version-guards/heredoc-data/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-data/fixture.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<'QUOTED_DATA'
+mapfile -t values </dev/null
+QUOTED_DATA
+cat <<PLAIN_DATA
+local -A labels=()
+PLAIN_DATA
+cat <<-TAB_DATA
+	readarray -t values </dev/null
+	TAB_DATA

--- a/tests/fixtures/bash-version-guards/heredoc-followed-by-code/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-followed-by-code/fixture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<'DATA'
+mapfile is data here
+DATA
+mapfile -t values </dev/null

--- a/tests/fixtures/bash-version-guards/heredoc-quoted-command-accepting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-quoted-command-accepting/fixture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<D'AT'A
+mapfile -t values </dev/null
+declare -A labels=()
+DATA

--- a/tests/fixtures/bash-version-guards/heredoc-quoted-command-rejecting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-quoted-command-rejecting/fixture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<'DATA'
+mapfile is literal data
+DATA
+mapfile -t values </dev/null

--- a/tests/fixtures/bash-version-guards/heredoc-quoted-expansion-accepting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-quoted-expansion-accepting/fixture.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+cat <<-'DATA'
+	${values[@]}
+	$(mapfile -t nested_values </dev/null)
+	DATA

--- a/tests/fixtures/bash-version-guards/heredoc-quoted-expansion-rejecting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-quoted-expansion-rejecting/fixture.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+cat <<-'DATA'
+	${values[@]}
+	$(mapfile -t nested_values </dev/null)
+	DATA
+printf '%s\n' "${values[@]}"

--- a/tests/fixtures/bash-version-guards/heredoc-unquoted-command-accepting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-unquoted-command-accepting/fixture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<DATA
+readarray -t values </dev/null
+local -A labels=()
+DATA

--- a/tests/fixtures/bash-version-guards/heredoc-unquoted-command-rejecting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-unquoted-command-rejecting/fixture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<DATA
+declare -A is literal data
+DATA
+declare -A labels=()

--- a/tests/fixtures/bash-version-guards/heredoc-unquoted-expansion-accepting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-unquoted-expansion-accepting/fixture.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "Bash 4+ required" >&2; exit 1; }
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+cat <<-DATA
+	${values[@]}
+	$(mapfile -t nested_values </dev/null)
+	DATA

--- a/tests/fixtures/bash-version-guards/heredoc-unquoted-expansion-rejecting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-unquoted-expansion-rejecting/fixture.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+cat <<-DATA
+	${values[@]}
+	$(mapfile -t nested_values </dev/null)
+	DATA

--- a/tests/fixtures/bash-version-guards/indented-declare/fixture.sh
+++ b/tests/fixtures/bash-version-guards/indented-declare/fixture.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+fixture() {
+  declare -A labels=()
+}

--- a/tests/fixtures/bash-version-guards/late-guard/fixture.sh
+++ b/tests/fixtures/bash-version-guards/late-guard/fixture.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# A guard after another line is too late.
+(( BASH_VERSINFO[0] >= 4 )) || { echo "fixture requires Bash 4 or newer" >&2; exit 1; }
+mapfile -t values </dev/null

--- a/tests/fixtures/bash-version-guards/local-associative/fixture.sh
+++ b/tests/fixtures/bash-version-guards/local-associative/fixture.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+fixture() {
+  local -A labels=()
+}

--- a/tests/fixtures/bash-version-guards/missing-guard/fixture.sh
+++ b/tests/fixtures/bash-version-guards/missing-guard/fixture.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+declare -A labels=()
+mapfile -t values </dev/null
+printf '%s\n' "${values[@]}"

--- a/tests/fixtures/bash-version-guards/quoted-decoy/fixture.sh
+++ b/tests/fixtures/bash-version-guards/quoted-decoy/fixture.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+printf '%s\n' 'mapfile -t values' 'declare -A labels=()' '${values[@]}'

--- a/tests/fixtures/shell-script-inventory/accepting/.github/scripts/report-one.sh
+++ b/tests/fixtures/shell-script-inventory/accepting/.github/scripts/report-one.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+exit 0

--- a/tests/fixtures/shell-script-inventory/accepting/tools/check-one.sh
+++ b/tests/fixtures/shell-script-inventory/accepting/tools/check-one.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+exit 0

--- a/tests/fixtures/shell-script-inventory/accepting/tools/run-one.sh
+++ b/tests/fixtures/shell-script-inventory/accepting/tools/run-one.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+exit 0

--- a/tools/aggregate_changelog.sh
+++ b/tools/aggregate_changelog.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "aggregate_changelog.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 #
 # Aggregates checked-in changelog fragments under `changelog.d/` into
@@ -115,7 +116,10 @@ export LC_ALL=C
 # end-to-end control-1/control-4 fixtures `cd` into a throwaway git repo and
 # re-invoke this tool, and `$0` alone would break there if the script was
 # invoked with a relative path.
-SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+self_directory="$(dirname "$0")"
+self_directory="$(cd "$self_directory" && pwd)"
+self_basename="$(basename "$0")"
+SELF="$self_directory/$self_basename"
 
 # This repository's bullet-lead-word vocabulary. See the header comment.
 DECLARED_CATEGORY_ORDER=(
@@ -239,15 +243,18 @@ reject_unenumerable_fragments() {
   local dir="$1" f rel
   [ -d "$dir" ] || return 0
   # A newline-joined string, not an array: `"${arr[@]}"` on a zero-element
-  # array is an unbound-variable error under `set -u` on bash < 4.4 (macOS's
-  # default bash is 3.2), and this dir legitimately has zero enumerable
+  # array is an unbound-variable error under `set -u` on bash 4.0-4.3, and
+  # this dir legitimately has zero enumerable
   # fragments whenever every file under it is unenumerable (the exact case
   # this function exists to catch) or the dir holds only README.md (which
   # list_fragment_files itself always skips). `grep -qxF` below does exact
   # whole-line membership testing against this string instead of iterating
   # an array, so the empty case needs no special-casing at all.
-  local enumerated
+  local enumerated found_paths
   enumerated="$(list_fragment_files "$dir")"
+  found_paths="$(mktemp)" || fail "could not create fragment path inventory"
+  find "$dir" -type f -print0 >"$found_paths" 2>/dev/null \
+    || { rm -f "$found_paths"; fail "could not enumerate fragment paths under $dir"; }
   while IFS= read -r -d '' f; do
     # rel, not basename: a nested README.md ("sub/README.md") must not be
     # mistaken for the top-level exemption -- only $dir/README.md itself is
@@ -257,22 +264,26 @@ reject_unenumerable_fragments() {
     # the full relative path, not the last path component.
     rel="${f#"$dir"/}"
     [ "$rel" = "README.md" ] && continue
-    is_known_non_fragment_artifact "$(basename "$rel")" && continue
+    local basename_rel
+    basename_rel="$(basename "$rel")"
+    is_known_non_fragment_artifact "$basename_rel" && continue
     if ! printf '%s\n' "$enumerated" | grep -qxF "$rel"; then
       fail "changelog-fragment-path-invalid: $dir/$rel (not enumerable by list_fragment_files -- fragments must be direct, non-hidden children of $dir/ with a .md extension; only $dir/README.md is exempt)"
     fi
-  done < <(find "$dir" -type f -print0 2>/dev/null)
+  done <"$found_paths"
+  rm -f "$found_paths"
 }
 
 validate_fragment_names() {
   local dir="$1"
   reject_unenumerable_fragments "$dir"
   local -a files=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$(list_fragment_files "$dir" | sort)"
+  local f listed
+  listed="$(list_fragment_files "$dir" | sort)" \
+    || fail "could not list and sort fragments under $dir"
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$listed"
   # `"${files[@]}"` on a zero-element array is an unbound-variable error
-  # under `set -u` on bash < 4.4 (macOS's default bash is 3.2, unlike
-  # ubuntu-latest's bash 5 that merge-readiness actually runs on), so guard
+  # under `set -u` on bash 4.0-4.3, so guard
   # the empty case -- an empty `changelog.d/` is trivially valid, not an
   # error, here.
   [ "${#files[@]}" -eq 0 ] && return 0
@@ -283,15 +294,15 @@ validate_fragment_names() {
 
 check_duplicates() {
   # Deliberately a plain indexed-array linear scan, not an associative
-  # array: this keeps the script running on bash 3.2 (macOS's default,
-  # unlike ubuntu-latest's bash 5, which is what merge-readiness actually
-  # runs on) so a contributor can execute it locally without a newer bash.
+  # array: the simpler data structure is sufficient for the bounded input.
   # Fragment counts are small (dozens at most between releases), so the
   # O(n^2) scan is not a performance concern.
   local dir="$1"
   local -a files=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$(list_fragment_files "$dir" | sort)"
+  local f listed
+  listed="$(list_fragment_files "$dir" | sort)" \
+    || fail "could not list and sort fragments under $dir"
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$listed"
   [ "${#files[@]}" -eq 0 ] && return 0
   local -a seen_keys=() seen_files=()
   for f in "${files[@]}"; do
@@ -315,8 +326,9 @@ check_duplicates() {
 sort_fragments() {
   local dir="$1"
   local -a files=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$(list_fragment_files "$dir")"
+  local f listed
+  listed="$(list_fragment_files "$dir")"
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$listed"
   [ "${#files[@]}" -eq 0 ] && return 0
   local keyed=""
   for f in "${files[@]}"; do
@@ -399,8 +411,9 @@ validate_fragment_hygiene() {
 validate_fragment_hygiene_all() {
   local dir="$1"
   local -a files=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$(list_fragment_files "$dir")"
+  local f listed
+  listed="$(list_fragment_files "$dir")"
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$listed"
   [ "${#files[@]}" -eq 0 ] && return 0
   for f in "${files[@]}"; do
     validate_fragment_hygiene "$dir/$f"
@@ -422,8 +435,9 @@ render_fragment() {
 aggregate_section_body() {
   local dir="$1"
   local -a sorted=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$(sort_fragments "$dir")"
+  local f listed
+  listed="$(sort_fragments "$dir")"
+  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$listed"
   [ "${#sorted[@]}" -eq 0 ] && return 0
   local out="" f_out
   for f in "${sorted[@]}"; do
@@ -463,11 +477,16 @@ split_bullets() {
 verify_conservation() {
   local dir="$1" produced="$2"
   local -a sorted=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$(sort_fragments "$dir")"
+  local f listed
+  listed="$(sort_fragments "$dir")"
+  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$listed"
   local -a actual=()
-  local seg
-  while IFS= read -r -d '' seg; do actual+=("$seg"); done < <(split_bullets "$produced")
+  local seg bullet_file
+  bullet_file="$(mktemp)" || fail "could not create rendered-bullet inventory"
+  split_bullets "$produced" >"$bullet_file" \
+    || { rm -f "$bullet_file"; fail "could not split rendered bullets"; }
+  while IFS= read -r -d '' seg; do actual+=("$seg"); done <"$bullet_file"
+  rm -f "$bullet_file"
   if [ "${#actual[@]}" -ne "${#sorted[@]}" ]; then
     fail "fragment-dropped: bullet count mismatch (expected ${#sorted[@]} fragment(s), produced ${#actual[@]} top-level bullet(s))"
   fi
@@ -751,7 +770,7 @@ classify_product_diff() {
     fail "changelog-fragment-missing: ${non_exempt[*]}"
   fi
   # `"${arr[@]}"` on an empty array is an unbound-variable error under
-  # `set -u` on bash < 4.4 (macOS's default bash is 3.2), so guard the
+  # `set -u` on bash 4.0-4.3, so guard the
   # common empty case explicitly instead of relying on a modern bash.
   if [ "${#check_fragments[@]}" -gt 0 ]; then
     printf '%s\n' "${check_fragments[@]}"
@@ -980,8 +999,9 @@ check_stale() {
   # dotfile) must not be able to reach tag time invisibly either (S3-1).
   reject_unenumerable_fragments "$dir"
   local -a files=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$(list_fragment_files "$dir")"
+  local f listed
+  listed="$(list_fragment_files "$dir")"
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$listed"
   if [ "${#files[@]}" -gt 0 ]; then
     fail "stale-fragments-present: ${files[*]}"
   fi
@@ -1008,8 +1028,9 @@ release() {
   validate_fragment_hygiene_all "$fragdir"
 
   local -a sorted=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$(sort_fragments "$fragdir")"
+  local f listed
+  listed="$(sort_fragments "$fragdir")"
+  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$listed"
   # An empty `changelog.d/` is a legitimate release, not an error (review
   # finding S3-2, #737, comment 2026-08-07, second round): a version bump
   # with no product-facing content since the previous release is a real
@@ -1020,7 +1041,7 @@ release() {
   # made step 7 impossible to run for that release shape at all. Guarded
   # with `-gt 0` before the loop below (rather than only inside it) because
   # `"${sorted[@]}"` on a zero-element array is an unbound-variable error
-  # under `set -u` on bash < 4.4 (macOS's default bash is 3.2).
+  # under `set -u` on bash 4.0-4.3.
   if [ "${#sorted[@]}" -gt 0 ]; then
     for f in "${sorted[@]}"; do
       fragment_is_empty "$fragdir/$f" && fail "changelog-fragment-empty: $fragdir/$f"
@@ -1255,7 +1276,10 @@ selftest_control3() {
   fi
   local lexicographic_numeric
   lexicographic_numeric="$(list_fragment_files "$tmp" | LC_ALL=C sort)"
-  echo "selftest: rejecting fixture 'control3 rejecting: lexicographic sham vs numeric golden' produced: $(printf '%s' "$lexicographic_numeric" | tr '\n' ' ')"
+  local lexicographic_numeric_display
+  lexicographic_numeric_display="$(printf '%s' "$lexicographic_numeric" | tr '\n' ' ')" \
+    || fail "could not format numeric-order selftest output"
+  echo "selftest: rejecting fixture 'control3 rejecting: lexicographic sham vs numeric golden' produced: $lexicographic_numeric_display"
   if [ "$lexicographic_numeric" = "$golden_numeric" ]; then
     st_report "control3 rejecting: lexicographic sham vs numeric golden (aggregation-order-wrong)" fail 0
   else
@@ -1278,7 +1302,10 @@ selftest_control3() {
   fi
   local lexicographic_category
   lexicographic_category="$(list_fragment_files "$tmp" | LC_ALL=C sort)"
-  echo "selftest: rejecting fixture 'control3 rejecting: lexicographic-category sham vs category golden' produced: $(printf '%s' "$lexicographic_category" | tr '\n' ' ')"
+  local lexicographic_category_display
+  lexicographic_category_display="$(printf '%s' "$lexicographic_category" | tr '\n' ' ')" \
+    || fail "could not format category-order selftest output"
+  echo "selftest: rejecting fixture 'control3 rejecting: lexicographic-category sham vs category golden' produced: $lexicographic_category_display"
   if [ "$lexicographic_category" = "$golden_category" ]; then
     st_report "control3 rejecting: lexicographic-category sham vs category golden (aggregation-order-wrong)" fail 0
   else
@@ -1353,8 +1380,10 @@ selftest_control5() {
   st_expect_pass "control5 accepting: faithful aggregation of 3 fragments (one multi-line)" verify_conservation "$tmp" "$faithful"
 
   # Rejecting (a): a sham that drops one of three fragments.
-  local dropped
-  dropped="$(render_fragment "$tmp/1-a.added.md")"$'\n'"$(render_fragment "$tmp/3-c.added.md")"
+  local dropped first_render third_render
+  first_render="$(render_fragment "$tmp/1-a.added.md")"
+  third_render="$(render_fragment "$tmp/3-c.added.md")"
+  dropped="${first_render}"$'\n'"${third_render}"
   st_expect_fail "control5 rejecting: sham drops one of three fragments (fragment-dropped)" verify_conservation "$tmp" "$dropped"
 
   # Rejecting (b): a sham that copies only each fragment's first line,
@@ -1376,8 +1405,9 @@ selftest_control5() {
   # must reject it.
   st_setup_frag "$tmp" "1-a.added.md" "Fixed (#1): a."
   st_setup_frag "$tmp" "2-b.added.md" "Fixed (#1): a." "more detail."
-  local duplicated
-  duplicated="$(render_fragment "$tmp/2-b.added.md")"$'\n'"$(render_fragment "$tmp/2-b.added.md")"
+  local duplicated duplicated_render
+  duplicated_render="$(render_fragment "$tmp/2-b.added.md")"
+  duplicated="${duplicated_render}"$'\n'"${duplicated_render}"
   st_expect_fail "control5 rejecting: sham drops fragment A and emits fragment B (whose block starts with A's) twice" \
     verify_conservation "$tmp" "$duplicated"
 

--- a/tools/aggregate_changelog.sh
+++ b/tools/aggregate_changelog.sh
@@ -887,9 +887,10 @@ check_direct_edit_files() {
 # own fail-closed behavior (a bad edit fails here, before control 1 ever
 # runs) and control 1's release exclusion -- one computation, consumed
 # twice, so the two controls cannot disagree (review finding S2-1, #737,
-# comment 2026-08-07, second round).
+# comment 2026-08-07, second round). $1 is the repository-relative changelog
+# path and must be supplied explicitly by the caller.
 compute_direct_edit_classification() {
-  local changelog="${1:-CHANGELOG.md}"
+  local changelog="$1"
   : "${BASE_SHA:?BASE_SHA is required}"
   : "${HEAD_SHA:?HEAD_SHA is required}"
   # Diff against the merge base, not BASE_SHA's tip: this repository's own
@@ -984,7 +985,7 @@ check_pr() {
   # cannot disagree about whether this diff is a genuine release move (S2-1).
   local classification status
   set +e
-  classification="$(compute_direct_edit_classification)"
+  classification="$(compute_direct_edit_classification "CHANGELOG.md")"
   status=$?
   set -e
   [ "$status" -eq 0 ] || exit 1

--- a/tools/check-bash-version-guards.py
+++ b/tools/check-bash-version-guards.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""Require an immediate Bash 4+ guard when repository scripts need it."""
+"""Require an immediate Bash 4+ guard for direct syntactic feature use.
+
+This lint detects direct shell syntax. Dynamic execution through ``eval`` or a
+variable-expanded command word is outside its static-detection boundary and is
+not part of its detection claim.
+"""
 
 from __future__ import annotations
 
@@ -112,11 +117,71 @@ def consume_backticks(source: str, start: int) -> tuple[str, int]:
     return source[start + 1 :], len(source)
 
 
+def consume_heredoc_delimiter(source: str, start: int) -> tuple[str, int]:
+    """Apply shell quote removal to one heredoc delimiter word."""
+    delimiter: list[str] = []
+    index = start
+    while index < len(source) and source[index] not in " \t\r\n;&|(){}<>":
+        char = source[index]
+        if char == "\\":
+            if index + 1 < len(source):
+                delimiter.append(source[index + 1])
+                index += 2
+            else:
+                index += 1
+            continue
+        if char == "'":
+            end = source.find("'", index + 1)
+            if end < 0:
+                delimiter.append(source[index + 1 :])
+                return "".join(delimiter), len(source)
+            delimiter.append(source[index + 1 : end])
+            index = end + 1
+            continue
+        if char == '"':
+            index += 1
+            while index < len(source) and source[index] != '"':
+                if source[index] == "\\" and index + 1 < len(source):
+                    escaped = source[index + 1]
+                    if escaped in {'$', '`', '"', "\\"}:
+                        delimiter.append(escaped)
+                    elif escaped != "\n":
+                        delimiter.extend(("\\", escaped))
+                    index += 2
+                else:
+                    delimiter.append(source[index])
+                    index += 1
+            index += index < len(source)
+            continue
+        delimiter.append(char)
+        index += 1
+    return "".join(delimiter), index
+
+
+def consume_heredoc_bodies(
+    source: str, start: int, delimiters: list[tuple[str, bool]]
+) -> int:
+    """Return the offset after parser-validated heredoc bodies and terminators."""
+    index = start
+    for delimiter, strip_tabs in delimiters:
+        while index < len(source):
+            newline = source.find("\n", index)
+            line_end = len(source) if newline < 0 else newline
+            line = source[index:line_end]
+            comparison = line.lstrip("\t") if strip_tabs else line
+            index = len(source) if newline < 0 else newline + 1
+            if comparison == delimiter:
+                break
+    return index
+
+
 def lex_shell(source: str) -> LexedShell:
     """Tokenize enough parsed Bash structure to classify executed simple commands."""
     result = LexedShell()
     word: list[str] = []
     word_active = False
+    heredoc_delimiters: list[tuple[str, bool]] = []
+    expect_heredoc_delimiter: bool | None = None
     index = 0
 
     def flush_word() -> None:
@@ -135,6 +200,14 @@ def lex_shell(source: str) -> LexedShell:
 
     while index < len(source):
         char = source[index]
+        if expect_heredoc_delimiter is not None:
+            if char in " \t\r":
+                index += 1
+                continue
+            delimiter, index = consume_heredoc_delimiter(source, index)
+            heredoc_delimiters.append((delimiter, expect_heredoc_delimiter))
+            expect_heredoc_delimiter = None
+            continue
         if char in " \t\r":
             flush_word()
             index += 1
@@ -143,6 +216,9 @@ def lex_shell(source: str) -> LexedShell:
             flush_word()
             result.tokens.append(Token("operator", "\n"))
             index += 1
+            if heredoc_delimiters:
+                index = consume_heredoc_bodies(source, index, heredoc_delimiters)
+                heredoc_delimiters.clear()
             continue
         if char == "#" and not word_active:
             newline = source.find("\n", index)
@@ -215,8 +291,14 @@ def lex_shell(source: str) -> LexedShell:
             continue
         if char in ";&|(){}<>":
             flush_word()
-            operator = char
-            if index + 1 < len(source) and source[index : index + 2] in {
+            if source.startswith("<<<", index):
+                operator = "<<<"
+                index += 3
+            elif source.startswith("<<-", index):
+                operator = "<<-"
+                index += 3
+                expect_heredoc_delimiter = True
+            elif index + 1 < len(source) and source[index : index + 2] in {
                 "&&",
                 "||",
                 ";;",
@@ -229,10 +311,13 @@ def lex_shell(source: str) -> LexedShell:
             }:
                 operator = source[index : index + 2]
                 index += 2
+                if operator == "<<":
+                    expect_heredoc_delimiter = False
                 if operator == ";;" and index < len(source) and source[index] == "&":
                     operator = ";;&"
                     index += 1
             else:
+                operator = char
                 index += 1
             result.tokens.append(Token("operator", operator))
             continue
@@ -418,6 +503,27 @@ FEATURE_CASES = (
     ),
     ("nounset disabled", "set +u\nvalues=()\nprintf '%s' \"${values[@]}\"\n", []),
     ("nounset positional argument", "set -- -u\nvalues=()\nprintf '%s' \"${values[@]}\"\n", []),
+    (
+        "quoted heredoc data",
+        "cat <<'EOF'\nmapfile -t values </dev/null\nEOF\n",
+        [],
+    ),
+    (
+        "tab-stripped heredoc data",
+        "cat <<-EOF\n\tlocal -A values=()\n\tEOF\n",
+        [],
+    ),
+    (
+        "code after heredoc",
+        "cat <<EOF\nmapfile data only\nEOF\nmapfile -t values </dev/null\n",
+        ["mapfile/readarray"],
+    ),
+    ("literal eval is outside boundary", "eval 'mapfile -t values </dev/null'\n", []),
+    (
+        "variable command is outside boundary",
+        "command_name=mapfile\n\"$command_name\" -t values </dev/null\n",
+        [],
+    ),
 )
 
 
@@ -463,6 +569,8 @@ def selftest(root: Path) -> int:
         "late-guard": ["require the fail-closed guard"],
         "quoted-decoy": [],
         "double-quoted-decoy": [],
+        "heredoc-data": [],
+        "heredoc-followed-by-code": ["mapfile/readarray"],
         "indented-declare": ["associative array"],
         "local-associative": ["associative array"],
     }
@@ -505,7 +613,7 @@ def selftest(root: Path) -> int:
     if ok:
         print(
             f"selftest: PASS: feature_cases={len(FEATURE_CASES)} "
-            "guard_accepting=3 guard_rejecting=4"
+            "guard_accepting=4 guard_rejecting=5"
         )
         return 0
     return 1

--- a/tools/check-bash-version-guards.py
+++ b/tools/check-bash-version-guards.py
@@ -9,66 +9,416 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 
 GUARD = re.compile(
     r'^\(\( BASH_VERSINFO\[0\] >= 4 \)\) \|\| \{ echo "[^"]+" >&2; exit 1; \}$'
 )
 ARRAY_EXPANSION = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}")
-SET_U = re.compile(r"(?m)^\s*set\s+-[^\n#]*u")
-MAPFILE = re.compile(r"(?<![A-Za-z0-9_])(mapfile|readarray)(?![A-Za-z0-9_])")
-ASSOCIATIVE = re.compile(r"(?m)(?:^|[;&|]\s*)(?:declare|typeset)\s+-[A-Za-z]*A")
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+COMMAND_BOUNDARIES = {"\n", ";", ";;", ";&", ";;&", "&", "&&", "|", "||", "(", ")", "{", "}"}
+COMMAND_KEYWORDS = {
+    "!",
+    "case",
+    "do",
+    "done",
+    "elif",
+    "else",
+    "esac",
+    "fi",
+    "for",
+    "function",
+    "if",
+    "in",
+    "select",
+    "then",
+    "time",
+    "until",
+    "while",
+}
 
 
-def executable_text(source: str) -> str:
-    """Erase comments and single-quoted literals while preserving shell structure."""
-    out: list[str] = []
-    state = "plain"
+class Token(NamedTuple):
+    kind: str
+    text: str
+
+
+class LexedShell:
+    def __init__(self) -> None:
+        self.tokens: list[Token] = []
+        self.nested_commands: list[str] = []
+        self.has_array_expansion = False
+
+
+def consume_parenthesized(source: str, start: int) -> tuple[str, int]:
+    """Return one parser-validated $(...) or $((...)) body and its end offset."""
+    arithmetic = source.startswith("$((", start)
+    first_parenthesis = start + 1
+    depth = 0
+    quote = ""
     escaped = False
-    for char in source:
-        if state == "comment":
-            if char == "\n":
-                state = "plain"
-                out.append(char)
-            else:
-                out.append(" ")
-            continue
-        if state == "single":
-            if char == "'":
-                state = "plain"
-            out.append("\n" if char == "\n" else " ")
-            continue
+    index = first_parenthesis
+    while index < len(source):
+        char = source[index]
         if escaped:
             escaped = False
-            out.append(char)
-            continue
-        if char == "\\" and state in ("plain", "double"):
+        elif char == "\\" and quote != "'":
             escaped = True
-            out.append(char)
-        elif char == "'" and state == "plain":
-            state = "single"
-            out.append(" ")
-        elif char == '"':
-            state = "plain" if state == "double" else "double"
-            out.append(" ")
-        elif char == "#" and state == "plain":
-            state = "comment"
-            out.append(" ")
-        else:
-            out.append(char)
-    return "".join(out)
+        elif quote:
+            if char == quote:
+                quote = ""
+        elif char in "'\"":
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                body_start = start + (3 if arithmetic else 2)
+                body_end = index - (1 if arithmetic else 0)
+                return source[body_start:body_end], index + 1
+        index += 1
+    return source[start:], len(source)
+
+
+def consume_braced(source: str, start: int) -> tuple[str, int]:
+    depth = 0
+    index = start + 1
+    while index < len(source):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1], index + 1
+        index += 1
+    return source[start:], len(source)
+
+
+def consume_backticks(source: str, start: int) -> tuple[str, int]:
+    index = start + 1
+    escaped = False
+    while index < len(source):
+        char = source[index]
+        if escaped:
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif char == "`":
+            return source[start + 1 : index], index + 1
+        index += 1
+    return source[start + 1 :], len(source)
+
+
+def lex_shell(source: str) -> LexedShell:
+    """Tokenize enough parsed Bash structure to classify executed simple commands."""
+    result = LexedShell()
+    word: list[str] = []
+    word_active = False
+    index = 0
+
+    def flush_word() -> None:
+        nonlocal word_active
+        if word_active:
+            result.tokens.append(Token("word", "".join(word)))
+            word.clear()
+            word_active = False
+
+    def append_parameter(expansion: str) -> None:
+        nonlocal word_active
+        word.append(expansion)
+        word_active = True
+        if ARRAY_EXPANSION.search(expansion):
+            result.has_array_expansion = True
+
+    while index < len(source):
+        char = source[index]
+        if char in " \t\r":
+            flush_word()
+            index += 1
+            continue
+        if char == "\n":
+            flush_word()
+            result.tokens.append(Token("operator", "\n"))
+            index += 1
+            continue
+        if char == "#" and not word_active:
+            newline = source.find("\n", index)
+            index = len(source) if newline < 0 else newline
+            continue
+        if char == "\\":
+            word_active = True
+            if index + 1 < len(source):
+                word.append(source[index + 1])
+                index += 2
+            else:
+                index += 1
+            continue
+        if char == "'":
+            word_active = True
+            end = source.find("'", index + 1)
+            if end < 0:
+                word.append(source[index + 1 :])
+                break
+            word.append(source[index + 1 : end])
+            index = end + 1
+            continue
+        if char == '"':
+            word_active = True
+            index += 1
+            while index < len(source) and source[index] != '"':
+                if source[index] == "\\" and index + 1 < len(source):
+                    word.append(source[index + 1])
+                    index += 2
+                elif source.startswith("$((", index):
+                    arithmetic, index = consume_parenthesized(source, index)
+                    append_parameter(arithmetic)
+                    word.append("$((...))")
+                elif source.startswith("$(", index):
+                    nested, index = consume_parenthesized(source, index)
+                    result.nested_commands.append(nested)
+                    word.append("$(...)")
+                elif source.startswith("${", index):
+                    expansion, index = consume_braced(source, index)
+                    append_parameter(expansion)
+                elif source[index] == "`":
+                    nested, index = consume_backticks(source, index)
+                    result.nested_commands.append(nested)
+                    word.append("`...`")
+                else:
+                    word.append(source[index])
+                    index += 1
+            index += index < len(source)
+            continue
+        if source.startswith("$((", index):
+            arithmetic, index = consume_parenthesized(source, index)
+            append_parameter(arithmetic)
+            word.append("$((...))")
+            continue
+        if source.startswith("$(", index):
+            nested, index = consume_parenthesized(source, index)
+            result.nested_commands.append(nested)
+            word.append("$(...)")
+            word_active = True
+            continue
+        if source.startswith("${", index):
+            expansion, index = consume_braced(source, index)
+            append_parameter(expansion)
+            continue
+        if char == "`":
+            nested, index = consume_backticks(source, index)
+            result.nested_commands.append(nested)
+            word.append("`...`")
+            word_active = True
+            continue
+        if char in ";&|(){}<>":
+            flush_word()
+            operator = char
+            if index + 1 < len(source) and source[index : index + 2] in {
+                "&&",
+                "||",
+                ";;",
+                ";&",
+                "|&",
+                "<<",
+                ">>",
+                "<&",
+                ">&",
+            }:
+                operator = source[index : index + 2]
+                index += 2
+                if operator == ";;" and index < len(source) and source[index] == "&":
+                    operator = ";;&"
+                    index += 1
+            else:
+                index += 1
+            result.tokens.append(Token("operator", operator))
+            continue
+        word.append(char)
+        word_active = True
+        index += 1
+    flush_word()
+    return result
+
+
+def simple_commands(tokens: list[Token]) -> list[list[str]]:
+    commands: list[list[str]] = []
+    current: list[str] = []
+    expect_function_name = False
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.kind == "operator" and token.text in COMMAND_BOUNDARIES:
+            if (
+                token.text == "("
+                and len(current) == 1
+                and index + 1 < len(tokens)
+                and tokens[index + 1] == Token("operator", ")")
+            ):
+                current = []
+                index += 2
+                continue
+            if current:
+                commands.append(current)
+                current = []
+            index += 1
+            continue
+        if token.kind != "word":
+            index += 1
+            continue
+        if expect_function_name:
+            expect_function_name = False
+            index += 1
+            continue
+        if not current and token.text in COMMAND_KEYWORDS:
+            expect_function_name = token.text == "function"
+            index += 1
+            continue
+        current.append(token.text)
+        index += 1
+    if current:
+        commands.append(current)
+    return commands
+
+
+def command_word(words: list[str]) -> tuple[str, list[str]]:
+    index = 0
+    while index < len(words) and ASSIGNMENT.match(words[index]):
+        index += 1
+    if index >= len(words):
+        return "", []
+    command = words[index]
+    arguments = words[index + 1 :]
+    if command == "command" and arguments:
+        if any(argument in {"-v", "-V"} for argument in arguments):
+            return "", []
+        while arguments and arguments[0].startswith("-"):
+            arguments = arguments[1:]
+        if arguments:
+            command = arguments[0]
+            arguments = arguments[1:]
+    elif command == "builtin" and arguments:
+        command = arguments[0]
+        arguments = arguments[1:]
+    return command, arguments
+
+
+def enables_nounset(arguments: list[str]) -> bool:
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == "--":
+            return False
+        if argument == "-o":
+            return index + 1 < len(arguments) and arguments[index + 1] == "nounset"
+        if argument.startswith("-") and "u" in argument[1:]:
+            return True
+        index += 1
+    return False
+
+
+def scan_facts(source: str) -> tuple[set[str], bool, bool]:
+    features: set[str] = set()
+    has_set_u = False
+    has_array_expansion = False
+    pending = [source]
+    while pending:
+        lexed = lex_shell(pending.pop())
+        pending.extend(lexed.nested_commands)
+        has_array_expansion = has_array_expansion or lexed.has_array_expansion
+        for words in simple_commands(lexed.tokens):
+            command, arguments = command_word(words)
+            if command in {"mapfile", "readarray"}:
+                features.add("mapfile/readarray")
+            if command in {"declare", "local", "typeset"}:
+                for argument in arguments:
+                    if argument == "--":
+                        break
+                    if argument.startswith("-") and "A" in argument[1:]:
+                        features.add("associative array")
+                        break
+            if command == "set":
+                has_set_u = has_set_u or enables_nounset(arguments)
+    return features, has_set_u, has_array_expansion
 
 
 def required_features(source: str) -> list[str]:
-    code = executable_text(source)
-    features: list[str] = []
-    if MAPFILE.search(code):
-        features.append("mapfile/readarray")
-    if ASSOCIATIVE.search(code):
-        features.append("associative array")
-    if SET_U.search(code) and ARRAY_EXPANSION.search(code):
-        features.append("array expansion under set -u")
-    return features
+    found, has_set_u, has_array_expansion = scan_facts(source)
+    if has_set_u and has_array_expansion:
+        found.add("array expansion under set -u")
+    return [
+        feature
+        for feature in (
+            "mapfile/readarray",
+            "associative array",
+            "array expansion under set -u",
+        )
+        if feature in found
+    ]
+
+
+FEATURE_CASES = (
+    ("mapfile column zero", "mapfile -t values </dev/null\n", ["mapfile/readarray"]),
+    ("mapfile indented", "f() {\n  mapfile -t values </dev/null\n}\n", ["mapfile/readarray"]),
+    ("readarray command", "readarray -t values </dev/null\n", ["mapfile/readarray"]),
+    ("quoted mapfile command", "\"mapfile\" -t values </dev/null\n", ["mapfile/readarray"]),
+    ("builtin mapfile command", "builtin mapfile -t values </dev/null\n", ["mapfile/readarray"]),
+    (
+        "mapfile in command substitution",
+        "printf '%s' \"$(mapfile -t values </dev/null)\"\n",
+        ["mapfile/readarray"],
+    ),
+    (
+        "mapfile in backticks",
+        "printf '%s' \"`mapfile -t values </dev/null`\"\n",
+        ["mapfile/readarray"],
+    ),
+    ("mapfile unquoted argument", "printf '%s' mapfile\n", []),
+    ("mapfile single-quoted argument", "printf '%s' 'mapfile -t values'\n", []),
+    ("mapfile double-quoted argument", "printf '%s' \"mapfile -t values\"\n", []),
+    ("mapfile comment", "# mapfile -t values\nprintf ok\n", []),
+    ("mapfile near miss", "mapfile_helper -t values\n", []),
+    ("mapfile keyword argument", "printf '%s' if mapfile\n", []),
+    ("mapfile function declaration", "mapfile() { printf ok; }\n", []),
+    ("declare associative", "declare -A values=()\n", ["associative array"]),
+    ("declare associative indented", "f() {\n  declare -A values=()\n}\n", ["associative array"]),
+    ("local associative", "f() {\n  local -A values=()\n}\n", ["associative array"]),
+    ("typeset associative", "f() {\n  typeset -A values=()\n}\n", ["associative array"]),
+    ("combined associative flags", "declare -gA values=()\n", ["associative array"]),
+    ("builtin associative declaration", "builtin declare -A values\n", ["associative array"]),
+    ("declare single-quoted argument", "printf '%s' 'declare -A values=()'\n", []),
+    ("local double-quoted argument", "printf '%s' \"local -A values=()\"\n", []),
+    ("associative comment", "# local -A values=()\nprintf ok\n", []),
+    ("indexed declaration", "declare -a values=()\n", []),
+    ("associative function declaration", "declare() { printf ok; }\n", []),
+    (
+        "set short nounset",
+        "set -u\nvalues=()\nprintf '%s' ${values[@]}\n",
+        ["array expansion under set -u"],
+    ),
+    (
+        "set combined nounset",
+        "set -euo pipefail\nvalues=()\nprintf '%s' \"${values[@]}\"\n",
+        ["array expansion under set -u"],
+    ),
+    (
+        "set named nounset",
+        "set -o nounset\nvalues=()\nprintf '%s' \"${values[@]}\"\n",
+        ["array expansion under set -u"],
+    ),
+    ("array expansion without nounset", "values=()\nprintf '%s' \"${values[@]}\"\n", []),
+    ("single-quoted array literal", "set -u\nprintf '%s' '${values[@]}'\n", []),
+    ("array expansion comment", "set -u\n# printf '%s' \"${values[@]}\"\nprintf ok\n", []),
+    (
+        "nounset double-quoted argument",
+        "printf '%s' \"set -u\"\nvalues=()\nprintf '%s' \"${values[@]}\"\n",
+        [],
+    ),
+    ("nounset disabled", "set +u\nvalues=()\nprintf '%s' \"${values[@]}\"\n", []),
+    ("nounset positional argument", "set -- -u\nvalues=()\nprintf '%s' \"${values[@]}\"\n", []),
+)
 
 
 def audit(root: Path, files: list[Path]) -> list[str]:
@@ -112,8 +462,31 @@ def selftest(root: Path) -> int:
         "missing-guard": ["require the fail-closed guard"],
         "late-guard": ["require the fail-closed guard"],
         "quoted-decoy": [],
+        "double-quoted-decoy": [],
+        "indented-declare": ["associative array"],
+        "local-associative": ["associative array"],
     }
     ok = True
+    for label, source, expected in FEATURE_CASES:
+        parsed = subprocess.run(
+            ["bash", "-n"], input=source, capture_output=True, text=True, check=False
+        )
+        if parsed.returncode != 0:
+            print(
+                f"selftest: FAIL: feature table {label}: bash parser rejected "
+                f"source: {parsed.stderr.strip()}",
+                file=sys.stderr,
+            )
+            ok = False
+            continue
+        produced = required_features(source)
+        if produced != expected:
+            print(
+                f"selftest: FAIL: feature table {label}: produced={produced!r} "
+                f"expected={expected!r}",
+                file=sys.stderr,
+            )
+            ok = False
     for name, expected_fragments in cases.items():
         case_root = fixtures / name
         produced = audit(case_root, [Path("fixture.sh")])
@@ -124,12 +497,16 @@ def selftest(root: Path) -> int:
         if fragments_match and bool(produced) == bool(expected_fragments):
             continue
         print(
-            f"selftest: FAIL: {name}: produced={produced!r} expected_fragments={expected_fragments!r}",
+            f"selftest: FAIL: {name}: produced={produced!r} "
+            f"expected_fragments={expected_fragments!r}",
             file=sys.stderr,
         )
         ok = False
     if ok:
-        print("selftest: PASS: accepting=2 rejecting=2")
+        print(
+            f"selftest: PASS: feature_cases={len(FEATURE_CASES)} "
+            "guard_accepting=3 guard_rejecting=4"
+        )
         return 0
     return 1
 

--- a/tools/check-bash-version-guards.py
+++ b/tools/check-bash-version-guards.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Require an immediate Bash 4+ guard when repository scripts need it."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+GUARD = re.compile(
+    r'^\(\( BASH_VERSINFO\[0\] >= 4 \)\) \|\| \{ echo "[^"]+" >&2; exit 1; \}$'
+)
+ARRAY_EXPANSION = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}")
+SET_U = re.compile(r"(?m)^\s*set\s+-[^\n#]*u")
+MAPFILE = re.compile(r"(?<![A-Za-z0-9_])(mapfile|readarray)(?![A-Za-z0-9_])")
+ASSOCIATIVE = re.compile(r"(?m)(?:^|[;&|]\s*)(?:declare|typeset)\s+-[A-Za-z]*A")
+
+
+def executable_text(source: str) -> str:
+    """Erase comments and single-quoted literals while preserving shell structure."""
+    out: list[str] = []
+    state = "plain"
+    escaped = False
+    for char in source:
+        if state == "comment":
+            if char == "\n":
+                state = "plain"
+                out.append(char)
+            else:
+                out.append(" ")
+            continue
+        if state == "single":
+            if char == "'":
+                state = "plain"
+            out.append("\n" if char == "\n" else " ")
+            continue
+        if escaped:
+            escaped = False
+            out.append(char)
+            continue
+        if char == "\\" and state in ("plain", "double"):
+            escaped = True
+            out.append(char)
+        elif char == "'" and state == "plain":
+            state = "single"
+            out.append(" ")
+        elif char == '"':
+            state = "plain" if state == "double" else "double"
+            out.append(" ")
+        elif char == "#" and state == "plain":
+            state = "comment"
+            out.append(" ")
+        else:
+            out.append(char)
+    return "".join(out)
+
+
+def required_features(source: str) -> list[str]:
+    code = executable_text(source)
+    features: list[str] = []
+    if MAPFILE.search(code):
+        features.append("mapfile/readarray")
+    if ASSOCIATIVE.search(code):
+        features.append("associative array")
+    if SET_U.search(code) and ARRAY_EXPANSION.search(code):
+        features.append("array expansion under set -u")
+    return features
+
+
+def audit(root: Path, files: list[Path]) -> list[str]:
+    findings: list[str] = []
+    for relative in files:
+        path = root / relative
+        parsed = subprocess.run(
+            ["bash", "-n", str(path)], capture_output=True, text=True, check=False
+        )
+        if parsed.returncode != 0:
+            findings.append(
+                f"{relative}: bash parser rejected file: {parsed.stderr.strip()}"
+            )
+            continue
+        source = path.read_text(encoding="utf-8")
+        features = required_features(source)
+        if not features:
+            continue
+        lines = source.splitlines()
+        if len(lines) < 2 or not GUARD.fullmatch(lines[1]):
+            findings.append(
+                f"{relative}: Bash 4+ feature(s) {', '.join(features)} require "
+                "the fail-closed guard immediately after the shebang"
+            )
+    return findings
+
+
+def repository_files(root: Path) -> list[Path]:
+    return sorted(
+        path.relative_to(root)
+        for directory in (root / "tools", root / ".github/scripts")
+        if directory.is_dir()
+        for path in directory.glob("*.sh")
+    )
+
+
+def selftest(root: Path) -> int:
+    fixtures = root / "tests/fixtures/bash-version-guards"
+    cases = {
+        "accepting": [],
+        "missing-guard": ["require the fail-closed guard"],
+        "late-guard": ["require the fail-closed guard"],
+        "quoted-decoy": [],
+    }
+    ok = True
+    for name, expected_fragments in cases.items():
+        case_root = fixtures / name
+        produced = audit(case_root, [Path("fixture.sh")])
+        fragments_match = all(
+            any(fragment in item for item in produced)
+            for fragment in expected_fragments
+        )
+        if fragments_match and bool(produced) == bool(expected_fragments):
+            continue
+        print(
+            f"selftest: FAIL: {name}: produced={produced!r} expected_fragments={expected_fragments!r}",
+            file=sys.stderr,
+        )
+        ok = False
+    if ok:
+        print("selftest: PASS: accepting=2 rejecting=2")
+        return 0
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("check", "selftest"))
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parent.parent
+    if args.command == "selftest":
+        return selftest(root)
+    findings = audit(root, repository_files(root))
+    if findings:
+        print("\n".join(findings), file=sys.stderr)
+        return 1
+    print("check-bash-version-guards: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check-bash-version-guards.py
+++ b/tools/check-bash-version-guards.py
@@ -4,7 +4,9 @@
 
 This lint detects direct shell syntax. Dynamic execution through ``eval`` or a
 variable-expanded command word is outside its static-detection boundary and is
-not part of its detection claim.
+not part of its detection claim. Literal heredoc command text is ignored;
+parameter, command, backtick, and arithmetic expansions are scanned only when
+the heredoc delimiter is unquoted.
 """
 
 from __future__ import annotations
@@ -20,7 +22,7 @@ from typing import NamedTuple
 GUARD = re.compile(
     r'^\(\( BASH_VERSINFO\[0\] >= 4 \)\) \|\| \{ echo "[^"]+" >&2; exit 1; \}$'
 )
-ARRAY_EXPANSION = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\}")
+ARRAY_EXPANSION = re.compile(r"\$\{[^}\n]*\[@\][^}\n]*\}")
 ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 COMMAND_BOUNDARIES = {"\n", ";", ";;", ";&", ";;&", "&", "&&", "|", "||", "(", ")", "{", "}"}
 COMMAND_KEYWORDS = {
@@ -47,6 +49,12 @@ COMMAND_KEYWORDS = {
 class Token(NamedTuple):
     kind: str
     text: str
+
+
+class Heredoc(NamedTuple):
+    delimiter: str
+    strip_tabs: bool
+    quoted: bool
 
 
 class LexedShell:
@@ -117,13 +125,15 @@ def consume_backticks(source: str, start: int) -> tuple[str, int]:
     return source[start + 1 :], len(source)
 
 
-def consume_heredoc_delimiter(source: str, start: int) -> tuple[str, int]:
-    """Apply shell quote removal to one heredoc delimiter word."""
+def consume_heredoc_delimiter(source: str, start: int) -> tuple[str, int, bool]:
+    """Apply quote removal and report whether a heredoc delimiter was quoted."""
     delimiter: list[str] = []
+    quoted = False
     index = start
     while index < len(source) and source[index] not in " \t\r\n;&|(){}<>":
         char = source[index]
         if char == "\\":
+            quoted = True
             if index + 1 < len(source):
                 delimiter.append(source[index + 1])
                 index += 2
@@ -131,14 +141,16 @@ def consume_heredoc_delimiter(source: str, start: int) -> tuple[str, int]:
                 index += 1
             continue
         if char == "'":
+            quoted = True
             end = source.find("'", index + 1)
             if end < 0:
                 delimiter.append(source[index + 1 :])
-                return "".join(delimiter), len(source)
+                return "".join(delimiter), len(source), quoted
             delimiter.append(source[index + 1 : end])
             index = end + 1
             continue
         if char == '"':
+            quoted = True
             index += 1
             while index < len(source) and source[index] != '"':
                 if source[index] == "\\" and index + 1 < len(source):
@@ -155,24 +167,56 @@ def consume_heredoc_delimiter(source: str, start: int) -> tuple[str, int]:
             continue
         delimiter.append(char)
         index += 1
-    return "".join(delimiter), index
+    return "".join(delimiter), index, quoted
 
 
 def consume_heredoc_bodies(
-    source: str, start: int, delimiters: list[tuple[str, bool]]
-) -> int:
-    """Return the offset after parser-validated heredoc bodies and terminators."""
+    source: str, start: int, heredocs: list[Heredoc]
+) -> tuple[int, list[str]]:
+    """Return the end offset and expansion-capable unquoted heredoc bodies."""
     index = start
-    for delimiter, strip_tabs in delimiters:
+    expandable_bodies: list[str] = []
+    for heredoc in heredocs:
+        body_start = index
         while index < len(source):
+            line_start = index
             newline = source.find("\n", index)
             line_end = len(source) if newline < 0 else newline
             line = source[index:line_end]
-            comparison = line.lstrip("\t") if strip_tabs else line
+            comparison = line.lstrip("\t") if heredoc.strip_tabs else line
             index = len(source) if newline < 0 else newline + 1
-            if comparison == delimiter:
+            if comparison == heredoc.delimiter:
+                if not heredoc.quoted:
+                    expandable_bodies.append(source[body_start:line_start])
                 break
-    return index
+    return index, expandable_bodies
+
+
+def record_heredoc_expansions(source: str, result: LexedShell) -> None:
+    """Record only expansions Bash executes in an unquoted heredoc body."""
+    index = 0
+    while index < len(source):
+        if source[index] == "\\":
+            index += 2
+            continue
+        if source.startswith("$((", index):
+            arithmetic, index = consume_parenthesized(source, index)
+            record_heredoc_expansions(arithmetic, result)
+            continue
+        if source.startswith("$(", index):
+            nested, index = consume_parenthesized(source, index)
+            result.nested_commands.append(nested)
+            continue
+        if source.startswith("${", index):
+            expansion, index = consume_braced(source, index)
+            if ARRAY_EXPANSION.search(expansion):
+                result.has_array_expansion = True
+            continue
+        if source[index] == "`":
+            nested, index = consume_backticks(source, index)
+            result.nested_commands.append(nested)
+            continue
+        index += 1
 
 
 def lex_shell(source: str) -> LexedShell:
@@ -180,7 +224,7 @@ def lex_shell(source: str) -> LexedShell:
     result = LexedShell()
     word: list[str] = []
     word_active = False
-    heredoc_delimiters: list[tuple[str, bool]] = []
+    heredocs: list[Heredoc] = []
     expect_heredoc_delimiter: bool | None = None
     index = 0
 
@@ -204,8 +248,8 @@ def lex_shell(source: str) -> LexedShell:
             if char in " \t\r":
                 index += 1
                 continue
-            delimiter, index = consume_heredoc_delimiter(source, index)
-            heredoc_delimiters.append((delimiter, expect_heredoc_delimiter))
+            delimiter, index, quoted = consume_heredoc_delimiter(source, index)
+            heredocs.append(Heredoc(delimiter, expect_heredoc_delimiter, quoted))
             expect_heredoc_delimiter = None
             continue
         if char in " \t\r":
@@ -216,9 +260,13 @@ def lex_shell(source: str) -> LexedShell:
             flush_word()
             result.tokens.append(Token("operator", "\n"))
             index += 1
-            if heredoc_delimiters:
-                index = consume_heredoc_bodies(source, index, heredoc_delimiters)
-                heredoc_delimiters.clear()
+            if heredocs:
+                index, expandable_bodies = consume_heredoc_bodies(
+                    source, index, heredocs
+                )
+                for body in expandable_bodies:
+                    record_heredoc_expansions(body, result)
+                heredocs.clear()
             continue
         if char == "#" and not word_active:
             newline = source.find("\n", index)
@@ -518,6 +566,41 @@ FEATURE_CASES = (
         "cat <<EOF\nmapfile data only\nEOF\nmapfile -t values </dev/null\n",
         ["mapfile/readarray"],
     ),
+    (
+        "unquoted heredoc command text",
+        "cat <<EOF\nmapfile -t values </dev/null\nEOF\n",
+        [],
+    ),
+    (
+        "quoted heredoc parameter and command text",
+        "set -u\nvalues=()\ncat <<'EOF'\n${values[@]}\n$(mapfile -t nested)\nEOF\n",
+        [],
+    ),
+    (
+        "unquoted heredoc array expansion",
+        "set -u\nvalues=()\ncat <<EOF\n${values[@]}\nEOF\n",
+        ["array expansion under set -u"],
+    ),
+    (
+        "unquoted heredoc command substitution",
+        "cat <<EOF\n$(mapfile -t values </dev/null)\nEOF\n",
+        ["mapfile/readarray"],
+    ),
+    (
+        "tab-stripped unquoted heredoc expansions",
+        "set -u\nvalues=()\ncat <<-EOF\n\t${values[@]}\n\t$(readarray -t nested)\n\tEOF\n",
+        ["mapfile/readarray", "array expansion under set -u"],
+    ),
+    (
+        "unquoted heredoc backtick substitution",
+        "cat <<EOF\n`mapfile -t values </dev/null`\nEOF\n",
+        ["mapfile/readarray"],
+    ),
+    (
+        "unquoted heredoc arithmetic expansion",
+        "set -u\nvalues=()\ncat <<EOF\n$(( ${values[@]} ))\nEOF\n",
+        ["array expansion under set -u"],
+    ),
     ("literal eval is outside boundary", "eval 'mapfile -t values </dev/null'\n", []),
     (
         "variable command is outside boundary",
@@ -571,6 +654,17 @@ def selftest(root: Path) -> int:
         "double-quoted-decoy": [],
         "heredoc-data": [],
         "heredoc-followed-by-code": ["mapfile/readarray"],
+        "heredoc-quoted-command-accepting": [],
+        "heredoc-quoted-command-rejecting": ["mapfile/readarray"],
+        "heredoc-unquoted-command-accepting": [],
+        "heredoc-unquoted-command-rejecting": ["associative array"],
+        "heredoc-quoted-expansion-accepting": [],
+        "heredoc-quoted-expansion-rejecting": ["array expansion under set -u"],
+        "heredoc-unquoted-expansion-accepting": [],
+        "heredoc-unquoted-expansion-rejecting": [
+            "mapfile/readarray",
+            "array expansion under set -u",
+        ],
         "indented-declare": ["associative array"],
         "local-associative": ["associative array"],
     }
@@ -613,7 +707,7 @@ def selftest(root: Path) -> int:
     if ok:
         print(
             f"selftest: PASS: feature_cases={len(FEATURE_CASES)} "
-            "guard_accepting=4 guard_rejecting=5"
+            "guard_accepting=8 guard_rejecting=9"
         )
         return 0
     return 1

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -37,6 +37,7 @@ check_automation() {
   # ShellCheck's extra masked-return analysis covers the pipeline/process-
   # substitution regressions from #898. The companion stdlib lint requires
   # Bash-4+ scripts to fail closed before executing any other command.
+  python3 tools/check-shell-scripts.py selftest
   python3 tools/check-shell-scripts.py
   python3 tools/check-bash-version-guards.py selftest
   python3 tools/check-bash-version-guards.py check

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -34,6 +34,12 @@ check_core_contracts() {
 }
 
 check_automation() {
+  # ShellCheck's extra masked-return analysis covers the pipeline/process-
+  # substitution regressions from #898. The companion stdlib lint requires
+  # Bash-4+ scripts to fail closed before executing any other command.
+  python3 tools/check-shell-scripts.py
+  python3 tools/check-bash-version-guards.py selftest
+  python3 tools/check-bash-version-guards.py check
   node --test .github/scripts/report-post-merge-ci.test.mjs
   # The privileged post-merge reporter has issues: write. Its separate
   # parser-backed workflow-shape controls reject comments, decoys, and shell

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "check-native-integration.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -103,10 +104,13 @@ check_rust_tests() {
     exit 2
   fi
 
-  local installed
-  installed="$(cargo nextest --version 2>&1 | awk -F': ' '/^release:/ {print $2}')"
+  local installed nextest_version_output
+  installed="$(cargo nextest --version 2>&1 | awk -F': ' '/^release:/ {print $2}')" \
+    || { echo "check-native-integration: could not inspect cargo-nextest version" >&2; exit 1; }
   if [ "$installed" != "$NEXTEST_VERSION" ]; then
-    echo "check-native-integration: requires exactly cargo-nextest $NEXTEST_VERSION; observed release '$installed' (raw: $(cargo nextest --version 2>&1 | head -n1))" >&2
+    # The raw output is diagnostic only after the authoritative comparison failed.
+    nextest_version_output="$(cargo nextest --version 2>&1 || true)"
+    echo "check-native-integration: requires exactly cargo-nextest $NEXTEST_VERSION; observed release '$installed' (raw: ${nextest_version_output%%$'\n'*})" >&2
     exit 1
   fi
 
@@ -224,7 +228,9 @@ check_rust_tests() {
     echo "check-native-integration: shard $spec listed zero tests -- N is likely larger than the test count, or the partition math is wrong" >&2
     exit 1
   }
-  if [ -n "$(comm -23 <(sort -u "$shard") <(sort -u "$full"))" ]; then
+  local shard_extra
+  shard_extra="$(comm -23 "$shard" "$full")"
+  if [ -n "$shard_extra" ]; then
     echo "check-native-integration: shard $spec names tests absent from the full workspace listing" >&2
     exit 1
   fi

--- a/tools/check-product-gate-scope.sh
+++ b/tools/check-product-gate-scope.sh
@@ -145,21 +145,29 @@ check() {
 
 selftest() {
   local failures=0
+  local actual
 
+  actual="$(printf 'src/main.rs\nrust/fsl-core/src/lib.rs\n' | classify_diff)" || return 1
   check "all-product-paths" product \
-    "$(printf 'src/main.rs\nrust/fsl-core/src/lib.rs\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf '.claude/skills/x/SKILL.md\nCHANGELOG.md\n' | classify_diff)" || return 1
   check "mixed exempt + CHANGELOG.md" exempt \
-    "$(printf '.claude/skills/x/SKILL.md\nCHANGELOG.md\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf '.claude/skills/x/SKILL.md\nrust/fsl-core/src/lib.rs\n' | classify_diff)" || return 1
   check "mixed exempt + product" product \
-    "$(printf '.claude/skills/x/SKILL.md\nrust/fsl-core/src/lib.rs\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf 'CLAUDE.md.d/x\n' | classify_diff)" || return 1
   check "filename-prefix near-miss" product \
-    "$(printf 'CLAUDE.md.d/x\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf '' | classify_diff)" || return 1
   check "empty input fail-closed" product \
-    "$(printf '' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf 'changelog.d/691-a.added.md\n' | classify_diff)" || return 1
   check "changelog.d/ fragment is exempt" exempt \
-    "$(printf 'changelog.d/691-a.added.md\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf 'changelog.dx/y\n' | classify_diff)" || return 1
   check "changelog.d/ directory-prefix near-miss" product \
-    "$(printf 'changelog.dx/y\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
 
   if [ "$failures" -ne 0 ]; then
     echo "check-product-gate-scope.sh selftest: $failures assertion(s) failed" >&2

--- a/tools/check-release-binary-linkage.sh
+++ b/tools/check-release-binary-linkage.sh
@@ -21,7 +21,10 @@ check_glibc() {
     printf 'release ABI check failed: %s has no GLIBC requirement\n' "$binary" >&2
     return 1
   fi
-  if ! test "$(printf '%s\n' GLIBC_2.39 "$required" | sort -V | tail -1)" = GLIBC_2.39; then
+  local maximum
+  maximum="$(printf '%s\n' GLIBC_2.39 "$required" | sort -V | tail -1)" \
+    || return 1
+  if ! test "$maximum" = GLIBC_2.39; then
     printf 'release ABI check failed: %s requires %s; maximum supported GLIBC version is GLIBC_2.39\n' \
       "$binary" "$required" >&2
     return 1

--- a/tools/check-shard-artifact-cohort.sh
+++ b/tools/check-shard-artifact-cohort.sh
@@ -146,11 +146,17 @@ check_cohort() {
     expect_equal run_id "$expected_run_id" "$run_id" "$artifact_name"
     expect_equal head_revision "$expected_revision" "$revision" "$artifact_name"
     expect_equal shard.total "$expected_total" "$total" "$artifact_name"
-    [[ "$index" =~ ^[1-9][0-9]*$ ]] && [ "$index" -le "$expected_total" ] \
-      || fail "$artifact_name: shard.index out of range: expected '1..$expected_total', actual '$index'"
+    if [[ "$index" =~ ^[1-9][0-9]*$ ]] && [ "$index" -le "$expected_total" ]; then
+      :
+    else
+      fail "$artifact_name: shard.index out of range: expected '1..$expected_total', actual '$index'"
+    fi
     expect_equal artifact_name "$expected_name" "$artifact_name" "$artifact_name"
-    [ "$attempt" -ge 1 ] && [ "$attempt" -le "$current_attempt" ] \
-      || fail "$artifact_name: run_attempt out of range: expected '1..$current_attempt', actual '$attempt'"
+    if [ "$attempt" -ge 1 ] && [ "$attempt" -le "$current_attempt" ]; then
+      :
+    else
+      fail "$artifact_name: run_attempt out of range: expected '1..$current_attempt', actual '$attempt'"
+    fi
     if [[ " ${seen[*]-} " = *" $index "* ]]; then
       fail "$artifact_name: duplicate shard.index: expected unique '1..$expected_total', actual '$index'"
     fi

--- a/tools/check-shard-artifact-cohort.sh
+++ b/tools/check-shard-artifact-cohort.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "check-shard-artifact-cohort.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 
 # Validate one downloaded cohort of stable-name sharded artifacts before the
@@ -291,9 +292,9 @@ write_provenance() {
 }
 
 make_rust_fixture() {
-  local directory="$1" attempts="$2"
+  local directory="$1" attempt_list="$2"
   local -a attempt_values
-  IFS=, read -r -a attempt_values <<<"$attempts"
+  IFS=, read -r -a attempt_values <<<"$attempt_list"
   local index
   for index in 1 2 3; do
     local artifact="$directory/rust-test-shard-$index-77"
@@ -309,9 +310,9 @@ make_rust_fixture() {
 }
 
 make_semantic_fixture() {
-  local directory="$1" attempts="$2"
+  local directory="$1" attempt_list="$2"
   local -a attempt_values
-  IFS=, read -r -a attempt_values <<<"$attempts"
+  IFS=, read -r -a attempt_values <<<"$attempt_list"
   local index
   for index in 1 2 3; do
     local artifact="$directory/semantic-mutation-operators-$index-77"
@@ -368,6 +369,7 @@ selftest() {
   real_sort="$(command -v sort)" || fail "selftest could not resolve sort"
   real_paste="$(command -v paste)" || fail "selftest could not resolve paste"
   mkdir -p "$tmp/failing-sort" "$tmp/failing-paste"
+  # shellcheck disable=SC2016 # generated wrapper expands these variables when it runs
   printf '%s\n' \
     '#!/usr/bin/env bash' \
     'for argument in "$@"; do' \
@@ -379,6 +381,7 @@ selftest() {
     'done' \
     'exec "$REAL_SORT" "$@"' >"$tmp/failing-sort/sort" \
     || fail "selftest comparison-sort wrapper creation failed"
+  # shellcheck disable=SC2016 # generated wrapper expands these variables when it runs
   printf '%s\n' \
     '#!/usr/bin/env bash' \
     'if [ "${FSL_COHORT_JOIN_CONTEXT:-}" = "attempts" ]; then' \

--- a/tools/check-shard-union.sh
+++ b/tools/check-shard-union.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "check-shard-union.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 #
 # Generic, line-set based shard-completeness guard (issue: CI wall-clock
@@ -72,7 +73,8 @@ check_union() {
 
   local -a shard_paths=("$@")
   local -a shard_sets=()
-  local index
+  local index comparison_dir
+  comparison_dir="$(mktemp -d)" || fail "could not create comparison directory"
   for index in "${!shard_paths[@]}"; do
     shard_sets+=("$(line_set "${shard_paths[$index]}")")
   done
@@ -80,9 +82,14 @@ check_union() {
   # Each shard must be a subset of full.
   for index in "${!shard_paths[@]}"; do
     local extra
-    extra="$(comm -23 <(printf '%s\n' "${shard_sets[$index]}") <(printf '%s\n' "$full") || true)"
+    printf '%s\n' "${shard_sets[$index]}" >"$comparison_dir/left"
+    printf '%s\n' "$full" >"$comparison_dir/right"
+    extra="$(comm -23 "$comparison_dir/left" "$comparison_dir/right")"
     if [ -n "$extra" ]; then
-      fail "shard '${shard_paths[$index]}' names entries absent from '$full_path': $(printf '%s' "$extra" | tr '\n' ' ')"
+      extra_display="$(printf '%s' "$extra" | tr '\n' ' ')" \
+        || { rm -rf "$comparison_dir"; fail "could not format extra shard entries"; }
+      rm -rf "$comparison_dir"
+      fail "shard '${shard_paths[$index]}' names entries absent from '$full_path': $extra_display"
     fi
   done
 
@@ -91,9 +98,14 @@ check_union() {
   for ((i = 0; i < ${#shard_paths[@]}; i++)); do
     for ((j = i + 1; j < ${#shard_paths[@]}; j++)); do
       local overlap
-      overlap="$(comm -12 <(printf '%s\n' "${shard_sets[$i]}") <(printf '%s\n' "${shard_sets[$j]}") || true)"
+      printf '%s\n' "${shard_sets[$i]}" >"$comparison_dir/left"
+      printf '%s\n' "${shard_sets[$j]}" >"$comparison_dir/right"
+      overlap="$(comm -12 "$comparison_dir/left" "$comparison_dir/right")"
       if [ -n "$overlap" ]; then
-        fail "shard '${shard_paths[$i]}' and shard '${shard_paths[$j]}' both name: $(printf '%s' "$overlap" | tr '\n' ' ')"
+        overlap_display="$(printf '%s' "$overlap" | tr '\n' ' ')" \
+          || { rm -rf "$comparison_dir"; fail "could not format overlapping shard entries"; }
+        rm -rf "$comparison_dir"
+        fail "shard '${shard_paths[$i]}' and shard '${shard_paths[$j]}' both name: $overlap_display"
       fi
     done
   done
@@ -102,18 +114,34 @@ check_union() {
   local union
   union="$(printf '%s\n' "${shard_sets[@]}" | sort -u)"
   local missing
-  missing="$(comm -23 <(printf '%s\n' "$full") <(printf '%s\n' "$union") || true)"
+  printf '%s\n' "$full" >"$comparison_dir/left"
+  printf '%s\n' "$union" >"$comparison_dir/right"
+  missing="$(comm -23 "$comparison_dir/left" "$comparison_dir/right")"
   if [ -n "$missing" ]; then
-    fail "$(printf '%s' "$missing" | grep -c . ) entr$([ "$(printf '%s' "$missing" | grep -c .)" = 1 ] && echo y || echo ies) in '$full_path' covered by no shard (silent coverage loss): $(printf '%s' "$missing" | tr '\n' ' ')"
+    local missing_count missing_suffix missing_display
+    missing_count="$(printf '%s' "$missing" | grep -c .)" \
+      || { rm -rf "$comparison_dir"; fail "could not count missing shard entries"; }
+    if [ "$missing_count" -eq 1 ]; then missing_suffix=y; else missing_suffix=ies; fi
+    missing_display="$(printf '%s' "$missing" | tr '\n' ' ')" \
+      || { rm -rf "$comparison_dir"; fail "could not format missing shard entries"; }
+    rm -rf "$comparison_dir"
+    fail "$missing_count entr$missing_suffix in '$full_path' covered by no shard (silent coverage loss): $missing_display"
   fi
 
   local extra_union
-  extra_union="$(comm -13 <(printf '%s\n' "$full") <(printf '%s\n' "$union") || true)"
+  extra_union="$(comm -13 "$comparison_dir/left" "$comparison_dir/right")"
   if [ -n "$extra_union" ]; then
-    fail "union names entries absent from '$full_path': $(printf '%s' "$extra_union" | tr '\n' ' ')"
+    extra_union_display="$(printf '%s' "$extra_union" | tr '\n' ' ')" \
+      || { rm -rf "$comparison_dir"; fail "could not format extra union entries"; }
+    rm -rf "$comparison_dir"
+    fail "union names entries absent from '$full_path': $extra_union_display"
   fi
 
-  echo "check-shard-union: PASS -- $(printf '%s\n' "$full" | grep -c .) entries in '$full_path', $(( ${#shard_paths[@]} )) shard(s), union matches exactly"
+  local full_count
+  full_count="$(printf '%s\n' "$full" | grep -c .)" \
+    || { rm -rf "$comparison_dir"; fail "could not count full-list entries"; }
+  rm -rf "$comparison_dir"
+  echo "check-shard-union: PASS -- $full_count entries in '$full_path', $(( ${#shard_paths[@]} )) shard(s), union matches exactly"
 }
 
 # See the "check-groups" usage block above. Format: non-comment, non-blank

--- a/tools/check-shell-scripts.py
+++ b/tools/check-shell-scripts.py
@@ -141,6 +141,30 @@ def check(root: Path) -> int:
     if executable is None:
         print("check-shell-scripts: shellcheck not found", file=sys.stderr)
         return 1
+    version_result = subprocess.run(
+        [executable, "--version"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    version = next(
+        (
+            line.partition(":")[2].strip()
+            for line in version_result.stdout.splitlines()
+            if line.startswith("version:")
+        ),
+        "",
+    )
+    if version_result.returncode != 0 or not version:
+        detail = (version_result.stderr or version_result.stdout).strip()
+        print(
+            "check-shell-scripts: cannot determine shellcheck version"
+            f" (exit {version_result.returncode}): {detail or '(no output)'}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"check-shell-scripts: shellcheck version {version}", flush=True)
     result = subprocess.run(
         [executable, "--enable=check-extra-masked-returns", *map(str, files)],
         cwd=root,

--- a/tools/check-shell-scripts.py
+++ b/tools/check-shell-scripts.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Run the repository ShellCheck contract and audit suppression reasons."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+SUPPRESSION = re.compile(r"#\s*shellcheck\s+disable=[^#\n]+(?P<reason>#.*)?$")
+
+
+def shell_files(root: Path) -> list[Path]:
+    return sorted((root / "tools").glob("*.sh")) + sorted(
+        (root / ".github/scripts").glob("*.sh")
+    )
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    files = shell_files(root)
+    findings: list[str] = []
+    for path in files:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for line_number, line in enumerate(lines, 1):
+            match = SUPPRESSION.search(line)
+            if match and not (match.group("reason") or "").lstrip("# ").strip():
+                findings.append(
+                    f"{path.relative_to(root)}:{line_number}: "
+                    "shellcheck suppression needs an inline reason"
+                )
+    if findings:
+        print("\n".join(findings), file=sys.stderr)
+        return 1
+
+    executable = shutil.which("shellcheck")
+    if executable is None:
+        print("check-shell-scripts: shellcheck not found", file=sys.stderr)
+        return 1
+    result = subprocess.run(
+        [executable, "--enable=check-extra-masked-returns", *map(str, files)],
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        return result.returncode
+    print(f"check-shell-scripts: PASS -- {len(files)} script(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check-shell-scripts.py
+++ b/tools/check-shell-scripts.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import argparse
 import re
 import shutil
 import subprocess
@@ -20,9 +21,108 @@ def shell_files(root: Path) -> list[Path]:
     )
 
 
-def main() -> int:
-    root = Path(__file__).resolve().parent.parent
+def tracked_shell_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--", "tools", ".github/scripts"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"git ls-files failed with exit {result.returncode}: {detail or '(no stderr)'}"
+        )
+    try:
+        names = result.stdout.decode("utf-8").split("\0")
+    except UnicodeDecodeError as error:
+        raise RuntimeError(f"git returned a non-UTF-8 path: {error}") from error
+    allowed_parents = {Path("tools"), Path(".github/scripts")}
+    return sorted(
+        root / relative
+        for name in names
+        if name
+        for relative in (Path(name),)
+        if relative.parent in allowed_parents and relative.suffix == ".sh"
+    )
+
+
+def inventory_findings(discovered: list[Path], tracked: list[Path]) -> list[str]:
+    if not tracked:
+        return ["tracked shell-script inventory is unexpectedly empty"]
+    if not discovered:
+        return ["discovered shell-script inventory is unexpectedly empty"]
+    missing = sorted(set(tracked) - set(discovered))
+    if not missing:
+        return []
+    return [
+        "tracked shell script missing from discovery: " + path.as_posix()
+        for path in missing
+    ]
+
+
+def selftest(root: Path) -> int:
+    fixture_root = root / "tests/fixtures/shell-script-inventory/accepting"
+    tracked = sorted(
+        [
+            fixture_root / "tools/check-one.sh",
+            fixture_root / "tools/run-one.sh",
+            fixture_root / ".github/scripts/report-one.sh",
+        ]
+    )
+    discovered = shell_files(fixture_root)
+    cases = {
+        "complete discovery": (discovered, tracked, []),
+        "untracked addition": (
+            [*discovered, fixture_root / "tools/untracked-extra.sh"],
+            tracked,
+            [],
+        ),
+        "narrowed tools glob": (
+            [path for path in discovered if path.name.startswith("check-")],
+            tracked,
+            ["run-one.sh", "report-one.sh"],
+        ),
+        "github directory omitted": (
+            [path for path in discovered if path.parent.name == "tools"],
+            tracked,
+            ["report-one.sh"],
+        ),
+        "empty discovery": ([], tracked, ["unexpectedly empty"]),
+        "empty tracked authority": (discovered, [], ["unexpectedly empty"]),
+    }
+    ok = True
+    for label, (case_discovered, case_tracked, expected_fragments) in cases.items():
+        produced = inventory_findings(case_discovered, case_tracked)
+        fragments_match = all(
+            any(fragment in finding for finding in produced)
+            for fragment in expected_fragments
+        )
+        if fragments_match and bool(produced) == bool(expected_fragments):
+            continue
+        print(
+            f"selftest: FAIL: {label}: produced={produced!r} "
+            f"expected_fragments={expected_fragments!r}",
+            file=sys.stderr,
+        )
+        ok = False
+    if ok:
+        print("selftest: PASS: inventory_accepting=2 inventory_rejecting=4")
+        return 0
+    return 1
+
+
+def check(root: Path) -> int:
     files = shell_files(root)
+    try:
+        tracked = tracked_shell_files(root)
+    except RuntimeError as error:
+        print(f"check-shell-scripts: {error}", file=sys.stderr)
+        return 1
+    inventory_errors = inventory_findings(files, tracked)
+    if inventory_errors:
+        print("\n".join(inventory_errors), file=sys.stderr)
+        return 1
     findings: list[str] = []
     for path in files:
         lines = path.read_text(encoding="utf-8").splitlines()
@@ -50,6 +150,18 @@ def main() -> int:
         return result.returncode
     print(f"check-shell-scripts: PASS -- {len(files)} script(s)")
     return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "command", nargs="?", choices=("check", "selftest"), default="check"
+    )
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parent.parent
+    if args.command == "selftest":
+        return selftest(root)
+    return check(root)
 
 
 if __name__ == "__main__":

--- a/tools/run-fault-operators.sh
+++ b/tools/run-fault-operators.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "run-fault-operators.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 #
 # Implementation fault operators (#537 C5). See
@@ -90,13 +91,15 @@ export CARGO_TARGET_DIR="$work/target"
 lock="$work/lock"
 mkdir -p "$work"
 if ! mkdir "$lock" 2>/dev/null; then
+  # shellcheck disable=SC2312 # the explicit fallback turns an unreadable stale holder into the intended diagnostic
   echo "fault-operators: another invocation holds $lock ($(cat "$lock/holder" 2>/dev/null || echo unknown)).
   If that run crashed, verify no cargo/fslc process is alive and remove the
   directory by hand. Not proceeding: two runners in one scratch make every
   verdict in the matrix meaningless." >&2
   exit 1
 fi
-echo "pid $$ started $(date -u +%FT%TZ)" >"$lock/holder"
+started_at="$(date -u +%FT%TZ)"
+echo "pid $$ started $started_at" >"$lock/holder"
 trap 'rm -rf "$lock"' EXIT
 
 fail() {
@@ -127,10 +130,11 @@ read_table() {
   local name patch_file contract seam_path seam_anchor primary_target primary_test
   local blind_target blind_test expected_change calibrated_edge source_scope extra
   while IFS='^' read -r name patch_file contract seam_path seam_anchor primary_target primary_test blind_target blind_test expected_change calibrated_edge source_scope extra; do
-    name="$(trim "${name:-}")"
+    name="$(trim "${name:-}")" || fail "$table: could not trim an operator name"
     [ -n "$name" ] || continue
     case "$name" in \#*) continue ;; esac
-    [ -z "$(trim "${extra:-}")" ] || fail "$table: row '$name' has more than twelve columns"
+    extra="$(trim "${extra:-}")" || fail "$table: could not trim the extra-column field"
+    [ -z "$extra" ] || fail "$table: row '$name' has more than twelve columns"
     patch_file="$(trim "${patch_file:-}")"
     [ -n "$patch_file" ] || fail "$table: row '$name' names no patch file"
     [ -f "$operators_dir/$patch_file" ] || fail "$table: row '$name' names a missing patch file '$patch_file'"
@@ -221,7 +225,10 @@ sync_scratch() {
   # seam". It reproduced only where the scratch's own `.git` was absent or
   # unusable, which is why it appeared in CI and never locally, and why the same
   # revision returned different verdicts on different runs.
-  if [ "$(cd "$scratch" && git rev-parse --show-toplevel 2>/dev/null || true)" != "$(cd "$scratch" && pwd -P)" ]; then
+  local scratch_toplevel scratch_physical
+  scratch_toplevel="$(cd "$scratch" && git rev-parse --show-toplevel 2>/dev/null || true)"
+  scratch_physical="$(cd "$scratch" && pwd -P)"
+  if [ "$scratch_toplevel" != "$scratch_physical" ]; then
     rm -rf "$scratch/.git"
     git -C "$scratch" init --quiet
   fi
@@ -335,7 +342,7 @@ run_detector() {
   local target="$1" name="$2" log="$3" status=0
   # `$target` is a cargo test-target selector ("--lib", "--test <name>") and
   # is deliberately word-split.
-  # shellcheck disable=SC2086
+  # shellcheck disable=SC2086 # deliberate word splitting applies the table's cargo arguments
   if ! (cd "$scratch" && cargo test --manifest-path rust/Cargo.toml -p fslc-rust $target --locked --no-run) >"$log.build" 2>&1; then
     tail -40 "$log.build" >&2
     fail "the patched checkout does not compile (target: $target). Full log: $log.build"
@@ -352,7 +359,7 @@ run_detector() {
   # this one is named directly rather than read back.
   detector_cli_hash=""
   [ -f "$CARGO_TARGET_DIR/debug/fslc" ] && detector_cli_hash="$(hash_file "$CARGO_TARGET_DIR/debug/fslc")"
-  # shellcheck disable=SC2086
+  # shellcheck disable=SC2086 # deliberate word splitting applies the table's cargo arguments
   (cd "$scratch" && cargo test --manifest-path rust/Cargo.toml -p fslc-rust $target --locked -- --exact "$name") >"$log" 2>&1 || status=$?
   if ! grep -q -- "^test ${name} \.\.\. " "$log"; then
     tail -20 "$log" >&2
@@ -451,7 +458,10 @@ no_op_cli_hashes=()
 # genuinely faulted binary equal the unfaulted one, so this only ever fires on
 # a real reuse, never on a flaky digest.
 assert_fault_reached_source() {
-  local file="$1" name="$2" patched seen=0
+  local file="$1" name="$2" patched seen=0 patched_paths
+  patched_paths="$(mktemp)" || fail "operator '$name': could not create patched-path inventory"
+  sed -n 's/^+++ b\///p' "$file" | sort -u >"$patched_paths" \
+    || { rm -f "$patched_paths"; fail "operator '$name': could not enumerate patched paths"; }
   while IFS= read -r patched; do
     [ -n "$patched" ] || continue
     seen=$((seen + 1))
@@ -463,7 +473,8 @@ assert_fault_reached_source() {
   the source the detector is about to be built from. Any verdict below would be
   a property of the harness, not of the fault."
     fi
-  done < <(sed -n 's/^+++ b\///p' "$file" | sort -u)
+  done <"$patched_paths"
+  rm -f "$patched_paths"
   [ "$seen" -gt 0 ] || fail "operator '$name': its patch names no files, so
   there is nothing to verify reached the scratch."
 }
@@ -531,12 +542,15 @@ executed_names=()
 for index in "${assigned_indices[@]}"; do
   executed_names+=("${names[$index]}")
 done
-table_operators_json="$(printf '%s\n' "${names[@]}" | jq -R . | jq -s .)"
-executed_operators_json="$(printf '%s\n' "${executed_names[@]}" | jq -R . | jq -s .)"
+table_operators_json="$(printf '%s\n' "${names[@]}" | jq -R . | jq -s .)" \
+  || fail "could not serialize the full operator inventory"
+executed_operators_json="$(printf '%s\n' "${executed_names[@]}" | jq -R . | jq -s .)" \
+  || fail "could not serialize the executed operator inventory"
+base_revision="$(git -C "$root" rev-parse HEAD)"
 jq -n \
   --arg schema "fslc.fault-operator-shard-manifest.v1" \
   --argjson schema_version 1 \
-  --arg base_revision "$(git -C "$root" rev-parse HEAD)" \
+  --arg base_revision "$base_revision" \
   --argjson shard_index "$shard_index" \
   --argjson shard_total "$shard_total" \
   --argjson table_operators "$table_operators_json" \

--- a/tools/run-fault-operators.sh
+++ b/tools/run-fault-operators.sh
@@ -226,7 +226,11 @@ sync_scratch() {
   # unusable, which is why it appeared in CI and never locally, and why the same
   # revision returned different verdicts on different runs.
   local scratch_toplevel scratch_physical
-  scratch_toplevel="$(cd "$scratch" && git rev-parse --show-toplevel 2>/dev/null || true)"
+  if scratch_toplevel="$(cd "$scratch" && git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    scratch_toplevel=""
+  fi
   scratch_physical="$(cd "$scratch" && pwd -P)"
   if [ "$scratch_toplevel" != "$scratch_physical" ]; then
     rm -rf "$scratch/.git"
@@ -349,9 +353,13 @@ run_detector() {
   fi
   local binary
   binary="$(executable_from_build_log "$log.build")"
-  [ -n "$binary" ] && [ -f "$binary" ] || fail "cargo reported no executable for
-  target '$target', so nothing here can prove which binary the detector ran.
-  Full log: $log.build"
+  if [ -n "$binary" ] && [ -f "$binary" ]; then
+    :
+  else
+    fail "cargo reported no executable for
+    target '$target', so nothing here can prove which binary the detector ran.
+    Full log: $log.build"
+  fi
   detector_binary_hash="$(hash_file "$binary")"
   # The `fslc` executable the detector may spawn instead of, or in addition to,
   # exercising the library in-process. `cargo test` builds the package's bins so

--- a/tools/run-fsl-logic-test.sh
+++ b/tools/run-fsl-logic-test.sh
@@ -26,5 +26,5 @@ if ! jq -e '.complete == true and .expected == .executed and (.cases | length) =
   echo "fsl-logic: incomplete report $report" >&2
   exit 1
 fi
-printf 'fsl-logic: tier=%s cases=%s report=%s\n' \
-  "$tier" "$(jq -r '.executed' "$report")" "$report"
+executed="$(jq -r '.executed' "$report")"
+printf 'fsl-logic: tier=%s cases=%s report=%s\n' "$tier" "$executed" "$report"

--- a/tools/run-semantic-mutation-gate.sh
+++ b/tools/run-semantic-mutation-gate.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "run-semantic-mutation-gate.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -101,8 +102,9 @@ run_operators_lane() {
 }
 
 if [ "$lane" != "operators" ]; then
-  if [ "$(cargo mutants --version)" != "$runner_version" ]; then
-    echo "semantic-mutation: requires exactly $runner_version; observed $(cargo mutants --version 2>&1)" >&2
+  observed_runner_version="$(cargo mutants --version 2>&1)"
+  if [ "$observed_runner_version" != "$runner_version" ]; then
+    echo "semantic-mutation: requires exactly $runner_version; observed $observed_runner_version" >&2
     exit 1
   fi
 fi
@@ -176,18 +178,23 @@ if [ "$mode" = changed ]; then
     cargo mutants "${args[@]}" "${diff_args[@]}" --list
   ) >"$filtered"
   if [ ! -s "$filtered" ]; then
-    changed_scope_paths="$(comm -12 \
-      <(sed -n 's|^+++ b/||p' "$diff_file" | sort -u) \
-      <(jq -r '.decisions[].path | sub("^rust/"; "")' "$scope" | sort -u))"
+    changed_diff_paths="$output/changed-diff-paths.txt"
+    changed_scope_inventory="$output/changed-scope-paths.txt"
+    sed -n 's|^+++ b/||p' "$diff_file" | sort -u >"$changed_diff_paths"
+    jq -r '.decisions[].path | sub("^rust/"; "")' "$scope" \
+      | sort -u >"$changed_scope_inventory"
+    changed_scope_paths="$(comm -12 "$changed_diff_paths" "$changed_scope_inventory")"
     if [ -z "$changed_scope_paths" ]; then
       (
         cd "$scratch/rust"
         cargo test --locked -p fsl-verifier -p fslc-rust \
           --test solver_fail_closed --test triangulated_assurance
       )
-      paths_json="$(sed -n 's|^+++ b/||p' "$diff_file" | sort -u | jq -Rsc 'split("\n") | map(select(length > 0) | "rust/" + .)')"
+      paths_json="$(sed -n 's|^+++ b/||p' "$diff_file" | sort -u | jq -Rsc 'split("\n") | map(select(length > 0) | "rust/" + .)')" \
+        || { echo "semantic-mutation: could not serialize changed paths" >&2; exit 1; }
+      report_revision="$(git -C "$root" rev-parse HEAD)"
       jq -n \
-        --arg revision "$(git -C "$root" rev-parse HEAD)" \
+        --arg revision "$report_revision" \
         --arg diff_base "${FSL_MUTATION_BASE:-unknown}" \
         --argjson paths "$paths_json" \
         '{
@@ -293,6 +300,8 @@ fi
 # source lines are derived from exact maintained anchors at run time, so line
 # movement cannot silently turn a decision ID into a bare function name.
 decision_anchors='[]'
+decision_rows="$output/decision-rows.jsonl"
+jq -c '.decisions[]' "$scope" >"$decision_rows"
 while IFS= read -r decision; do
   decision_id="$(jq -r '.id' <<<"$decision")"
   decision_path="$(jq -r '.path' <<<"$decision")"
@@ -313,7 +322,7 @@ while IFS= read -r decision; do
     --argjson line "$decision_line" \
     '. + [{id: $id, path: $path, function: $function, line: $line}]' \
     <<<"$decision_anchors")"
-done < <(jq -c '.decisions[]' "$scope")
+done <"$decision_rows"
 
 jq \
   --arg revision "$base_revision" \
@@ -388,6 +397,14 @@ jq \
 # failing tests in each mutant's log. A caught classification without the
 # detector that actually failed is not reviewable mutation evidence, so enrich
 # every killed row and fail closed if the runner log cannot supply one.
+caught_mutant_rows="$output/caught-mutant-rows.tsv"
+jq -r '
+  [.outcomes[] | select(.scenario != "Baseline")]
+  | to_entries[]
+  | select(.value.summary == "CaughtMutant")
+  | [.key, .value.log_path]
+  | @tsv
+' "$raw/outcomes.json" >"$caught_mutant_rows"
 while IFS=$'\t' read -r mutant_index log_path; do
   case "$log_path" in
     log/*) ;;
@@ -415,15 +432,7 @@ while IFS=$'\t' read -r mutant_index log_path; do
     '.mutants[$mutant_index].primary_failing_test = $primary_failing_test' \
     "$output/implementation-mutation-report.v1.json" >"$report_tmp"
   mv "$report_tmp" "$output/implementation-mutation-report.v1.json"
-done < <(
-  jq -r '
-    [.outcomes[] | select(.scenario != "Baseline")]
-    | to_entries[]
-    | select(.value.summary == "CaughtMutant")
-    | [.key, .value.log_path]
-    | @tsv
-  ' "$raw/outcomes.json"
-)
+done <"$caught_mutant_rows"
 
 FSL_IMPLEMENTATION_MUTATION_REPORT="$output/implementation-mutation-report.v1.json" \
   cargo test --manifest-path "$root/rust/Cargo.toml" -p fslc-rust \


### PR DESCRIPTION
## Problem

Two mechanically-detectable defect classes recurred repeatedly (#898): pipeline/process-substitution exit-code swallowing (3 occurrences in one cycle: #757 F5/F6 plus a gate-verdict pipe) and bash-3.2 incompatibility (`mapfile` missing; empty array + `set -u`) — while no shell lint ran anywhere.

## Change

- `tools/check-shell-scripts.py`: shellcheck over the **git-tracked** `tools/*.sh` / `.github/scripts/*.sh` inventory, wired into the required `merge readiness` automation lane. Fails closed when shellcheck is absent (no silent skip); a fail-closed inventory self-check rejects a shrunk target set. 5 reasoned suppressions (SC2016×4 generated code, SC2163×1 dynamic export), each verified at site; unreasoned suppressions are themselves detected.
- `tools/check-bash-version-guards.py`: parser-backed, token-aware lint requiring a fail-closed `BASH_VERSINFO` guard in every script using bash-4+ features. Boundary pinned through four review rounds: indented `declare -A`/`local -A` detected; double-quoted decoys and **quoted**-delimiter heredoc bodies excluded; **unquoted** heredoc bodies still scanned for expansion-context hazards (`${arr[@]}` under `set -u` is live there) while command-position words stay excluded — 8 quadrant fixtures pin both directions. Dynamic execution via `eval` is a documented non-goal fixed by an expected-non-detection selftest.
- Guards added and real findings fixed across 9 `tools/*.sh`; decision recorded in `docs/DESIGN-ci.md`; `changelog.d/898-shellcheck-wiring.required.md`.

## Evidence

- Independent review (separate codex session), **four rounds to zero findings**: R1 3 findings (indented-declare bypass, shrunk-glob pass-through, quoted-string false positive) → R2 fixed, 2 new (eval boundary, heredoc FP) → R3 heredoc excluded + boundary documented, 1 new High (unquoted-heredoc expansions missed) → R4 quadrant split; reviewer re-ran every counterexample. Final findings 0; full review attached.
- Detector proofs throughout (verdict-pipe injection, guard removal, unreasoned suppression, glob shrink, each quadrant), produced/expected recorded, restores proven by empty diff; selftests and the automation lane run twice per round.

Closes #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)