### PR TITLE
fix(core): close the check/verify false-green class for alias members and typed binders

### DIFF
--- a/changelog.d/832-compose-check-alias-members.fixed.md
+++ b/changelog.d/832-compose-check-alias-members.fixed.md
@@ -1,0 +1,7 @@
+Fixed (#832): native `fslc check` now fails closed for two compose alias
+resolution gaps that `verify` already rejected. A declared alias no longer
+authorizes a nonexistent qualified type such as `core.NoSuchType`, and an
+undeclared alias-shaped expression in an `init if` condition receives the same
+type check as an assignment right-hand side. Both errors retain the author's
+spelling and source location; valid imported types and state conditions remain
+accepted.

--- a/changelog.d/832-compose-check-alias-members.fixed.md
+++ b/changelog.d/832-compose-check-alias-members.fixed.md
@@ -1,7 +1,8 @@
-Fixed (#832): native `fslc check` now fails closed for two compose alias
-resolution gaps that `verify` already rejected. A declared alias no longer
-authorizes a nonexistent qualified type such as `core.NoSuchType`, and an
-undeclared alias-shaped expression in an `init if` condition receives the same
-type check as an assignment right-hand side. Both errors retain the author's
-spelling and source location; valid imported types and state conditions remain
-accepted.
+Fixed (#832): native `fslc check` now fails closed for compose alias and typed
+binder resolution gaps that `verify` already rejected. A declared alias no
+longer authorizes a nonexistent qualified type such as `core.NoSuchType`, and
+an undeclared alias-shaped expression in an `init if` condition receives the
+same type check as an assignment right-hand side. Unknown typed binder names
+are also rejected uniformly in properties, action postconditions, and init.
+Errors retain the author's spelling and source location; valid imported types,
+binder types, and state conditions remain accepted.

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -380,7 +380,22 @@ fn error_at(message: impl Into<String>, span: fsl_syntax::Span) -> CoreError {
         message: message.into(),
         line: span.start.line,
         column: span.start.column,
-        origin: None,
+        origin: Some(Box::new(crate::OriginChain {
+            id: crate::OriginId(format!(
+                "compose:error:{}:{}",
+                span.start.offset, span.end.offset
+            )),
+            dialect: "compose".to_owned(),
+            primary: Some(crate::OriginSite {
+                source_file: None,
+                span: Some(span),
+                dialect: "compose".to_owned(),
+                declaration_path: Vec::new(),
+            }),
+            secondary: Vec::new(),
+            lowering_steps: Vec::new(),
+            generated: false,
+        })),
         name_resolution: false,
     }
 }
@@ -914,7 +929,7 @@ fn rewrite_compose_item(
             annotations,
         } => SpecItem::Invariant {
             name,
-            expr: Box::new(resolve_alias_expr(*expr, components)?),
+            expr: Box::new(resolve_alias_expr_with_span(*expr, components, Some(span))?),
             span,
             meta,
             annotations,
@@ -927,7 +942,7 @@ fn rewrite_compose_item(
             annotations,
         } => SpecItem::Trans {
             name,
-            expr: Box::new(resolve_alias_expr(*expr, components)?),
+            expr: Box::new(resolve_alias_expr_with_span(*expr, components, Some(span))?),
             span,
             meta,
             annotations,
@@ -940,7 +955,7 @@ fn rewrite_compose_item(
             annotations,
         } => SpecItem::Reachable {
             name,
-            expr: Box::new(resolve_alias_expr(*expr, components)?),
+            expr: Box::new(resolve_alias_expr_with_span(*expr, components, Some(span))?),
             span,
             meta,
             annotations,
@@ -1221,69 +1236,129 @@ fn resolve_alias_expr(
     expr: Expr,
     components: &BTreeMap<String, Component>,
 ) -> Result<Expr, CoreError> {
+    resolve_alias_expr_with_span(expr, components, None)
+}
+
+#[allow(clippy::too_many_lines)]
+fn resolve_alias_expr_with_span(
+    expr: Expr,
+    components: &BTreeMap<String, Component>,
+    diagnostic_span: Option<fsl_syntax::Span>,
+) -> Result<Expr, CoreError> {
     Ok(match expr {
         Expr::Field(base, name) => {
             if let Expr::Var(alias) = base.as_ref() {
                 if components.contains_key(alias) {
                     Expr::Var(prefix(alias, &name))
                 } else {
-                    Expr::Field(Box::new(resolve_alias_expr(*base, components)?), name)
+                    Expr::Field(
+                        Box::new(resolve_alias_expr_with_span(
+                            *base,
+                            components,
+                            diagnostic_span,
+                        )?),
+                        name,
+                    )
                 }
             } else {
-                Expr::Field(Box::new(resolve_alias_expr(*base, components)?), name)
+                Expr::Field(
+                    Box::new(resolve_alias_expr_with_span(
+                        *base,
+                        components,
+                        diagnostic_span,
+                    )?),
+                    name,
+                )
             }
         }
-        Expr::Some(expr) => Expr::Some(Box::new(resolve_alias_expr(*expr, components)?)),
+        Expr::Some(expr) => Expr::Some(Box::new(resolve_alias_expr_with_span(
+            *expr,
+            components,
+            diagnostic_span,
+        )?)),
         Expr::Set(items) => Expr::Set(
             items
                 .into_iter()
-                .map(|item| resolve_alias_expr(item, components))
+                .map(|item| resolve_alias_expr_with_span(item, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
         ),
         Expr::Seq(items) => Expr::Seq(
             items
                 .into_iter()
-                .map(|item| resolve_alias_expr(item, components))
+                .map(|item| resolve_alias_expr_with_span(item, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
         ),
         Expr::Struct { name, fields } => Expr::Struct {
             name,
             fields: fields
                 .into_iter()
-                .map(|(name, expr)| Ok((name, resolve_alias_expr(expr, components)?)))
+                .map(|(name, expr)| {
+                    Ok((
+                        name,
+                        resolve_alias_expr_with_span(expr, components, diagnostic_span)?,
+                    ))
+                })
                 .collect::<Result<_, CoreError>>()?,
         },
         Expr::Call { name, args, span } => Expr::Call {
             name,
             args: args
                 .into_iter()
-                .map(|arg| resolve_alias_expr(arg, components))
+                .map(|arg| resolve_alias_expr_with_span(arg, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
             span,
         },
         Expr::Index(base, index) => Expr::Index(
-            Box::new(resolve_alias_expr(*base, components)?),
-            Box::new(resolve_alias_expr(*index, components)?),
+            Box::new(resolve_alias_expr_with_span(
+                *base,
+                components,
+                diagnostic_span,
+            )?),
+            Box::new(resolve_alias_expr_with_span(
+                *index,
+                components,
+                diagnostic_span,
+            )?),
         ),
         Expr::Method {
             receiver,
             name,
             args,
         } => Expr::Method {
-            receiver: Box::new(resolve_alias_expr(*receiver, components)?),
+            receiver: Box::new(resolve_alias_expr_with_span(
+                *receiver,
+                components,
+                diagnostic_span,
+            )?),
             name,
             args: args
                 .into_iter()
-                .map(|arg| resolve_alias_expr(arg, components))
+                .map(|arg| resolve_alias_expr_with_span(arg, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
         },
         Expr::Binary { op, left, right } => Expr::Binary {
             op,
-            left: Box::new(resolve_alias_expr(*left, components)?),
-            right: Box::new(resolve_alias_expr(*right, components)?),
+            left: Box::new(resolve_alias_expr_with_span(
+                *left,
+                components,
+                diagnostic_span,
+            )?),
+            right: Box::new(resolve_alias_expr_with_span(
+                *right,
+                components,
+                diagnostic_span,
+            )?),
         },
-        Expr::Neg(expr) => Expr::Neg(Box::new(resolve_alias_expr(*expr, components)?)),
-        Expr::Not(expr) => Expr::Not(Box::new(resolve_alias_expr(*expr, components)?)),
+        Expr::Neg(expr) => Expr::Neg(Box::new(resolve_alias_expr_with_span(
+            *expr,
+            components,
+            diagnostic_span,
+        )?)),
+        Expr::Not(expr) => Expr::Not(Box::new(resolve_alias_expr_with_span(
+            *expr,
+            components,
+            diagnostic_span,
+        )?)),
         Expr::Conditional {
             condition,
             then_expr,
@@ -1291,12 +1366,28 @@ fn resolve_alias_expr(
             spans,
         } => Expr::Conditional {
             spans,
-            condition: Box::new(resolve_alias_expr(*condition, components)?),
-            then_expr: Box::new(resolve_alias_expr(*then_expr, components)?),
-            else_expr: Box::new(resolve_alias_expr(*else_expr, components)?),
+            condition: Box::new(resolve_alias_expr_with_span(
+                *condition,
+                components,
+                diagnostic_span,
+            )?),
+            then_expr: Box::new(resolve_alias_expr_with_span(
+                *then_expr,
+                components,
+                diagnostic_span,
+            )?),
+            else_expr: Box::new(resolve_alias_expr_with_span(
+                *else_expr,
+                components,
+                diagnostic_span,
+            )?),
         },
         Expr::Is { expr, pattern } => Expr::Is {
-            expr: Box::new(resolve_alias_expr(*expr, components)?),
+            expr: Box::new(resolve_alias_expr_with_span(
+                *expr,
+                components,
+                diagnostic_span,
+            )?),
             pattern,
         },
         Expr::Quantified {
@@ -1305,8 +1396,12 @@ fn resolve_alias_expr(
             body,
         } => Expr::Quantified {
             quantifier,
-            binder: resolve_alias_binder(binder, components, None)?,
-            body: Box::new(resolve_alias_expr(*body, components)?),
+            binder: resolve_alias_binder(binder, components, diagnostic_span)?,
+            body: Box::new(resolve_alias_expr_with_span(
+                *body,
+                components,
+                diagnostic_span,
+            )?),
         },
         Expr::Aggregate {
             kind,
@@ -1314,20 +1409,34 @@ fn resolve_alias_expr(
             value,
         } => Expr::Aggregate {
             kind,
-            binder: resolve_alias_binder(binder, components, None)?,
+            binder: resolve_alias_binder(binder, components, diagnostic_span)?,
             value: value
-                .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
+                .map(|expr| {
+                    resolve_alias_expr_with_span(*expr, components, diagnostic_span).map(Box::new)
+                })
                 .transpose()?,
         },
         Expr::UnaryNamed { name, expr, span } => Expr::UnaryNamed {
             name,
-            expr: Box::new(resolve_alias_expr(*expr, components)?),
+            expr: Box::new(resolve_alias_expr_with_span(
+                *expr,
+                components,
+                diagnostic_span,
+            )?),
             span,
         },
         Expr::BinaryNamed { name, left, right } => Expr::BinaryNamed {
             name,
-            left: Box::new(resolve_alias_expr(*left, components)?),
-            right: Box::new(resolve_alias_expr(*right, components)?),
+            left: Box::new(resolve_alias_expr_with_span(
+                *left,
+                components,
+                diagnostic_span,
+            )?),
+            right: Box::new(resolve_alias_expr_with_span(
+                *right,
+                components,
+                diagnostic_span,
+            )?),
         },
         Expr::TernaryNamed {
             name,
@@ -1336,9 +1445,21 @@ fn resolve_alias_expr(
             third,
         } => Expr::TernaryNamed {
             name,
-            first: Box::new(resolve_alias_expr(*first, components)?),
-            second: Box::new(resolve_alias_expr(*second, components)?),
-            third: Box::new(resolve_alias_expr(*third, components)?),
+            first: Box::new(resolve_alias_expr_with_span(
+                *first,
+                components,
+                diagnostic_span,
+            )?),
+            second: Box::new(resolve_alias_expr_with_span(
+                *second,
+                components,
+                diagnostic_span,
+            )?),
+            third: Box::new(resolve_alias_expr_with_span(
+                *third,
+                components,
+                diagnostic_span,
+            )?),
         },
         other => other,
     })

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -995,7 +995,7 @@ fn resolve_alias_statement(
             statements,
             span,
         } => Statement::ForAll {
-            binder: resolve_alias_binder(binder, components)?,
+            binder: resolve_alias_binder(binder, components, Some(span))?,
             statements: statements
                 .into_iter()
                 .map(|statement| resolve_alias_statement(statement, components))
@@ -1014,7 +1014,7 @@ fn sync_action(
         .params
         .iter()
         .cloned()
-        .map(|param| resolve_alias_param(param, components))
+        .map(|param| resolve_alias_param(param, components, action.span))
         .collect::<Result<Vec<_>, _>>()?;
     let mut items = Vec::new();
     let mut fair_constituents = Vec::new();
@@ -1117,11 +1117,13 @@ fn sync_action(
 fn resolve_alias_param(
     param: Param,
     components: &BTreeMap<String, Component>,
+    span: fsl_syntax::Span,
 ) -> Result<Param, CoreError> {
     Ok(match param {
-        Param::Typed(name, qualified) => {
-            Param::Typed(name, resolve_alias_qualified_name(qualified, components)?)
-        }
+        Param::Typed(name, qualified) => Param::Typed(
+            name,
+            resolve_alias_qualified_name(qualified, components, Some(span))?,
+        ),
         Param::Range(name, lo, hi) => Param::Range(
             name,
             resolve_alias_expr(lo, components)?,
@@ -1133,16 +1135,33 @@ fn resolve_alias_param(
 fn resolve_alias_qualified_name(
     qualified: QualifiedName,
     components: &BTreeMap<String, Component>,
+    span: Option<fsl_syntax::Span>,
 ) -> Result<QualifiedName, CoreError> {
     if let Some(alias) = qualified.namespace {
-        if !components.contains_key(&alias) {
-            return Err(CoreError {
-                message: format!("unknown alias '{alias}'"),
-                line: 1,
-                column: 1,
-                origin: None,
-                name_resolution: false,
-            });
+        let component = components.get(&alias).ok_or_else(|| {
+            span.map_or_else(
+                || CoreError {
+                    message: format!("unknown alias '{alias}'"),
+                    line: 1,
+                    column: 1,
+                    origin: None,
+                    name_resolution: false,
+                },
+                |span| error_at(format!("unknown alias '{alias}'"), span),
+            )
+        })?;
+        if !component.names.types.contains(&qualified.name) {
+            let message = format!("unknown type '{alias}.{}'", qualified.name);
+            return Err(span.map_or_else(
+                || CoreError {
+                    message: message.clone(),
+                    line: 1,
+                    column: 1,
+                    origin: None,
+                    name_resolution: false,
+                },
+                |span| error_at(message.clone(), span),
+            ));
         }
         Ok(QualifiedName {
             namespace: None,
@@ -1156,6 +1175,7 @@ fn resolve_alias_qualified_name(
 fn resolve_alias_binder(
     binder: Binder,
     components: &BTreeMap<String, Component>,
+    span: Option<fsl_syntax::Span>,
 ) -> Result<Binder, CoreError> {
     Ok(match binder {
         Binder::Typed {
@@ -1164,7 +1184,7 @@ fn resolve_alias_binder(
             where_expr,
         } => Binder::Typed {
             name,
-            type_name: resolve_alias_qualified_name(type_name, components)?,
+            type_name: resolve_alias_qualified_name(type_name, components, span)?,
             where_expr: where_expr
                 .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
                 .transpose()?,
@@ -1285,7 +1305,7 @@ fn resolve_alias_expr(
             body,
         } => Expr::Quantified {
             quantifier,
-            binder: resolve_alias_binder(binder, components)?,
+            binder: resolve_alias_binder(binder, components, None)?,
             body: Box::new(resolve_alias_expr(*body, components)?),
         },
         Expr::Aggregate {
@@ -1294,7 +1314,7 @@ fn resolve_alias_expr(
             value,
         } => Expr::Aggregate {
             kind,
-            binder: resolve_alias_binder(binder, components)?,
+            binder: resolve_alias_binder(binder, components, None)?,
             value: value
                 .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
                 .transpose()?,

--- a/rust/fsl-core/src/typecheck.rs
+++ b/rust/fsl-core/src/typecheck.rs
@@ -123,7 +123,15 @@ pub(crate) fn binder_type(
     model: &KernelModel,
 ) -> Result<TypeRef, TypecheckError> {
     match binder {
-        Binder::Typed { type_name, .. } => Ok(TypeRef::Named(qualified_name(type_name)?)),
+        Binder::Typed { type_name, .. } => {
+            let name = qualified_name(type_name)?;
+            match name.as_str() {
+                "Bool" => Ok(TypeRef::Bool),
+                "Int" => Ok(TypeRef::Int),
+                _ if model.types.contains_key(&name) => Ok(TypeRef::Named(name)),
+                _ => Err(error(format!("unknown type '{name}'"))),
+            }
+        }
         Binder::Range { lo, hi, .. } => {
             ensure_assignable(lo, &TypeRef::Int, env, model, unknown_span())?;
             ensure_assignable(hi, &TypeRef::Int, env, model, unknown_span())?;
@@ -759,7 +767,7 @@ fn validate_binder(
     model: &KernelModel,
     span: Span,
 ) -> Result<TypeRef, TypecheckError> {
-    let ty = binder_type(binder, env, model)?;
+    let ty = binder_type(binder, env, model).map_err(|error| error.with_span(span))?;
     let (name, where_expr) = match binder {
         Binder::Typed {
             name, where_expr, ..
@@ -1086,25 +1094,14 @@ fn validate_statement_assignments(
                 })
         }
         Statement::ForAll {
-            binder, statements, ..
+            binder,
+            statements,
+            span,
         } => {
-            let (name, ty) = match binder {
-                Binder::Typed {
-                    name, type_name, ..
-                } => (name, TypeRef::Named(qualified_name(type_name)?)),
-                Binder::Range { name, .. } => (name, TypeRef::Int),
-                Binder::Collection {
-                    name, collection, ..
-                } => {
-                    let collection_ty = resolve(model, &infer_type(collection, env, model, None)?)?;
-                    let (TypeRef::Set(item) | TypeRef::Seq(item, _)) = collection_ty else {
-                        return Err(error("collection binder requires Set or Seq"));
-                    };
-                    (name, *item)
-                }
-            };
+            let name = binder_name(binder);
+            let ty = validate_binder(binder, env, model, *span)?;
             let mut local = env.clone();
-            local.insert(name.clone(), ty);
+            local.insert(name.to_owned(), ty);
             let mut local_visible_consts = visible_consts.clone();
             local_visible_consts.remove(name);
             statements.iter().try_for_each(|item| {

--- a/rust/fsl-core/src/typecheck.rs
+++ b/rust/fsl-core/src/typecheck.rs
@@ -1072,13 +1072,19 @@ fn validate_statement_assignments(
             validate_expression(value, env, model, *span, Some(&ty))
         }
         Statement::If {
+            condition,
             then_statements,
             else_statements,
-            ..
-        } => then_statements
-            .iter()
-            .chain(else_statements)
-            .try_for_each(|item| validate_statement_assignments(item, env, model, visible_consts)),
+            span,
+        } => {
+            validate_expression(condition, env, model, *span, Some(&TypeRef::Bool))?;
+            then_statements
+                .iter()
+                .chain(else_statements)
+                .try_for_each(|item| {
+                    validate_statement_assignments(item, env, model, visible_consts)
+                })
+        }
         Statement::ForAll {
             binder, statements, ..
         } => {

--- a/rust/fsl-core/tests/compose_alias_forall.rs
+++ b/rust/fsl-core/tests/compose_alias_forall.rs
@@ -86,6 +86,39 @@ fn declared_alias_with_unknown_forall_type_returns_located_core_error() {
     assert_eq!(error.message, "unknown type 'core.NoSuchType'");
     assert_eq!(error.line, 5);
     assert_eq!(error.column, 5);
+    assert!(
+        error
+            .origin
+            .as_deref()
+            .is_some_and(|origin| origin.id.0.starts_with("compose:error:"))
+    );
+}
+
+/// Rejecting detector for the expression-binder path: a qualified type in an
+/// invariant must retain the authored property's location while resolving the
+/// alias member.
+#[test]
+fn declared_alias_with_unknown_invariant_binder_returns_located_core_error() {
+    let source = r#"compose Broken {
+  use Core as core from "core.fsl"
+  state { x: Int }
+    invariant Bad { forall u: core.NoSuchType { true } }
+}"#;
+
+    let error = parse_kernel_source(source, &resolver())
+        .expect_err("an unknown invariant binder member must fail during lowering");
+
+    assert_eq!(error.message, "unknown type 'core.NoSuchType'");
+    assert_eq!(error.line, 4);
+    assert_eq!(error.column, 5);
+    let origin = error.origin.expect("authored compose error origin");
+    assert_eq!(
+        origin
+            .primary
+            .and_then(|site| site.span)
+            .map(|span| (span.start.line, span.start.column)),
+        Some((4, 5))
+    );
 }
 
 /// Accepting control: a correctly declared alias used the same way (in a

--- a/rust/fsl-core/tests/compose_alias_forall.rs
+++ b/rust/fsl-core/tests/compose_alias_forall.rs
@@ -59,12 +59,33 @@ fn undeclared_alias_in_forall_binder_returns_core_error_not_panic() {
         .expect_err("an undeclared alias must fail, not panic");
 
     assert_eq!(error.message, "unknown alias 'nonexistent'");
-    // This location is a placeholder, not a real source position: the
-    // qualified-name resolver (`resolve_alias_qualified_name`) has no span
-    // to draw from, so it always reports (1, 1) regardless of where the
-    // binder actually appears.
+    // The statement span now gives the qualified-name resolver the real
+    // source position instead of the former (1, 1) placeholder.
     assert_eq!(error.line, 1);
-    assert_eq!(error.column, 1);
+    assert_eq!(error.column, 42);
+}
+
+/// Rejecting detector for issue #832 shape A: a declared alias does not make
+/// an absent member a valid binder type. The diagnostic keeps author spelling
+/// and the `forall` statement's real location.
+#[test]
+fn declared_alias_with_unknown_forall_type_returns_located_core_error() {
+    let source = r#"compose Broken {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    forall u: core.NoSuchType {
+      x = 0
+    }
+  }
+}"#;
+
+    let error = parse_kernel_source(source, &resolver())
+        .expect_err("an unknown member of a declared alias must fail during lowering");
+
+    assert_eq!(error.message, "unknown type 'core.NoSuchType'");
+    assert_eq!(error.line, 5);
+    assert_eq!(error.column, 5);
 }
 
 /// Accepting control: a correctly declared alias used the same way (in a

--- a/rust/fsl-core/tests/compose_init_condition_types.rs
+++ b/rust/fsl-core/tests/compose_init_condition_types.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Issue #832 shape B: checked-model construction must type every `init if`
+//! condition, not only assignments nested below it.
+
+use std::collections::BTreeMap;
+
+use fsl_core::{CoreError, FileResolver, build_model, parse_kernel_source};
+
+struct MemoryResolver(BTreeMap<String, String>);
+
+impl FileResolver for MemoryResolver {
+    fn read(&self, path: &str) -> Result<String, CoreError> {
+        self.0.get(path).cloned().ok_or_else(|| CoreError {
+            message: format!("missing {path}"),
+            line: 1,
+            column: 1,
+            origin: None,
+            name_resolution: false,
+        })
+    }
+}
+
+const CORE_COMPONENT: &str = "spec Core { \
+    type RealType = 0..1 \
+    state { flag: Bool } \
+    init { flag = true } \
+    action noop() {} \
+}";
+
+fn resolver() -> MemoryResolver {
+    MemoryResolver(BTreeMap::from([(
+        "core.fsl".to_owned(),
+        CORE_COMPONENT.to_owned(),
+    )]))
+}
+
+/// Rejecting detector: the undeclared root of a field-shaped condition is
+/// rejected at the `if`, matching assignment-RHS type checking.
+#[test]
+fn undeclared_alias_shaped_init_condition_is_rejected() {
+    let source = r#"compose Broken {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    if nonexistent.flag {
+      x = 0
+    }
+  }
+}"#;
+    let kernel = parse_kernel_source(source, &resolver()).expect("compose lowers");
+    let error = build_model(kernel).expect_err("the unknown condition root must fail check");
+
+    assert_eq!(
+        error.message,
+        "invalid init statement: public Kernel cannot type identifier 'nonexistent'"
+    );
+    let span = error
+        .origin
+        .as_deref()
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.span)
+        .expect("the condition error is located");
+    assert_eq!(span.start.line, 5);
+    assert_eq!(span.start.column, 5);
+}
+
+/// Accepting control: a declared component alias and real Bool member remain
+/// valid in the same `init if` condition position.
+#[test]
+fn declared_alias_init_condition_still_builds() {
+    let source = r#"compose Works {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    if core.flag {
+      x = 0
+    }
+  }
+}"#;
+    let kernel = parse_kernel_source(source, &resolver()).expect("compose lowers");
+    build_model(kernel).expect("a declared alias Bool condition must remain valid");
+}

--- a/rust/fsl-core/tests/typed_binder_resolution.rs
+++ b/rust/fsl-core/tests/typed_binder_resolution.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use fsl_core::{FsResolver, ModelError, build_model, parse_kernel_source};
+
+struct BinderPathCase {
+    owner: &'static str,
+    form: &'static str,
+    source: &'static str,
+    line: u32,
+    column: u32,
+}
+
+const BINDER_PATH_CASES: [BinderPathCase; 13] = [
+    BinderPathCase {
+        owner: "invariant",
+        form: "forall expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  invariant P { forall x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "invariant",
+        form: "exists expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  invariant P { exists x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "invariant",
+        form: "aggregate expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  invariant P { count(x: Missing) == 0 }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "ensures",
+        form: "forall expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  action stay() { flag = flag ensures forall x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "ensures",
+        form: "exists expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  action stay() { flag = flag ensures exists x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "ensures",
+        form: "aggregate expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  action stay() { flag = flag ensures count(x: Missing) == 0 }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "reachable",
+        form: "forall expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  reachable P { forall x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "reachable",
+        form: "exists expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  reachable P { exists x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "reachable",
+        form: "aggregate expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  reachable P { count(x: Missing) == 0 }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "init",
+        form: "forall statement",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { forall x: Missing { flag = false } }\n}",
+        line: 3,
+        column: 10,
+    },
+    BinderPathCase {
+        owner: "init",
+        form: "forall expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = forall x: Missing { true } }\n}",
+        line: 3,
+        column: 10,
+    },
+    BinderPathCase {
+        owner: "init",
+        form: "exists expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { if exists x: Missing { true } { flag = false } }\n}",
+        line: 3,
+        column: 10,
+    },
+    BinderPathCase {
+        owner: "init",
+        form: "aggregate expression",
+        source: "spec Bad {\n  state { total: Int }\n  init { total = count(x: Missing) }\n}",
+        line: 3,
+        column: 10,
+    },
+];
+
+fn rejected_model(case: &BinderPathCase) -> ModelError {
+    let kernel = parse_kernel_source(case.source, &FsResolver::new("."))
+        .unwrap_or_else(|error| panic!("{} / {} did not lower: {error}", case.owner, case.form));
+    match build_model(kernel) {
+        Err(error) => error,
+        Ok(model) => panic!(
+            "{} / {} unexpectedly built: {}",
+            case.owner, case.form, model.name
+        ),
+    }
+}
+
+/// Mechanical inventory of every authored owner called out by issue #832.
+///
+/// Quantified and aggregate expressions recurse through the same
+/// `validate_expression` arms regardless of owner. Init additionally has a
+/// statement-form `forall`, so it gets one row for that distinct AST path and
+/// separate expression rows for `forall`, `exists`, and aggregates.
+#[test]
+fn unknown_typed_binders_are_rejected_in_every_authored_owner_and_ast_form() {
+    for case in &BINDER_PATH_CASES {
+        let error = rejected_model(case);
+        assert_eq!(
+            error.message,
+            if case.owner == "init" {
+                "invalid init statement: unknown type 'Missing'"
+            } else {
+                "invalid model expression: unknown type 'Missing'"
+            },
+            "{} / {}",
+            case.owner,
+            case.form
+        );
+        let span = error
+            .origin
+            .as_deref()
+            .and_then(|origin| origin.primary.as_ref())
+            .and_then(|site| site.span)
+            .or(error.span)
+            .unwrap_or_else(|| panic!("{} / {} lost its location", case.owner, case.form));
+        assert_eq!(
+            (span.start.line, span.start.column),
+            (case.line, case.column),
+            "{} / {}",
+            case.owner,
+            case.form
+        );
+    }
+}
+
+#[test]
+fn real_typed_binder_remains_accepted() {
+    let source = "spec Good {\n  type Item = 0..1\n  state { flag: Bool }\n  init { flag = false }\n  invariant P { forall x: Item { true } }\n}";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("lower valid binder");
+    build_model(kernel).expect("build valid binder");
+}
+
+/// Every spec-like dialect that can carry the shared expression AST either
+/// reaches the checked-model binder gate or rejects the name earlier while
+/// resolving its own typed domain vocabulary.
+#[test]
+fn all_binder_capable_dialects_reject_unknown_typed_names() {
+    let checked_model_cases = [
+        (
+            "spec",
+            "spec Bad { state { flag: Bool } init { flag = false } invariant P { forall x: Missing { true } } }",
+        ),
+        (
+            "requirements",
+            "requirements Bad { process Claim { stages Draft, Done initial Draft transition finish Draft -> Done by System } invariant P { forall x: Missing { true } } } verify { instances Claim = 1 }",
+        ),
+        (
+            "business",
+            "business Bad { actor System entity Claim process Claim { stages Draft, Done initial Draft transition finish Draft -> Done by System } goal G \"bad\" { forall x: Missing { true } } } verify { instances Claim = 1 }",
+        ),
+        (
+            "compose",
+            "compose Bad { state { flag: Bool } init { flag = false } invariant P { forall x: Missing { true } } }",
+        ),
+    ];
+
+    for (dialect, source) in checked_model_cases {
+        let kernel = parse_kernel_source(source, &FsResolver::new("."))
+            .unwrap_or_else(|error| panic!("{dialect} did not lower: {error}"));
+        let Err(error) = build_model(kernel) else {
+            panic!("{dialect} accepted unknown binder type");
+        };
+        assert!(
+            error.message.contains("unknown type 'Missing'"),
+            "{dialect}: {error}"
+        );
+    }
+
+    let domain = "domain Bad { type Status = Draft | Done aggregate Claim { state { status: Status = Draft; } command Finish {} event Finished {} decide Finish { emits Finished } evolve Finished { status = Done } invariant bad { forall x: Missing { true } } } }";
+    let error = parse_kernel_source(domain, &FsResolver::new("."))
+        .expect_err("domain type resolution must reject an unknown binder type");
+    assert!(error.message.contains("Missing"), "domain: {error}");
+}

--- a/rust/fslc/src/source_diagnostic.rs
+++ b/rust/fslc/src/source_diagnostic.rs
@@ -85,24 +85,23 @@ pub fn diagnostics_with_model(
 }
 
 fn core_diagnostic(source: &str, error: &fsl_core::CoreError) -> SourceDiagnostic {
-    let message = error.to_string();
+    let diagnostic = crate::spec_load::SemanticDiagnostic::from_core_error(error);
     SourceDiagnostic {
-        kind: crate::verification_output::diagnostic_kind(&message, error.name_resolution),
+        kind: crate::verification_output::diagnostic_kind(
+            &diagnostic.message,
+            diagnostic.name_resolution,
+        ),
         code: "FSL-SEMANTIC".to_owned(),
-        message,
+        message: diagnostic.message,
         span: error
             .origin
             .as_deref()
             .and_then(|origin| origin.primary.as_ref())
             .and_then(|site| site.span)
             .unwrap_or_else(|| point_span(source, error.line, error.column)),
-        // `CoreError` carries `line: 0` as its "unknown" sentinel.
-        located: error.line != 0
-            || error
-                .origin
-                .as_deref()
-                .and_then(|origin| origin.primary.as_ref())
-                .is_some_and(|site| site.span.is_some()),
+        // `line`/`column` also carry legacy placeholders such as `(1, 1)`.
+        // Only an authored origin proves that the public location is real.
+        located: diagnostic.loc.is_some(),
     }
 }
 

--- a/rust/fslc/src/spec_load.rs
+++ b/rust/fslc/src/spec_load.rs
@@ -82,7 +82,14 @@ impl SemanticDiagnostic {
     pub fn from_core_error(error: &fsl_core::CoreError) -> Self {
         Self {
             message: error.to_string(),
-            loc: crate::verification_output::origin_loc(error.origin.as_deref()),
+            loc: crate::verification_output::origin_loc(error.origin.as_deref()).or_else(|| {
+                (error.line != 0).then(|| {
+                    json!({
+                        "line": error.line,
+                        "column": error.column,
+                    })
+                })
+            }),
             name_resolution: error.name_resolution,
         }
     }

--- a/rust/fslc/src/spec_load.rs
+++ b/rust/fslc/src/spec_load.rs
@@ -80,16 +80,21 @@ impl SemanticDiagnostic {
     /// frontend's name-resolution classification.
     #[must_use]
     pub fn from_core_error(error: &fsl_core::CoreError) -> Self {
+        // Compose's authored lowering diagnostics historically render without
+        // a file prefix. Their new origin exists to prove the span is real,
+        // not to change that public message contract. Component-load origins
+        // have a non-empty declaration path and keep their file-qualified
+        // rendering.
+        let authored_compose_error = error.origin.as_deref().is_some_and(|origin| {
+            origin.dialect == "compose" && origin.id.0.starts_with("compose:error:")
+        });
         Self {
-            message: error.to_string(),
-            loc: crate::verification_output::origin_loc(error.origin.as_deref()).or_else(|| {
-                (error.line != 0).then(|| {
-                    json!({
-                        "line": error.line,
-                        "column": error.column,
-                    })
-                })
-            }),
+            message: if authored_compose_error {
+                format!("{} at {}:{}", error.message, error.line, error.column)
+            } else {
+                error.to_string()
+            },
+            loc: crate::verification_output::origin_loc(error.origin.as_deref()),
             name_resolution: error.name_resolution,
         }
     }

--- a/rust/fslc/tests/fixtures/issue_832/accept_alias_condition.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/accept_alias_condition.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose AcceptAliasCondition {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    if core.flag {
+      x = 0
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_832/accept_real_type.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/accept_real_type.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose AcceptRealType {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    forall u: core.RealType {
+      x = 0
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_832/core.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/core.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec Core {
+  type RealType = 0..1
+  state { flag: Bool }
+  init { flag = true }
+  action noop() {}
+}

--- a/rust/fslc/tests/fixtures/issue_832/expr_binder.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/expr_binder.fsl
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+compose Broken {
+  use Core as core from "core.fsl"
+    invariant Bad { forall u: core.NoSuchType { true } }
+}

--- a/rust/fslc/tests/fixtures/issue_832/requirements_missing_binder.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/requirements_missing_binder.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+requirements ProcessBinderLocation {
+  process Claim {
+    stages Draft, Done
+    initial Draft
+    transition finish Draft -> Done by System
+  }
+  invariant Bad { forall c: Missing { true } }
+}
+verify { instances Claim = 1 }

--- a/rust/fslc/tests/fixtures/issue_832/requirements_real_binder.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/requirements_real_binder.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+requirements ProcessBinderLocation {
+  process Claim {
+    stages Draft, Done
+    initial Draft
+    transition finish Draft -> Done by System
+  }
+  invariant Good { forall c: Claim { true } }
+}
+verify { instances Claim = 1 }

--- a/rust/fslc/tests/fixtures/issue_832/rhs_control.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/rhs_control.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose RhsControl {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    x = nonexistent.value
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_832/shape_a.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/shape_a.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose ShapeA {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    forall u: core.NoSuchType {
+      x = 0
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_832/shape_b.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/shape_b.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose ShapeB {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    if nonexistent.flag {
+      x = 0
+    }
+  }
+}

--- a/rust/fslc/tests/issue_681_precedence_policy.rs
+++ b/rust/fslc/tests/issue_681_precedence_policy.rs
@@ -318,7 +318,7 @@ verify { instances Item = 1 }
 
 #[test]
 fn unknown_and_ambiguous_references_fail_with_policy_identity_and_location() {
-    for (name, process, policy, expected) in [
+    for (name, process, policy, expected, expected_line) in [
         (
             "unknown-stage",
             r"process Return {
@@ -327,7 +327,8 @@ fn unknown_and_ambiguous_references_fail_with_policy_identity_and_location() {
     transition refund Requested -> Refunded by Manager
   }",
             "every Return reaching Refunded must have passed through Missing",
-            "stage 'Missing' is not declared",
+            "stage 'Missing' is not declared for process 'Return'",
+            9,
         ),
         (
             "unknown-entity",
@@ -338,6 +339,7 @@ fn unknown_and_ambiguous_references_fail_with_policy_identity_and_location() {
   }",
             "every Invoice reaching Refunded must have passed through Requested",
             "entity 'Invoice' has no process",
+            9,
         ),
         (
             "ambiguous-entity",
@@ -352,7 +354,8 @@ fn unknown_and_ambiguous_references_fail_with_policy_identity_and_location() {
     transition legacyRefund Requested -> Refunded by Manager
   }",
             "every Return reaching Refunded must have passed through Requested",
-            "multiple processes; precedence policy is ambiguous",
+            "entity 'Return' has multiple processes; precedence policy is ambiguous",
+            14,
         ),
     ] {
         let source = format!(
@@ -371,9 +374,19 @@ verify {{ instances Return = 1 }}
         assert_eq!(status, 2, "{output:#}");
         assert_eq!(output["kind"], "semantics", "{output:#}");
         let message = output["message"].as_str().expect("diagnostic message");
-        assert!(message.contains("policy 'CTRL-BAD'"), "{output:#}");
-        assert!(message.contains(expected), "{output:#}");
-        assert!(output["loc"]["line"].as_u64().is_some(), "{output:#}");
-        assert!(output["loc"]["column"].as_u64().is_some(), "{output:#}");
+        assert_eq!(
+            message,
+            format!("policy 'CTRL-BAD': {expected} at {expected_line}:3"),
+            "{output:#}"
+        );
+        let policy_line = source
+            .lines()
+            .nth(expected_line - 1)
+            .expect("diagnostic line exists in authored source");
+        assert_eq!(policy_line.find("policy").map(|offset| offset + 1), Some(3));
+        assert!(
+            output.get("loc").is_none(),
+            "unproven CoreError coordinates must not become public loc: {output:#}"
+        );
     }
 }

--- a/rust/fslc/tests/issue_832_compose_check.rs
+++ b/rust/fslc/tests/issue_832_compose_check.rs
@@ -30,6 +30,30 @@ fn fixture(name: &str) -> String {
     format!("{FIXTURES}/{name}.fsl")
 }
 
+#[test]
+fn compose_core_error_origin_preserves_the_existing_message_shape() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root");
+    let path = root.join(fixture("shape_a"));
+    let source = std::fs::read_to_string(&path).expect("shape A source");
+    let resolver = fsl_core::FsResolver::new(path.parent().expect("fixture directory"));
+    let error = fsl_core::parse_kernel_source_with_file(
+        &source,
+        &resolver,
+        path.strip_prefix(root)
+            .expect("relative fixture path")
+            .display()
+            .to_string(),
+    )
+    .expect_err("shape A must fail");
+    let diagnostic = fslc_rust::spec_load::SemanticDiagnostic::from_core_error(&error);
+
+    assert_eq!(diagnostic.message, "unknown type 'core.NoSuchType' at 7:5");
+    assert_eq!(diagnostic.loc, Some(json!({"line": 7, "column": 5})));
+}
+
 fn assert_rejected_by_check_and_verify(name: &str, kind: &str, message: &str, loc: &Value) {
     let path = fixture(name);
     for args in [
@@ -54,6 +78,18 @@ fn check_rejects_unknown_member_of_declared_alias() {
         "type",
         "unknown type 'core.NoSuchType' at 7:5",
         &json!({"line": 7, "column": 5}),
+    );
+}
+
+/// Rejecting detector for the expression-binder path: an invariant's typed
+/// `forall` reports its authored location instead of the `(1, 1)` placeholder.
+#[test]
+fn check_rejects_unknown_member_in_invariant_binder_at_authored_location() {
+    assert_rejected_by_check_and_verify(
+        "expr_binder",
+        "type",
+        "unknown type 'core.NoSuchType' at 4:5",
+        &json!({"line": 4, "column": 5}),
     );
 }
 
@@ -90,4 +126,27 @@ fn assignment_rhs_rejection_is_preserved() {
         "invalid init statement: public Kernel cannot type identifier 'nonexistent' at 7:5",
         &json!({"line": 7, "column": 5}),
     );
+}
+
+/// Negative location control: CLI scope overrides own no source construct, so
+/// their placeholder `(1, 1)` must never be promoted into a public `loc`.
+#[test]
+fn sweep_scope_error_does_not_fabricate_source_location() {
+    let (value, status) = run_cli(&[
+        "sweep",
+        "examples/e2e/3_design.fsl",
+        "--instances",
+        "Typo=1..1",
+        "--depth",
+        "1..1",
+    ]);
+
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error", "{value}");
+    assert_eq!(value["kind"], "semantics", "{value}");
+    assert_eq!(
+        value["message"], "verify instances references undeclared entity 'Typo' at 1:1",
+        "{value}"
+    );
+    assert!(value.get("loc").is_none(), "fabricated loc: {value}");
 }

--- a/rust/fslc/tests/issue_832_compose_check.rs
+++ b/rust/fslc/tests/issue_832_compose_check.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use std::process::Command;
+
+use serde_json::{Value, json};
+
+const FIXTURES: &str = "rust/fslc/tests/fixtures/issue_832";
+
+fn run_cli(args: &[&str]) -> (Value, i32) {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root");
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn fixture(name: &str) -> String {
+    format!("{FIXTURES}/{name}.fsl")
+}
+
+fn assert_rejected_by_check_and_verify(name: &str, kind: &str, message: &str, loc: &Value) {
+    let path = fixture(name);
+    for args in [
+        vec!["check", path.as_str()],
+        vec!["verify", path.as_str(), "--depth", "1", "--no-cache"],
+    ] {
+        let command = args[0];
+        let (value, status) = run_cli(&args);
+        assert_eq!(status, 2, "{command}: {value}");
+        assert_eq!(value["result"], "error", "{command}: {value}");
+        assert_eq!(value["kind"], kind, "{command}: {value}");
+        assert_eq!(value["message"], message, "{command}: {value}");
+        assert_eq!(&value["loc"], loc, "{command}: {value}");
+    }
+}
+
+/// Rejecting detector A: a declared alias must not authorize an absent type.
+#[test]
+fn check_rejects_unknown_member_of_declared_alias() {
+    assert_rejected_by_check_and_verify(
+        "shape_a",
+        "type",
+        "unknown type 'core.NoSuchType' at 7:5",
+        &json!({"line": 7, "column": 5}),
+    );
+}
+
+/// Rejecting detector B: `init if` conditions receive the same name/type gate
+/// as assignment right-hand sides.
+#[test]
+fn check_rejects_undeclared_alias_shaped_init_condition() {
+    assert_rejected_by_check_and_verify(
+        "shape_b",
+        "semantics",
+        "invalid init statement: public Kernel cannot type identifier 'nonexistent' at 7:5",
+        &json!({"line": 7, "column": 5}),
+    );
+}
+
+/// Accepting controls for both corrected positions.
+#[test]
+fn check_accepts_real_alias_type_and_declared_alias_condition() {
+    for name in ["accept_real_type", "accept_alias_condition"] {
+        let path = fixture(name);
+        let (value, status) = run_cli(&["check", &path]);
+        assert_eq!(status, 0, "{name}: {value}");
+        assert_eq!(value["result"], "ok", "{name}: {value}");
+    }
+}
+
+/// Preservation control: the pre-existing assignment-RHS rejection remains
+/// active; this is not a detector for either new fix.
+#[test]
+fn assignment_rhs_rejection_is_preserved() {
+    assert_rejected_by_check_and_verify(
+        "rhs_control",
+        "semantics",
+        "invalid init statement: public Kernel cannot type identifier 'nonexistent' at 7:5",
+        &json!({"line": 7, "column": 5}),
+    );
+}

--- a/rust/fslc/tests/issue_832_compose_check.rs
+++ b/rust/fslc/tests/issue_832_compose_check.rs
@@ -93,6 +93,20 @@ fn check_rejects_unknown_member_in_invariant_binder_at_authored_location() {
     );
 }
 
+/// Rejecting detector for the shared typed-binder gate: requirements process
+/// lowering must not let an unknown invariant binder pass `check` and fail only
+/// when `verify` tries to enumerate its finite domain. The binder is authored
+/// on line 8, where the invariant declaration owns the property diagnostic.
+#[test]
+fn check_rejects_unknown_requirements_binder_at_authored_property_location() {
+    assert_rejected_by_check_and_verify(
+        "requirements_missing_binder",
+        "semantics",
+        "invalid model expression: unknown type 'Missing' at 8:3",
+        &json!({"line": 8, "column": 3}),
+    );
+}
+
 /// Rejecting detector B: `init if` conditions receive the same name/type gate
 /// as assignment right-hand sides.
 #[test]
@@ -114,6 +128,16 @@ fn check_accepts_real_alias_type_and_declared_alias_condition() {
         assert_eq!(status, 0, "{name}: {value}");
         assert_eq!(value["result"], "ok", "{name}: {value}");
     }
+}
+
+/// Accepting control for the shared gate: a process entity is a real lowered
+/// type and remains valid as an invariant binder.
+#[test]
+fn check_accepts_real_requirements_process_binder() {
+    let path = fixture("requirements_real_binder");
+    let (value, status) = run_cli(&["check", &path]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "ok", "{value}");
 }
 
 /// Preservation control: the pre-existing assignment-RHS rejection remains


### PR DESCRIPTION
## Problem

`fslc check` blessed documents that `fslc verify` then rejected with semantics errors (#832) — a fail-open in the fast loop authors and AI agents run first:

- **Shape A**: a declared `use` alias with a nonexistent member (`forall u: core.NoSuchType`) — `resolve_alias_qualified_name` checked only the alias, and the late verifier error named the mangled `core__NoSuchType`.
- **Shape B**: an undeclared alias inside an `init` `if` condition — the same identifier in an assignment RHS was already rejected, so this was a typing gap, not a designed split.
- **Review-found sibling (High)**: kernel typecheck never resolved a typed binder's `TypeRef::Named` against the type table, so `forall c: Missing` inside any dialect's invariant/ensures/reachable passed `check` and failed `verify`.

## Change (fail-closed; four commits)

1. `fac6e19`: compose lowering rejects unknown qualified types with the **author's spelling** and location.
2. `f8932aa`: `init` `if` conditions are typed at check time like assignment RHS.
3. `6e1bf7a` (review round 1): real spans carried through expression binders, and `SemanticDiagnostic::from_core_error` no longer fabricates `loc: 1:1` for location-less CoreErrors (origin-based promotion; sweep `--instances` regression control pins `loc` absent).
4. `367b998` (review round 2): typed binder names resolved at check time across **all enumerated binder paths and dialects**, with authored-location diagnostics.

## Evidence

- Independent review (separate codex session), **three rounds to zero findings**: R1 found the fabricated-loc High and expression-span Medium; R2 closed both and found the typed-binder High via novel cross-dialect probes; R3 verified the sweep-table against code, probed 4 more paths (business/domain/requirements/spec leadsTo), and approved. Full review attached.
- Before/after: Shapes A/B check exit 0→2 (verify unchanged at 2), authored spelling + real loc (e.g. 7:5, 8:3); assignment-RHS preservation control kept; accepting controls for real members and declared aliases; corpus_check_sweep ×2 green (no over-rejection); per-shape detector reverts exit 101 with restores proven by empty diff; fmt / scoped clippy ×2 exit 0.

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)