### PR TITLE
fix(runtime): collide unresolved init writes with concrete keys

### DIFF
--- a/changelog.d/826-init-root-collision.fixed.md
+++ b/changelog.d/826-init-root-collision.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#826): unresolved indexed `init` writes now conservatively collide with every concrete key on the same logical map root instead of silently accepting aliasing writes with equal values.

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -12,7 +12,8 @@ use fsl_core::{
 
 use super::trace::{ParentLink, reconstruct_trace, state_changes};
 use super::{
-    Bindings, Monitor, RuntimeError, State, Violation, eval, runtime_error, with_total_division,
+    Bindings, Monitor, RuntimeError, State, Violation, eval, runtime_error, runtime_error_at,
+    with_total_division,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -76,14 +77,18 @@ pub fn verify_explicit(
 /// the symbolic engine).
 #[must_use]
 pub fn explicit_unsupported_reason(model: &KernelModel) -> Option<String> {
+    explicit_unsupported_error(model).map(|error| error.message)
+}
+
+fn explicit_unsupported_error(model: &KernelModel) -> Option<RuntimeError> {
     if let Err(error) = check_deterministic_init(model) {
-        return Some(error.message);
+        return Some(error);
     }
     if !model.leadstos.is_empty() {
-        return Some(
+        return Some(runtime_error(
             "the explicit engine does not support leadsTo properties; use --engine bmc or exclude the leadsTo property"
                 .to_owned(),
-        );
+        ));
     }
     None
 }
@@ -115,8 +120,8 @@ pub fn verify_explicit_selected(
     if max_states == 0 {
         return Err(runtime_error("explicit state budget must be at least 1"));
     }
-    if let Some(reason) = explicit_unsupported_reason(&model) {
-        return Err(runtime_error(reason));
+    if let Some(error) = explicit_unsupported_error(&model) {
+        return Err(error);
     }
 
     // The frontier carries `State` only, not `Monitor` -- a full `Monitor`
@@ -694,7 +699,7 @@ fn walk_init_write_ownership(
 ) -> Result<BTreeSet<InitWriteKey>, RuntimeError> {
     for statement in statements {
         match statement {
-            Statement::Assign { target, .. } => {
+            Statement::Assign { target, span, .. } => {
                 let logical = logical_var(target)
                     .ok_or_else(|| runtime_error("invalid init assignment target"))?;
                 let contribution = assignment_coverage(target, bound_names, model);
@@ -705,9 +710,10 @@ fn walk_init_write_ownership(
                         .any(|previous| init_write_keys_overlap(previous, key))
                 }) {
                     let scope = if in_forall { "init forall" } else { "init" };
-                    return Err(runtime_error(format!(
-                        "state variable '{logical}' assigned more than once in {scope}"
-                    )));
+                    return Err(runtime_error_at(
+                        format!("state variable '{logical}' assigned more than once in {scope}"),
+                        *span,
+                    ));
                 }
                 possibly_assigned.extend(keys);
             }
@@ -762,7 +768,12 @@ fn walk_init(
 ) -> Result<(BTreeMap<String, Coverage>, BTreeSet<InitWriteKey>), RuntimeError> {
     for statement in statements {
         match statement {
-            Statement::Assign { target, value, .. } => {
+            Statement::Assign {
+                target,
+                value,
+                span,
+                ..
+            } => {
                 let logical = logical_var(target)
                     .ok_or_else(|| runtime_error("invalid init assignment target"))?;
                 let contribution = assignment_coverage(target, bound_names, model);
@@ -773,9 +784,10 @@ fn walk_init(
                         .any(|previous| init_write_keys_overlap(previous, key))
                 }) {
                     let scope = if in_forall { "init forall" } else { "init" };
-                    return Err(runtime_error(format!(
-                        "state variable '{logical}' assigned more than once in {scope}"
-                    )));
+                    return Err(runtime_error_at(
+                        format!("state variable '{logical}' assigned more than once in {scope}"),
+                        *span,
+                    ));
                 }
                 if let LValue::Index(_, key_expr) = target {
                     check_init_expr(key_expr, &definitely_assigned, model)?;

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -673,6 +673,84 @@ fn assignment_coverage(
     }
 }
 
+/// Enforce init's assign-once ownership rule without requiring a concrete
+/// initial state. Symbolic verification may admit partially assigned init,
+/// but it must reject two writes that can own the same state location.
+///
+/// # Errors
+///
+/// Returns [`RuntimeError`] when two writes may overlap on one logical root.
+pub fn check_init_write_ownership(model: &KernelModel) -> Result<(), RuntimeError> {
+    walk_init_write_ownership(&model.init, BTreeSet::new(), false, &BTreeMap::new(), model)?;
+    Ok(())
+}
+
+fn walk_init_write_ownership(
+    statements: &[Statement],
+    mut possibly_assigned: BTreeSet<InitWriteKey>,
+    in_forall: bool,
+    bound_names: &BTreeMap<String, Option<Vec<Value>>>,
+    model: &KernelModel,
+) -> Result<BTreeSet<InitWriteKey>, RuntimeError> {
+    for statement in statements {
+        match statement {
+            Statement::Assign { target, .. } => {
+                let logical = logical_var(target)
+                    .ok_or_else(|| runtime_error("invalid init assignment target"))?;
+                let contribution = assignment_coverage(target, bound_names, model);
+                let keys = init_write_keys(target, contribution.as_ref());
+                if keys.iter().any(|key| {
+                    possibly_assigned
+                        .iter()
+                        .any(|previous| init_write_keys_overlap(previous, key))
+                }) {
+                    let scope = if in_forall { "init forall" } else { "init" };
+                    return Err(runtime_error(format!(
+                        "state variable '{logical}' assigned more than once in {scope}"
+                    )));
+                }
+                possibly_assigned.extend(keys);
+            }
+            Statement::ForAll {
+                binder, statements, ..
+            } => {
+                let binder_values = compute_binder_values(binder, model)?;
+                let mut nested_bound = bound_names.clone();
+                nested_bound.insert(binder_name(binder).to_owned(), binder_values);
+                possibly_assigned = walk_init_write_ownership(
+                    statements,
+                    possibly_assigned,
+                    true,
+                    &nested_bound,
+                    model,
+                )?;
+            }
+            Statement::If {
+                then_statements,
+                else_statements,
+                ..
+            } => {
+                let then_possible = walk_init_write_ownership(
+                    then_statements,
+                    possibly_assigned.clone(),
+                    in_forall,
+                    bound_names,
+                    model,
+                )?;
+                let else_possible = walk_init_write_ownership(
+                    else_statements,
+                    possibly_assigned,
+                    in_forall,
+                    bound_names,
+                    model,
+                )?;
+                possibly_assigned = then_possible.union(&else_possible).cloned().collect();
+            }
+        }
+    }
+    Ok(possibly_assigned)
+}
+
 #[allow(clippy::too_many_lines)]
 fn walk_init(
     statements: &[Statement],
@@ -689,7 +767,11 @@ fn walk_init(
                     .ok_or_else(|| runtime_error("invalid init assignment target"))?;
                 let contribution = assignment_coverage(target, bound_names, model);
                 let keys = init_write_keys(target, contribution.as_ref());
-                if keys.iter().any(|key| possibly_assigned.contains(key)) {
+                if keys.iter().any(|key| {
+                    possibly_assigned
+                        .iter()
+                        .any(|previous| init_write_keys_overlap(previous, key))
+                }) {
                     let scope = if in_forall { "init forall" } else { "init" };
                     return Err(runtime_error(format!(
                         "state variable '{logical}' assigned more than once in {scope}"
@@ -956,18 +1038,9 @@ fn logical_var(target: &LValue) -> Option<&str> {
 /// Falls back to `InitWriteKey::Root` (whole-variable) whenever `coverage`
 /// is not `Coverage::Keys` for an `Index` target — including `Full`,
 /// `Fields`, and unresolved (`None`, e.g. a dynamic key or a nested lvalue).
-/// That fallback never *accepts* something the coarser, pre-#821
-/// `Root`-only classification would have rejected: every write this
-/// function buckets under `Root` was already bucketed there before. It is
-/// not, however, "as strict as touching the entire variable" in the
-/// collision sense: `Root(name)` never collides with
-/// `ConcreteIndex(name, _)`, so a `None`-coverage target is simply not
-/// collision-checked against any concrete key at all. A `forall`-bound
-/// index used through a non-`Var` key expression (e.g. `m[i - i]`) is one
-/// such target; two iterations of it aliasing each other, or it aliasing a
-/// separate `m[K] = ...`, can still go undetected here when the values
-/// agree. That gap is pre-existing (identical on `origin/main`) and is not
-/// fixed by this change.
+/// `init_write_keys_overlap` treats that root as touching every concrete key
+/// on the same logical variable, so unresolved indexed writes fail closed
+/// against both concrete writes and other unresolved writes (issue #826).
 fn init_write_keys(target: &LValue, coverage: Option<&Coverage>) -> BTreeSet<InitWriteKey> {
     if let (LValue::Index(name, _), Some(Coverage::Keys(keys))) = (target, coverage) {
         return keys
@@ -981,6 +1054,20 @@ fn init_write_keys(target: &LValue, coverage: Option<&Coverage>) -> BTreeSet<Ini
             .expect("kernel lvalue has a logical root")
             .to_owned(),
     )])
+}
+
+fn init_write_keys_overlap(left: &InitWriteKey, right: &InitWriteKey) -> bool {
+    match (left, right) {
+        (
+            InitWriteKey::Root(left),
+            InitWriteKey::Root(right) | InitWriteKey::ConcreteIndex(right, _),
+        )
+        | (InitWriteKey::ConcreteIndex(left, _), InitWriteKey::Root(right)) => left == right,
+        (
+            InitWriteKey::ConcreteIndex(left_root, left_key),
+            InitWriteKey::ConcreteIndex(right_root, right_key),
+        ) => left_root == right_root && left_key == right_key,
+    }
 }
 
 fn binder_name(binder: &Binder) -> &str {

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -20,8 +20,9 @@ mod explicit;
 mod trace;
 
 pub use explicit::{
-    ExplicitReachableWitness, ExplicitResult, ExplicitViolation, deterministic_initial_state,
-    explicit_unsupported_reason, verify_explicit, verify_explicit_selected,
+    ExplicitReachableWitness, ExplicitResult, ExplicitViolation, check_init_write_ownership,
+    deterministic_initial_state, explicit_unsupported_reason, verify_explicit,
+    verify_explicit_selected,
 };
 
 pub type State = BTreeMap<String, Value>;

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -10,7 +10,7 @@ use fsl_core::{
     ActionCorrespondenceTarget, ActionDef, ActionGuard, FslValue as Value,
     KernelAggregateKind as AggregateKind, KernelBinder as Binder, KernelExpr as Expr,
     KernelLValue as LValue, KernelModel, KernelStatement as Statement, ModelError, ParamDef,
-    Refinement, TraceAction, TraceChange, TraceStep, TypeDef, TypeRef, display_name,
+    Refinement, Span, TraceAction, TraceChange, TraceStep, TypeDef, TypeRef, display_name,
     insert_requirement_metadata, internal_origin_json, model_warnings, origin_display_name,
     state_summary, static_leadsto_bindings,
 };
@@ -61,6 +61,8 @@ fn with_total_division<T>(body: impl FnOnce() -> T) -> T {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RuntimeError {
     pub message: String,
+    /// Authored construct responsible for this runtime diagnostic, when one exists.
+    pub span: Option<Span>,
 }
 
 impl fmt::Display for RuntimeError {
@@ -75,6 +77,7 @@ impl From<ModelError> for RuntimeError {
     fn from(error: ModelError) -> Self {
         Self {
             message: error.message,
+            span: error.span,
         }
     }
 }
@@ -732,6 +735,14 @@ fn i64_len(value: usize) -> Result<i64, RuntimeError> {
 fn runtime_error(message: impl Into<String>) -> RuntimeError {
     RuntimeError {
         message: message.into(),
+        span: None,
+    }
+}
+
+fn runtime_error_at(message: impl Into<String>, span: Span) -> RuntimeError {
+    RuntimeError {
+        message: message.into(),
+        span: Some(span),
     }
 }
 

--- a/rust/fsl-runtime/tests/explicit_engine.rs
+++ b/rust/fsl-runtime/tests/explicit_engine.rs
@@ -461,6 +461,10 @@ fn unresolved_init_index_writes_collide_by_logical_root() {
         error.message,
         "state variable 'm' assigned more than once in init forall"
     );
+    assert!(
+        error.span.is_some(),
+        "collision must retain the second write span"
+    );
 
     let root_root = model(
         "spec RootRoot { type Idx = 0..2 state { m: Map<Idx, Bool> } \
@@ -472,6 +476,10 @@ fn unresolved_init_index_writes_collide_by_logical_root() {
     assert_eq!(
         error.message,
         "state variable 'm' assigned more than once in init forall"
+    );
+    assert!(
+        error.span.is_some(),
+        "collision must retain the second write span"
     );
 
     let lone_root = model(

--- a/rust/fsl-runtime/tests/explicit_engine.rs
+++ b/rust/fsl-runtime/tests/explicit_engine.rs
@@ -444,6 +444,44 @@ fn init_forall_write_collides_with_later_concrete_write_to_the_same_key() {
     assert!(result.violation.is_none());
 }
 
+/// Issue #826: an indexed init write whose key coverage cannot be resolved
+/// may touch every key of its logical map root. It therefore overlaps both
+/// concrete-key writes and another unresolved indexed write, while a lone
+/// unresolved write has no competing owner and remains admissible to BMC.
+#[test]
+fn unresolved_init_index_writes_collide_by_logical_root() {
+    let root_concrete = model(
+        "spec RootConcrete { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { forall i: Idx { m[i - i] = true } forall j: Idx { m[j] = true } } \
+         action noop() { } }",
+    );
+    let error = fsl_runtime::check_init_write_ownership(&root_concrete)
+        .expect_err("unresolved write must overlap every concrete key on the same root");
+    assert_eq!(
+        error.message,
+        "state variable 'm' assigned more than once in init forall"
+    );
+
+    let root_root = model(
+        "spec RootRoot { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { forall i: Idx { m[i - i] = true } \
+                forall j: Idx { m[j - j] = true } } action noop() { } }",
+    );
+    let error = fsl_runtime::check_init_write_ownership(&root_root)
+        .expect_err("two unresolved writes must overlap on the same logical root");
+    assert_eq!(
+        error.message,
+        "state variable 'm' assigned more than once in init forall"
+    );
+
+    let lone_root = model(
+        "spec LoneRoot { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { forall i: Idx { m[i - i] = true } } action noop() { } }",
+    );
+    fsl_runtime::check_init_write_ownership(&lone_root)
+        .expect("a lone unresolved write has no duplicate owner");
+}
+
 #[test]
 fn explicit_violation_trace_replays_through_the_monitor() {
     let model = model(

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5585,7 +5585,10 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
     match load_kernel_model(path) {
         Ok((_, kernel, model)) => {
             if let Err(error) = fsl_runtime::check_init_write_ownership(&model) {
-                return (semantic_error_output(&error.to_string()), 2);
+                return (
+                    fslc_rust::verification_output::render_runtime_error(envelope(), &error),
+                    2,
+                );
             }
             let has_trace_contract = match validate_requirement_traces(path, &model) {
                 Ok((Some(failure), _)) => return (failure, 2),

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5584,6 +5584,9 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
     }
     match load_kernel_model(path) {
         Ok((_, kernel, model)) => {
+            if let Err(error) = fsl_runtime::check_init_write_ownership(&model) {
+                return (semantic_error_output(&error.to_string()), 2);
+            }
             let has_trace_contract = match validate_requirement_traces(path, &model) {
                 Ok((Some(failure), _)) => return (failure, 2),
                 Ok((None, has_contract)) => has_contract,

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -874,7 +874,12 @@ pub(super) fn run_explicit_filtered(request: ExplicitRequest<'_>) -> (Value, i32
         checked_bounds.as_ref(),
     ) {
         Ok(result) => result,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => {
+            return (
+                fslc_rust::verification_output::render_runtime_error(envelope(), &error),
+                2,
+            );
+        }
     };
     let (vacuity, reachable_diagnostics) =
         match explicit_solver_findings(&model, &result.action_coverage) {
@@ -933,7 +938,12 @@ pub(super) fn run_auto_filtered(request: ExplicitRequest<'_>) -> (Value, i32) {
         checked_bounds.as_ref(),
     ) {
         Ok(result) => result,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => {
+            return (
+                fslc_rust::verification_output::render_runtime_error(envelope(), &error),
+                2,
+            );
+        }
     };
     let (vacuity, reachable_diagnostics) =
         match explicit_solver_findings(&model, &result.action_coverage) {
@@ -1043,8 +1053,12 @@ fn prepare_bmc(request: &BmcRequest<'_>, started: Instant) -> Result<PreparedBmc
     let model = load_selected_model(request.selection)
         .map_err(|error| (spec_load_error_output(&error), 2))?;
     if request.initial_state.is_none() {
-        fsl_runtime::check_init_write_ownership(&model)
-            .map_err(|error| (semantic_error_output(&error.to_string()), 2))?;
+        fsl_runtime::check_init_write_ownership(&model).map_err(|error| {
+            (
+                fslc_rust::verification_output::render_runtime_error(envelope(), &error),
+                2,
+            )
+        })?;
     }
     let checked_bounds = selected_implicit_bounds(
         &model,

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -1042,6 +1042,10 @@ fn execute_bmc(
 fn prepare_bmc(request: &BmcRequest<'_>, started: Instant) -> Result<PreparedBmc, CommandResult> {
     let model = load_selected_model(request.selection)
         .map_err(|error| (spec_load_error_output(&error), 2))?;
+    if request.initial_state.is_none() {
+        fsl_runtime::check_init_write_ownership(&model)
+            .map_err(|error| (semantic_error_output(&error.to_string()), 2))?;
+    }
     let checked_bounds = selected_implicit_bounds(
         &model,
         request.selection.property,

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -164,6 +164,20 @@ pub fn render_semantic_error(
     Value::Object(output)
 }
 
+/// Render a runtime diagnostic without discarding an authored statement span.
+#[must_use]
+pub fn render_runtime_error(
+    output: Map<String, Value>,
+    error: &fsl_runtime::RuntimeError,
+) -> Value {
+    render_semantic_error(
+        output,
+        &error.message,
+        error.span.map(fsl_syntax::Span::python_loc),
+        false,
+    )
+}
+
 /// A governance diagnostic with its source location preserved across delivery
 /// surfaces.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rust/fslc/tests/explicit_engine.rs
+++ b/rust/fslc/tests/explicit_engine.rs
@@ -285,6 +285,7 @@ fn unresolved_init_index_collisions_share_the_ownership_diagnostic() {
         assert_eq!(checked["result"], "error");
         assert_eq!(checked["kind"], "semantics");
         assert_eq!(checked["message"], expected);
+        assert_eq!(checked["loc"], json!({"line": 8, "column": 21}));
 
         for engine in ["bmc", "explicit"] {
             let (verified, verify_status) = verify(path, engine, 1, &[]);
@@ -292,6 +293,7 @@ fn unresolved_init_index_collisions_share_the_ownership_diagnostic() {
             assert_eq!(verified["result"], checked["result"]);
             assert_eq!(verified["kind"], checked["kind"]);
             assert_eq!(verified["message"], checked["message"]);
+            assert_eq!(verified["loc"], checked["loc"]);
         }
     }
 

--- a/rust/fslc/tests/explicit_engine.rs
+++ b/rust/fslc/tests/explicit_engine.rs
@@ -272,6 +272,40 @@ fn explicit_accepts_forall_init_writing_the_same_value_every_iteration() {
 }
 
 #[test]
+fn unresolved_init_index_collisions_share_the_ownership_diagnostic() {
+    let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let expected = "state variable 'm' assigned more than once in init forall";
+
+    for name in ["issue_826_root_concrete.fsl", "issue_826_root_root.fsl"] {
+        let path = fixtures.join(name);
+        let path = path.to_str().expect("UTF-8 fixture path");
+
+        let (checked, check_status) = run_cli(&["check".to_owned(), path.to_owned()]);
+        assert_eq!(check_status, 2, "check accepted {name}: {checked:#}");
+        assert_eq!(checked["result"], "error");
+        assert_eq!(checked["kind"], "semantics");
+        assert_eq!(checked["message"], expected);
+
+        for engine in ["bmc", "explicit"] {
+            let (verified, verify_status) = verify(path, engine, 1, &[]);
+            assert_eq!(verify_status, 2, "{engine} accepted {name}: {verified:#}");
+            assert_eq!(verified["result"], checked["result"]);
+            assert_eq!(verified["kind"], checked["kind"]);
+            assert_eq!(verified["message"], checked["message"]);
+        }
+    }
+
+    let lone = fixtures.join("issue_826_lone_root.fsl");
+    let lone = lone.to_str().expect("UTF-8 fixture path");
+    let (checked, check_status) = run_cli(&["check".to_owned(), lone.to_owned()]);
+    assert_eq!(check_status, 0, "check rejected a lone owner: {checked:#}");
+    assert_eq!(checked["result"], "ok");
+    let (verified, verify_status) = verify(lone, "bmc", 1, &[]);
+    assert_eq!(verify_status, 0, "BMC rejected a lone owner: {verified:#}");
+    assert_eq!(verified["result"], "verified");
+}
+
+#[test]
 fn explicit_closure_proves_true_noninductive_invariant() {
     let fixture =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/explicit_noninductive.fsl");

--- a/rust/fslc/tests/fixtures/issue_826_lone_root.fsl
+++ b/rust/fslc/tests/fixtures/issue_826_lone_root.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec LoneRootWrite {
+  type Idx = 0..2
+  state { m: Map<Idx, Bool> }
+  init { forall i: Idx { m[i - i] = true } }
+  action noop() { }
+}

--- a/rust/fslc/tests/fixtures/issue_826_root_concrete.fsl
+++ b/rust/fslc/tests/fixtures/issue_826_root_concrete.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec RootConcreteCollision {
+  type Idx = 0..2
+  state { m: Map<Idx, Bool> }
+  init {
+    forall i: Idx { m[i - i] = true }
+    forall j: Idx { m[j] = true }
+  }
+  action noop() { }
+}

--- a/rust/fslc/tests/fixtures/issue_826_root_root.fsl
+++ b/rust/fslc/tests/fixtures/issue_826_root_root.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec RootRootCollision {
+  type Idx = 0..2
+  state { m: Map<Idx, Bool> }
+  init {
+    forall i: Idx { m[i - i] = true }
+    forall j: Idx { m[j - j] = true }
+  }
+  action noop() { }
+}


### PR DESCRIPTION
## Problem

`docs/DESIGN-bridge.md` §1.3's alias clause was unenforced (#826): `init_write_keys`'s `InitWriteKey::Root` fallback for unresolvable index expressions never collided with `ConcreteIndex` (or another `Root`) on the same variable, so `forall i { m[i - i] = true }` overlapping `forall j { m[j] = true }` with agreeing values was silently `proved`. Pre-existing (not introduced by #821); the fallback's 'at least as strict' doc-comment was overstated.

## Change (fail-closed; contract unchanged)

An unresolvable init index target is now treated as potentially touching every key of its logical root: `Root(m)` collides with `ConcreteIndex(m, _)` and with another `Root(m)`, rejected by the owning duplicate-write rule (`state variable 'm' assigned more than once in init forall`) — not the unsatisfiability backstop — **with the authored location of the colliding write carried through all three paths** (review round: the diagnostic initially lacked the DESIGN-v1-required `loc`). Doc-comment corrected.

## Evidence

- Independent review (separate codex session), two rounds: R1 verified semantics, three-engine agreement, over-rejection probes (3 legitimate patterns), `--from-state` preservation, and mutations — one finding (missing `loc`); R2 confirmed `loc` at the second colliding write across check/explicit/BMC. **Findings 0.** Full review attached.
- Before/after: Root/concrete and Root/Root agreeing-value overlaps check exit 0→2 with **check/BMC/explicit verdicts identical**; lone unresolved write stays accepted; #824/#860 per-key allowances preserved; corpus_check_sweep ×2 green; detector revert exit 101 with restore proven by empty diff; fmt / scoped clippy ×2 exit 0.

Closes #826

🤖 Generated with [Claude Code](https://claude.com/claude-code)