### PR TITLE
fix(runtime): treat terminal states as non-deadlocks in legacy BFS

### DIFF
--- a/changelog.d/904-bfs-terminal-deadlock.fixed.md
+++ b/changelog.d/904-bfs-terminal-deadlock.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#904): legacy solver-free BFS now excludes intended `terminal` states from deadlock reporting while preserving true deadlocks, matching explicit BFS and symbolic BMC.

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -12,7 +12,8 @@ use fsl_core::{
 
 use super::trace::{ParentLink, reconstruct_trace, state_changes};
 use super::{
-    Bindings, Monitor, RuntimeError, State, Violation, eval, runtime_error, with_total_division,
+    Bindings, Monitor, RuntimeError, State, Violation, eval, runtime_error, terminal_holds,
+    with_total_division,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -263,24 +264,6 @@ pub fn verify_explicit_selected(
 
     result.states_explored = seen.len();
     Ok(result)
-}
-
-fn terminal_holds(monitor: &Monitor) -> Result<bool, RuntimeError> {
-    let Some(terminal) = &monitor.model.terminal else {
-        return Ok(false);
-    };
-    with_total_division(|| {
-        match eval(
-            terminal,
-            &monitor.state,
-            &mut Bindings::new(),
-            &monitor.model,
-            None,
-        )? {
-            Value::Bool(value) => Ok(value),
-            _ => Err(runtime_error("terminal expression must be Boolean")),
-        }
-    })
 }
 
 fn record_reachables(

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -1315,6 +1315,24 @@ pub struct BfsResult {
     pub action_coverage: BTreeMap<String, bool>,
 }
 
+fn terminal_holds(monitor: &Monitor) -> Result<bool, RuntimeError> {
+    let Some(terminal) = &monitor.model.terminal else {
+        return Ok(false);
+    };
+    with_total_division(|| {
+        match eval(
+            terminal,
+            &monitor.state,
+            &mut Bindings::new(),
+            &monitor.model,
+            None,
+        )? {
+            Value::Bool(value) => Ok(value),
+            _ => Err(runtime_error("terminal expression must be Boolean")),
+        }
+    })
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RefinementFailure {
     pub kind: String,
@@ -2024,7 +2042,28 @@ pub fn bfs(model: KernelModel, depth: usize) -> Result<BfsResult, RuntimeError> 
         scratch.step = step;
         let enabled = scratch.enabled()?;
         if enabled.is_empty() {
-            result.deadlock_step = Some(result.deadlock_step.map_or(step, |old| old.min(step)));
+            let terminal = match terminal_holds(&scratch) {
+                Ok(value) => value,
+                Err(error) if is_partial_operation_error(&error.message) => {
+                    let violation = Violation {
+                        kind: "partial_op".to_owned(),
+                        name: "_partial_property_terminal".to_owned(),
+                        step,
+                    };
+                    if result
+                        .violation
+                        .as_ref()
+                        .is_none_or(|old| violation.step < old.step)
+                    {
+                        result.violation = Some(violation);
+                    }
+                    return Ok(result);
+                }
+                Err(error) => return Err(error),
+            };
+            if !terminal {
+                result.deadlock_step = Some(result.deadlock_step.map_or(step, |old| old.min(step)));
+            }
         }
         for instance in &enabled {
             result.action_coverage.insert(instance.action.clone(), true);

--- a/rust/fsl-runtime/tests/issue_904_terminal_deadlock.rs
+++ b/rust/fsl-runtime/tests/issue_904_terminal_deadlock.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use std::path::{Path, PathBuf};
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../fslc/tests/fixtures")
+        .join(name)
+}
+
+fn run_bfs(name: &str) -> fsl_runtime::BfsResult {
+    let path = fixture(name);
+    let source = std::fs::read_to_string(&path).expect("read terminal fixture");
+    let resolver = FsResolver::new(path.parent().expect("fixture directory"));
+    let kernel = parse_kernel_source(&source, &resolver).expect("parse terminal fixture");
+    let model = build_model(kernel).expect("build terminal fixture");
+    fsl_runtime::bfs(model, 1).expect("run legacy BFS")
+}
+
+#[test]
+fn legacy_bfs_does_not_report_an_intended_terminal_state_as_deadlocked() {
+    let result = run_bfs("assurance_terminal_once.fsl");
+
+    assert_eq!(
+        result.deadlock_step, None,
+        "terminal positive control: produced {:?}, expected None",
+        result.deadlock_step
+    );
+}
+
+#[test]
+fn legacy_bfs_still_reports_the_missing_terminal_sibling_as_deadlocked() {
+    let result = run_bfs("assurance_terminal_once_missing.fsl");
+
+    assert_eq!(
+        result.deadlock_step,
+        Some(1),
+        "missing-terminal sibling: produced {:?}, expected Some(1)",
+        result.deadlock_step
+    );
+}

--- a/rust/fslc/tests/typed_agreement/engines.rs
+++ b/rust/fslc/tests/typed_agreement/engines.rs
@@ -18,7 +18,10 @@ use std::future::Future;
 use std::pin::pin;
 use std::task::{Context, Poll, Waker};
 
-use fsl_core::{FsResolver, KernelModel, build_model, build_surface_model, parse_kernel_source};
+use fsl_core::{
+    FsResolver, FslValue as Value, KernelModel, build_model, build_surface_model,
+    parse_kernel_source,
+};
 use fsl_runtime::{Monitor, State, Violation};
 use fsl_syntax::{Expr, SpecItem};
 
@@ -129,6 +132,7 @@ impl fmt::Display for AgreementFailure {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AgreementObservation {
     pub verdict: Verdict,
+    pub deadlock_step: Option<usize>,
     pub required_edges: Vec<&'static str>,
     pub property_location: Option<String>,
     pub completeness: AgreementCompleteness,
@@ -146,8 +150,40 @@ pub struct AgreementCompleteness {
 
 struct MonitorObservation {
     verdict: Verdict,
+    deadlock_step: Option<usize>,
     depth_reached: usize,
     closure: bool,
+}
+
+fn monitor_terminal_holds(id: &str, monitor: &Monitor) -> Result<bool, AgreementFailure> {
+    let Some(terminal) = &monitor.model.terminal else {
+        return Ok(false);
+    };
+    match fsl_runtime::eval(
+        terminal,
+        &monitor.state,
+        &mut BTreeMap::new(),
+        &monitor.model,
+        None,
+    )
+    .map_err(|error| {
+        disagreement(
+            id,
+            "earliest_deadlock",
+            "terminal",
+            "Boolean",
+            error.message,
+        )
+    })? {
+        Value::Bool(value) => Ok(value),
+        value => Err(disagreement(
+            id,
+            "earliest_deadlock",
+            "terminal",
+            "Boolean",
+            value,
+        )),
+    }
 }
 
 fn disagreement(
@@ -178,6 +214,36 @@ fn require_equal<T: Eq + fmt::Debug>(
     } else {
         Err(disagreement(id, edge, field, left, right))
     }
+}
+
+pub fn require_deadlock_agreement(
+    id: &str,
+    monitor: Option<usize>,
+    legacy_bfs: Option<usize>,
+    explicit: Option<usize>,
+    symbolic: Option<usize>,
+) -> Result<(), AgreementFailure> {
+    require_equal(
+        id,
+        "earliest_deadlock",
+        "monitor_bfs",
+        &monitor,
+        &legacy_bfs,
+    )?;
+    require_equal(
+        id,
+        "earliest_deadlock",
+        "bfs_explicit",
+        &legacy_bfs,
+        &explicit,
+    )?;
+    require_equal(
+        id,
+        "earliest_deadlock",
+        "explicit_bmc",
+        &explicit,
+        &symbolic,
+    )
 }
 
 fn property_location(
@@ -236,6 +302,7 @@ fn observe_monitor(
         .map_err(|error| disagreement(id, "monitor_bfs", "engine", "ok", error.message))?;
     let mut frontier = BTreeMap::from([(initial.state.clone(), initial)]);
     let mut seen: BTreeSet<_> = frontier.keys().cloned().collect();
+    let mut deadlock_step = None;
 
     for level in 0..=depth {
         for monitor in frontier.values() {
@@ -245,17 +312,11 @@ fn observe_monitor(
             if violation.is_some() {
                 return Ok(MonitorObservation {
                     verdict: Verdict::from(violation),
+                    deadlock_step,
                     depth_reached: level,
                     closure: false,
                 });
             }
-        }
-        if level == depth {
-            return Ok(MonitorObservation {
-                verdict: Verdict::Clean,
-                depth_reached: level,
-                closure: false,
-            });
         }
 
         let mut next = BTreeMap::new();
@@ -263,6 +324,15 @@ fn observe_monitor(
             let enabled = monitor
                 .enabled()
                 .map_err(|error| disagreement(id, "monitor_bfs", "enabled", "ok", error.message))?;
+            if enabled.is_empty()
+                && deadlock_step.is_none()
+                && !monitor_terminal_holds(id, monitor)?
+            {
+                deadlock_step = Some(level);
+            }
+            if level == depth {
+                continue;
+            }
             for action in enabled {
                 let mut child = monitor.clone();
                 let stepped = child.step(&action).map_err(|error| {
@@ -271,6 +341,7 @@ fn observe_monitor(
                 if stepped.violation.is_some() {
                     return Ok(MonitorObservation {
                         verdict: Verdict::from(stepped.violation),
+                        deadlock_step,
                         depth_reached: level + 1,
                         closure: false,
                     });
@@ -280,9 +351,18 @@ fn observe_monitor(
                 }
             }
         }
+        if level == depth {
+            return Ok(MonitorObservation {
+                verdict: Verdict::Clean,
+                deadlock_step,
+                depth_reached: level,
+                closure: false,
+            });
+        }
         if next.is_empty() {
             return Ok(MonitorObservation {
                 verdict: Verdict::Clean,
+                deadlock_step,
                 depth_reached: level,
                 closure: true,
             });
@@ -440,6 +520,13 @@ pub fn compare_agreement(
             // different points after a violation. Reachable steps and action
             // coverage therefore have a common contract only for clean runs.
             if matches!(bmc_verdict, Verdict::Clean) {
+                require_deadlock_agreement(
+                    id,
+                    monitor.deadlock_step,
+                    bfs_result.deadlock_step,
+                    explicit_result.deadlock_step,
+                    bmc_result.deadlock_step,
+                )?;
                 let bfs_reachables = bfs_result
                     .reachables
                     .iter()
@@ -532,6 +619,7 @@ pub fn compare_agreement(
 
     Ok(AgreementObservation {
         verdict: bmc_verdict,
+        deadlock_step: bmc_result.deadlock_step,
         required_edges: if has_leadsto {
             vec!["depth_completeness", "replay", "successor_admission"]
         } else {
@@ -545,6 +633,9 @@ pub fn compare_agreement(
             ];
             if trace_compared {
                 edges.push("trace_explicit_bmc");
+            }
+            if !has_violation {
+                edges.push("earliest_deadlock");
             }
             if has_violation {
                 edges.push("property_location");

--- a/rust/fslc/tests/typed_agreement/inventory.rs
+++ b/rust/fslc/tests/typed_agreement/inventory.rs
@@ -77,4 +77,21 @@ fn generation_inventory_is_coupled_to_registries_and_test_anchors() {
         BTreeSet::from(["head", "pop", "at", "index", "divide", "remainder"]),
         "head/pop/at/index/divide/remainder inventory must stay complete"
     );
+
+    let excluded = inventory["excluded_observation_fields"]
+        .as_object()
+        .expect("excluded observation fields");
+    let required_edges = inventory["required_edges"]
+        .as_array()
+        .expect("required agreement edges");
+    assert!(
+        !excluded.contains_key("deadlock_step"),
+        "terminal-aware legacy BFS must not retain the deadlock_step exclusion"
+    );
+    assert!(
+        required_edges
+            .iter()
+            .any(|edge| edge == "earliest_deadlock"),
+        "removing the deadlock_step exclusion must promote earliest_deadlock to a required edge"
+    );
 }

--- a/rust/fslc/tests/typed_agreement/inventory.v1.json
+++ b/rust/fslc/tests/typed_agreement/inventory.v1.json
@@ -44,6 +44,7 @@
     "monitor_bfs",
     "bfs_explicit",
     "explicit_bmc",
+    "earliest_deadlock",
     "generated_expectation",
     "depth_completeness",
     "trace_explicit_bmc",
@@ -52,7 +53,6 @@
     "successor_admission"
   ],
   "excluded_observation_fields": {
-    "deadlock_step": "Terminal-state handling makes BFS deadlock_step and explicit deadlock_step intentionally non-identical; terminal verdict and action coverage remain required.",
     "auxiliary_observations_after_violation": "Engines intentionally stop at different points after the first violation; reachable steps and action coverage are equated only for clean bounded runs.",
     "states_explored": "Symbolic BMC has no concrete state-count analogue.",
     "symbolic_frontier_vs_concrete_closure": "Monitor and explicit concrete closure are equated. BMC frontier progress uses a different bounded symbolic proof domain, so both values are reported without pretending they are identical."

--- a/rust/fslc/tests/typed_agreement/logic_test.rs
+++ b/rust/fslc/tests/typed_agreement/logic_test.rs
@@ -69,6 +69,52 @@ fn validate_report(report: &Value) {
         .expect("FSL Logic report matches schema");
 }
 
+#[test]
+fn terminal_siblings_agree_on_the_earliest_reportable_deadlock() {
+    for (id, source, expected) in [
+        (
+            "terminal_positive",
+            include_str!("../fixtures/assurance_terminal_once.fsl"),
+            None,
+        ),
+        (
+            "missing_terminal_sibling",
+            include_str!("../fixtures/assurance_terminal_once_missing.fsl"),
+            Some(1),
+        ),
+    ] {
+        let model = engines::build(id, source);
+        let observation = engines::compare_agreement(id, &model, 1)
+            .unwrap_or_else(|failure| panic!("{id}: {failure}"));
+        assert_eq!(
+            observation.deadlock_step, expected,
+            "{id}: produced {:?}, expected {expected:?}",
+            observation.deadlock_step
+        );
+        assert!(
+            observation.required_edges.contains(&"earliest_deadlock"),
+            "{id}: earliest_deadlock edge did not execute"
+        );
+    }
+}
+
+#[test]
+fn earliest_deadlock_edge_rejects_an_isolated_legacy_misclassification() {
+    let failure = engines::require_deadlock_agreement(
+        "terminal_deadlock_mutation",
+        None,
+        Some(1),
+        None,
+        None,
+    )
+    .expect_err("a legacy terminal-as-deadlock mutation must be detected");
+
+    assert_eq!(failure.edge, "earliest_deadlock");
+    assert_eq!(failure.field, "monitor_bfs");
+    assert_eq!(failure.left, "None", "expected monitor value");
+    assert_eq!(failure.right, "Some(1)", "produced mutated legacy value");
+}
+
 fn parse_replay_case(value: &str) -> (u64, usize, usize) {
     let coordinates = value
         .strip_prefix("fsl-logic-v1-s")


### PR DESCRIPTION
## Problem

Legacy `fsl_runtime::bfs` recorded every state with no enabled action as a deadlock without checking `terminal`, diverging from `docs/LANGUAGE.md`'s contract, BMC, and explicit BFS (#904). The divergence was institutionalized by `typed_agreement/inventory.v1.json`'s `deadlock_step` exclusion — an exclusion masking a language-contract violation by one engine.

## Change (BFS/BMC migration PR1 per accepted `docs/DESIGN-bfs-bmc-native-migration.md`)

- `explicit.rs`'s terminal evaluation moved to a shared private runtime helper; legacy BFS now checks `terminal` before recording `deadlock_step`.
- The `deadlock_step` inventory exclusion is **removed** (self-retirement): typed agreement now compares earliest deadlock across the engines as an executable control.
- New `issue_904_terminal_deadlock.rs`: terminal-positive control (no deadlock reported) and missing-terminal sibling (true deadlock still reported).

## Evidence

- Independent review (separate codex session): **findings 0 in the first round** — verified the decision rule against LANGUAGE.md/BMC/explicit source, ran both models through explicit/BMC/BFS with identical verdicts, confirmed the exclusion removal actually enables the comparison (agreement-breaking mutation fails typed_agreement), audited the full diff for residue from an aborted full-gate run, and confirmed no solver dependency entered `fsl-runtime` (`cargo tree`). Full review attached.
- Detector: terminal-check revert flips `deadlock_step` None→Some(1), exit 101; restore proven by empty diff. fsl-runtime / typed_agreement focused / fmt / scoped clippy ×2 exit 0.

Closes #904 (unblocks migration PR2–PR4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)