### PR TITLE
docs(ci): record the first natural mixed-attempt partial re-run

### DIFF
--- a/changelog.d/757-natural-rerun-observation.documented.md
+++ b/changelog.d/757-natural-rerun-observation.documented.md
@@ -1,0 +1,4 @@
+Documented (#757): recorded the first natural production partial re-run — a GitHub-side
+artifact-service transient failed one test shard on a docs-only PR, `gh run rerun --failed`
+re-ran only that shard, and the aggregator accepted the mixed-attempt cohort
+(`attempts=1,1,2`), recovering in one shard's time instead of a full three-shard re-run.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -443,6 +443,15 @@ attempts=1,2,1 shards=1,2,3` and `check-shard-artifact-cohort: PASS --
 lane=semantic-mutation-operators run_id=32798975136 attempts=1,2,1 shards=1,2,3`. This satisfies the
 probe precondition above; the probe commit itself was then removed from the branch.
 
+**First natural production observation (recorded 2026-08-26, run `32931874941` on PR #908).**
+A docs-only PR's `rust tests (3/3)` shard failed on a GitHub-side transient — five
+`ArtifactService/ListArtifacts` and `CreateArtifact` request timeouts with the tests themselves
+green — exactly the transient class this design targets. `gh run rerun --failed` re-ran only that
+shard; attempt 2 completed `success` overall and the aggregator accepted the mixed cohort:
+`check-shard-artifact-cohort: PASS -- lane=rust-tests run_id=32931874941 attempts=1,1,2
+shards=1,2,3`. Before this design, that recovery would have required a full ~60-minute re-run of
+every shard.
+
 **Agent-configuration-exempt pull requests still work.** Every shard job runs
 `check-product-gate-scope.sh` itself and early-exits its own later steps when `run=false`, so the
 shard's job result is still `success` and no artifact is ever uploaded. Both aggregators therefore


### PR DESCRIPTION
Records the observation `docs/DESIGN-ci.md`'s sharded-evidence section asks for: the first naturally occurring single-shard failure after #891 (a GitHub artifact-service transient on PR #908's `rust tests (3/3)`, tests green) recovered via `gh run rerun --failed` — only the failed shard re-ran and the aggregator accepted `attempts=1,1,2 shards=1,2,3` (run 32931874941). One shard's time instead of a full three-shard re-run.

Docs + changelog fragment only.

Refs #757, #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)