### PR TITLE
chore(release): v4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+## [4.4.1] - 2026-08-26
+
+- Fixed (#761): the legacy replay trace object wrapper is now exactly `{"events": [...]}` —
+  a misspelled key (for example `eventz`), a non-array `events` value, or extra keys are
+  rejected with the wrapper diagnostic instead of being silently tolerated. Focused native
+  accepting and rejecting contracts pin the wrapper and its full public projection, and a
+  new liveness-witness replay matrix rejects isolated state, action, and loop corruptions
+  of every `leadsTo` lasso case the retired Python comparison covered.
+- Fixed (#786): the frozen Python compatibility reference now lets an explicit
+  inline `implements` action correspondence override the same requirements-process
+  auto map, so the manual dialect-conformance corpus no longer rejects a valid
+  arity-changing refinement mapping.
+- Fixed (#826): unresolved indexed `init` writes now conservatively collide with every concrete key on the same logical map root instead of silently accepting aliasing writes with equal values.
+- Fixed (#832): native `fslc check` now fails closed for compose alias and typed
+  binder resolution gaps that `verify` already rejected. A declared alias no
+  longer authorizes a nonexistent qualified type such as `core.NoSuchType`, and
+  an undeclared alias-shaped expression in an `init if` condition receives the
+  same type check as an assignment right-hand side. Unknown typed binder names
+  are also rejected uniformly in properties, action postconditions, and init.
+  Errors retain the author's spelling and source location; valid imported types,
+  binder types, and state conditions remain accepted.
+- Fixed (#904): legacy solver-free BFS now excludes intended `terminal` states from deadlock reporting while preserving true deadlocks, matching explicit BFS and symbolic BMC.
+- Required (#742): merge readiness now rejects Git-tracked citations to missing
+  `docs/DESIGN-*.md` sections, including colon and explicit-section forms, without
+  letting untracked documents satisfy them; calibrated folded, list-tail, historical,
+  and accepting controls preserve the boundary.
+- Required (#746): the five frozen-Python and DESIGN-index coupled-change metatests now run in the required pre-merge automation lane while remaining outside the Rust-native product gate.
+- Required (#761): native Rust tests now bind every corpus `verify` result class to
+  its exact public process exit code; pin the business, requirements, and governance
+  induction CLI contracts; exercise all nine leadsTo case-by-corruption replay cells
+  with exact diagnostics; compare the complete legacy object-wrapper envelopes
+  while rejecting wrong keys, value types, and extra root keys; compare the
+  complete stable `refine` envelope projection with a live, reasoned exclusion for
+  solver-selected implementation traces; and own all sixteen stable induction
+  envelope/exit cases with live exclusions and negative controls before the Python
+  parity harnesses are retired.
+- Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and fail-closed tracked-script enumeration, plus a calibrated direct-syntax Bash-version guard lint that scans expansions in unquoted heredocs, ignores literal heredoc data, and documents its dynamic-execution boundary.
+- Required (#761): the sixteen induction CLI cases the retired Python parity harness compared
+  are now owned by a native golden contract (`induction_cli_contract.rs`) — full stable
+  envelopes with reason-coded, live-hit-checked exclusions, a calibrated cache-mode control,
+  and an idempotent golden regeneration path.
+- Required (#761): refinement corpus parity now compares the full stable projection of every
+  corpus envelope against a checked-in golden with reason-coded exclusions and a
+  dead-exclusion check, replacing the result/kind/exit-only assertion the retired Python
+  harness was stronger than.
+- Documented (#757): recorded the first natural production partial re-run — a GitHub-side
+  artifact-service transient failed one test shard on a docs-only PR, `gh run rerun --failed`
+  re-ran only that shard, and the aggregator accepted the mixed-attempt cohort
+  (`attempts=1,1,2`), recovering in one shard's time instead of a full three-shard re-run.
+- Documented (#761): recorded all 17 Python/Rust parity-harness dispositions and deletion preconditions without deleting a harness, including seven native-owner gaps, the full-envelope helper dependency, the parked Phase-3 comparison, three native-migration candidates, and five bounded manual controls.
+- Documented (#904): accepted the #761 native BFS/BMC migration plan, including the
+  checked 20-model decision matrix, bidirectional witness validation, terminal-aware
+  deadlock repair, rejecting controls, and safe Python-harness and helper-binary
+  retirement order.
+- Required (#906): the induction contract golden is now part of the release-commit
+  regeneration set. It records each envelope's `versions` block, so a version bump made the
+  complete product gate fail comparing the previous version against the new one; `docs/RELEASE.md`
+  step 6 now names its `UPDATE_INDUCTION_CLI_CONTRACT` regeneration and
+  `is_release_bump_path` names the golden, keeping the release commit exempt from a
+  fragment for that path.
+
 ## [4.4.0] - 2026-08-25
 
 - Changed (#760): native CLI tests now cover deterministic DOT and Mermaid
@@ -5641,7 +5702,8 @@ The de facto first release. FSL (AI-native formal specification language) and th
   an example conformance test against a plain Python implementation.
 - A one-liner installer (with ZIP-download support) and an Agent Skill for AI agents.
 
-[Unreleased]: https://github.com/ymm-oss/fsl/compare/v4.4.0...HEAD
+[Unreleased]: https://github.com/ymm-oss/fsl/compare/v4.4.1...HEAD
+[4.4.1]: https://github.com/ymm-oss/fsl/compare/v4.4.0...v4.4.1
 [4.4.0]: https://github.com/ymm-oss/fsl/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/ymm-oss/fsl/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/ymm-oss/fsl/compare/v4.1.0...v4.2.0

--- a/changelog.d/742-design-citation-lint.required.md
+++ b/changelog.d/742-design-citation-lint.required.md
@@ -1,4 +1,0 @@
-Required (#742): merge readiness now rejects Git-tracked citations to missing
-`docs/DESIGN-*.md` sections, including colon and explicit-section forms, without
-letting untracked documents satisfy them; calibrated folded, list-tail, historical,
-and accepting controls preserve the boundary.

--- a/changelog.d/746-coupled-change-metatest.required.md
+++ b/changelog.d/746-coupled-change-metatest.required.md
@@ -1,1 +1,0 @@
-Required (#746): the five frozen-Python and DESIGN-index coupled-change metatests now run in the required pre-merge automation lane while remaining outside the Rust-native product gate.

--- a/changelog.d/757-natural-rerun-observation.documented.md
+++ b/changelog.d/757-natural-rerun-observation.documented.md
@@ -1,4 +1,0 @@
-Documented (#757): recorded the first natural production partial re-run — a GitHub-side
-artifact-service transient failed one test shard on a docs-only PR, `gh run rerun --failed`
-re-ran only that shard, and the aggregator accepted the mixed-attempt cohort
-(`attempts=1,1,2`), recovering in one shard's time instead of a full three-shard re-run.

--- a/changelog.d/761-legacy-wrapper-exactness.fixed.md
+++ b/changelog.d/761-legacy-wrapper-exactness.fixed.md
@@ -1,6 +1,0 @@
-Fixed (#761): the legacy replay trace object wrapper is now exactly `{"events": [...]}` —
-a misspelled key (for example `eventz`), a non-array `events` value, or extra keys are
-rejected with the wrapper diagnostic instead of being silently tolerated. Focused native
-accepting and rejecting contracts pin the wrapper and its full public projection, and a
-new liveness-witness replay matrix rejects isolated state, action, and loop corruptions
-of every `leadsTo` lasso case the retired Python comparison covered.

--- a/changelog.d/761-native-owners-f1-f2.required.md
+++ b/changelog.d/761-native-owners-f1-f2.required.md
@@ -1,9 +1,0 @@
-Required (#761): native Rust tests now bind every corpus `verify` result class to
-its exact public process exit code; pin the business, requirements, and governance
-induction CLI contracts; exercise all nine leadsTo case-by-corruption replay cells
-with exact diagnostics; compare the complete legacy object-wrapper envelopes
-while rejecting wrong keys, value types, and extra root keys; compare the
-complete stable `refine` envelope projection with a live, reasoned exclusion for
-solver-selected implementation traces; and own all sixteen stable induction
-envelope/exit cases with live exclusions and negative controls before the Python
-parity harnesses are retired.

--- a/changelog.d/761-record-parity-harness-dispositions.documented.md
+++ b/changelog.d/761-record-parity-harness-dispositions.documented.md
@@ -1,1 +1,0 @@
-Documented (#761): recorded all 17 Python/Rust parity-harness dispositions and deletion preconditions without deleting a harness, including seven native-owner gaps, the full-envelope helper dependency, the parked Phase-3 comparison, three native-migration candidates, and five bounded manual controls.

--- a/changelog.d/786-conformance-harness-failures.fixed.md
+++ b/changelog.d/786-conformance-harness-failures.fixed.md
@@ -1,4 +1,0 @@
-Fixed (#786): the frozen Python compatibility reference now lets an explicit
-inline `implements` action correspondence override the same requirements-process
-auto map, so the manual dialect-conformance corpus no longer rejects a valid
-arity-changing refinement mapping.

--- a/changelog.d/826-init-root-collision.fixed.md
+++ b/changelog.d/826-init-root-collision.fixed.md
@@ -1,1 +1,0 @@
-Fixed (#826): unresolved indexed `init` writes now conservatively collide with every concrete key on the same logical map root instead of silently accepting aliasing writes with equal values.

--- a/changelog.d/832-compose-check-alias-members.fixed.md
+++ b/changelog.d/832-compose-check-alias-members.fixed.md
@@ -1,8 +1,0 @@
-Fixed (#832): native `fslc check` now fails closed for compose alias and typed
-binder resolution gaps that `verify` already rejected. A declared alias no
-longer authorizes a nonexistent qualified type such as `core.NoSuchType`, and
-an undeclared alias-shaped expression in an `init if` condition receives the
-same type check as an assignment right-hand side. Unknown typed binder names
-are also rejected uniformly in properties, action postconditions, and init.
-Errors retain the author's spelling and source location; valid imported types,
-binder types, and state conditions remain accepted.

--- a/changelog.d/898-shellcheck-wiring.required.md
+++ b/changelog.d/898-shellcheck-wiring.required.md
@@ -1,1 +1,0 @@
-Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and fail-closed tracked-script enumeration, plus a calibrated direct-syntax Bash-version guard lint that scans expansions in unquoted heredocs, ignores literal heredoc data, and documents its dynamic-execution boundary.

--- a/changelog.d/904-bfs-terminal-deadlock.fixed.md
+++ b/changelog.d/904-bfs-terminal-deadlock.fixed.md
@@ -1,1 +1,0 @@
-Fixed (#904): legacy solver-free BFS now excludes intended `terminal` states from deadlock reporting while preserving true deadlocks, matching explicit BFS and symbolic BMC.

--- a/changelog.d/904-bfsbmc-migration-design.documented.md
+++ b/changelog.d/904-bfsbmc-migration-design.documented.md
@@ -1,4 +1,0 @@
-Documented (#904): accepted the #761 native BFS/BMC migration plan, including the
-checked 20-model decision matrix, bidirectional witness validation, terminal-aware
-deadlock repair, rejecting controls, and safe Python-harness and helper-binary
-retirement order.

--- a/changelog.d/906-induction-envelope-owner.required.md
+++ b/changelog.d/906-induction-envelope-owner.required.md
@@ -1,4 +1,0 @@
-Required (#761): the sixteen induction CLI cases the retired Python parity harness compared
-are now owned by a native golden contract (`induction_cli_contract.rs`) — full stable
-envelopes with reason-coded, live-hit-checked exclusions, a calibrated cache-mode control,
-and an idempotent golden regeneration path.

--- a/changelog.d/907-refinement-full-projection.required.md
+++ b/changelog.d/907-refinement-full-projection.required.md
@@ -1,4 +1,0 @@
-Required (#761): refinement corpus parity now compares the full stable projection of every
-corpus envelope against a checked-in golden with reason-coded exclusions and a
-dead-exclusion check, replacing the result/kind/exit-only assertion the retired Python
-harness was stronger than.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -92,9 +92,22 @@ It also rejects a dynamic dependency on `libz3`.
    snapshot is regenerated, never hand-edited; any other change in that diff is
    a contract change that does not belong in a release commit.
 
+   Regenerate the induction contract golden for the same reason — it records each
+   envelope's `versions` block:
+
+   ```bash
+   UPDATE_INDUCTION_CLI_CONTRACT=1 \
+     cargo test --manifest-path rust/Cargo.toml -p fslc-rust \
+     --test induction_cli_contract --locked
+   ```
+
+   Apply the same review rule: version strings only. Skipping this fails the complete
+   product gate, not merge-readiness — observed on the v4.4.1 candidate, where
+   `induction_cli_contract` compared 4.4.0 against 4.4.1.
+
    **Steps 4–6 above touch `rust/Cargo.toml`, `rust/Cargo.lock`, the domain characterization
-   baseline, `editors/vscode/package.json`, and `editors/vscode/package-lock.json`.** The first
-   three are product surfaces under `tools/aggregate_changelog.sh`'s `is_product_surface_path`,
+   baseline, the induction contract golden, `editors/vscode/package.json`, and
+   `editors/vscode/package-lock.json`.** The first four are product surfaces under `tools/aggregate_changelog.sh`'s `is_product_surface_path`,
    and are exactly what `is_release_bump_path` names — the fixed set the merge-readiness
    `check-pr` gate exempts from needing a fragment once this diff's `CHANGELOG.md` edit is a
    validated release move (H1/F3; review, #737, comments 2026-08-07 third round and 2026-08-08

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fsl-vscode",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fsl-vscode",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fsl-vscode",
   "displayName": "FSL",
   "description": "Language support for FSL specifications.",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "publisher": "fslc",
   "license": "Apache-2.0",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-core"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-syntax",
  "serde_json",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-lsp"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "crossbeam-channel",
  "fsl-core",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-runtime"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-core",
  "serde_json",
@@ -373,14 +373,14 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fsl-solver-z3"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-solver",
  "z3",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver-z3js"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-solver",
  "js-sys",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-syntax"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-tools"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-core",
  "fsl-syntax",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-verifier"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-wasm"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "fslc-rust"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.4.0"
+version = "4.4.1"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -7630,11 +7630,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -7786,11 +7786,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -7811,11 +7811,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8038,11 +8038,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8063,11 +8063,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8102,11 +8102,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8133,11 +8133,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8162,11 +8162,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8192,11 +8192,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8220,11 +8220,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8250,11 +8250,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8278,11 +8278,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8308,11 +8308,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8336,11 +8336,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8367,11 +8367,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8396,11 +8396,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8427,11 +8427,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8456,11 +8456,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8486,11 +8486,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8514,11 +8514,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",

--- a/rust/fslc/tests/goldens/induction_cli_contract.json
+++ b/rust/fslc/tests/goldens/induction_cli_contract.json
@@ -131,7 +131,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -140,7 +140,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -247,7 +247,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -256,7 +256,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -382,7 +382,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -391,7 +391,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -559,7 +559,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -568,7 +568,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -727,7 +727,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -736,7 +736,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -843,7 +843,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -852,7 +852,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       }
     }
@@ -958,7 +958,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -967,7 +967,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       }
     }
@@ -1088,7 +1088,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1097,7 +1097,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -1221,7 +1221,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1230,7 +1230,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -1345,7 +1345,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1354,7 +1354,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -1488,7 +1488,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1497,7 +1497,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -1632,7 +1632,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1641,7 +1641,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -1770,7 +1770,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1779,7 +1779,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -1954,7 +1954,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1963,7 +1963,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -2109,7 +2109,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -2118,7 +2118,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -2339,7 +2339,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -2348,7 +2348,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violated_at_step": 4,

--- a/tools/aggregate_changelog.sh
+++ b/tools/aggregate_changelog.sh
@@ -621,6 +621,12 @@ is_release_bump_path() {
     rust/Cargo.lock) return 0 ;;
     rust/Cargo.toml) return 0 ;;
     rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json) return 0 ;;
+    # #906's induction contract golden records each envelope's `versions`
+    # block, so a release bump regenerates it for the same reason as the
+    # characterization baseline above. Observed on the v4.4.1 candidate: the
+    # complete product gate failed comparing 4.4.0 against 4.4.1 before this
+    # path was named here.
+    rust/fslc/tests/goldens/induction_cli_contract.json) return 0 ;;
     *) return 1 ;;
   esac
 }


### PR DESCRIPTION
## Release commit for v4.4.1

Per `docs/RELEASE.md` §1: workspace and VS Code extension bumped to 4.4.1, both version-embedding goldens regenerated (each diff is version strings only — 0 non-version lines), 15 changelog entries aggregated into `## [4.4.1] - 2026-08-26` (`changelog.d/` empty, link references updated).

## Scope since v4.4.0

Soundness fixes: #832 (check/verify false green for alias members **and** typed binders across all dialects), #826 (unresolved init writes now collide with concrete keys), #904 (legacy BFS no longer reports terminal states as deadlocks; the `deadlock_step` agreement exclusion self-retires), #786 (frozen-Python implements-override), #617/#882/#883 CRLF independence. Detection strengthening: #742 design-citation lint, #746 coupled-change metatest wiring, #898 shellcheck + bash-version-guard lint, #757 stable shard artifacts (plus its first natural production partial re-run, recorded), #761 native owners F1–F4/F6/F7 and the parity-harness disposition record. Docs: #762 root help, the accepted BFS/BMC migration design.

## Release-procedure gap closed here

This candidate's first complete-gate run failed on `induction_cli_contract`: #906's golden records each envelope's `versions` block, but neither `docs/RELEASE.md` step 6 nor `is_release_bump_path` named it — so every future release would have hit the same failure. Both are updated in this commit, with the observation recorded in the changelog entry.

## Verification evidence

- `cargo check --workspace` + `--locked`: exit 0; `fslc --version` = `fslc 4.4.1` (exact-match test); characterization regen 3 passed; both golden diffs version-strings-only.
- Complete product gate on this tree: rust, wasm, fault-operators, fsl-logic legs green. `semantic-mutation complete` reports **14 timeouts, 0 surviving mutants** — a measured local-performance difference (mutant builds reach 775 s against the 600 s build timeout; baseline build alone is 322 s). **The same commit's CI `mutation mutants` tested 55 mutants: 47 caught, 8 unviable, 0 timeouts.** Local timeout counts are therefore not treated as a code defect; `missed.txt` was empty in both local runs.
- `main`'s post-merge product gate on `d9e9710` is **success** (its earlier failure was a cancelled `native Z3 (windows-latest)` job, resolved by `rerun --failed`).
- `git diff --check`, `aggregate_changelog.sh check`, shellcheck lint: exit 0.

## Next (per RELEASE.md §2–3)

Merge → record candidate SHA → `workflow_dispatch` release.yml dry-run → promotion PR `main` → `production` → revalidate on the production HEAD → tag `v4.4.1` (with explicit confirmation immediately before the tag push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)