### PR TITLE
release: promote v4.4.1 (1552033) to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ and versioning follows [Semantic Versioning](https://semver.org/). Each version 
 
 ## [Unreleased]
 
+## [4.4.1] - 2026-08-26
+
+- Fixed (#761): the legacy replay trace object wrapper is now exactly `{"events": [...]}` —
+  a misspelled key (for example `eventz`), a non-array `events` value, or extra keys are
+  rejected with the wrapper diagnostic instead of being silently tolerated. Focused native
+  accepting and rejecting contracts pin the wrapper and its full public projection, and a
+  new liveness-witness replay matrix rejects isolated state, action, and loop corruptions
+  of every `leadsTo` lasso case the retired Python comparison covered.
+- Fixed (#786): the frozen Python compatibility reference now lets an explicit
+  inline `implements` action correspondence override the same requirements-process
+  auto map, so the manual dialect-conformance corpus no longer rejects a valid
+  arity-changing refinement mapping.
+- Fixed (#826): unresolved indexed `init` writes now conservatively collide with every concrete key on the same logical map root instead of silently accepting aliasing writes with equal values.
+- Fixed (#832): native `fslc check` now fails closed for compose alias and typed
+  binder resolution gaps that `verify` already rejected. A declared alias no
+  longer authorizes a nonexistent qualified type such as `core.NoSuchType`, and
+  an undeclared alias-shaped expression in an `init if` condition receives the
+  same type check as an assignment right-hand side. Unknown typed binder names
+  are also rejected uniformly in properties, action postconditions, and init.
+  Errors retain the author's spelling and source location; valid imported types,
+  binder types, and state conditions remain accepted.
+- Fixed (#904): legacy solver-free BFS now excludes intended `terminal` states from deadlock reporting while preserving true deadlocks, matching explicit BFS and symbolic BMC.
+- Required (#742): merge readiness now rejects Git-tracked citations to missing
+  `docs/DESIGN-*.md` sections, including colon and explicit-section forms, without
+  letting untracked documents satisfy them; calibrated folded, list-tail, historical,
+  and accepting controls preserve the boundary.
+- Required (#746): the five frozen-Python and DESIGN-index coupled-change metatests now run in the required pre-merge automation lane while remaining outside the Rust-native product gate.
+- Required (#761): native Rust tests now bind every corpus `verify` result class to
+  its exact public process exit code; pin the business, requirements, and governance
+  induction CLI contracts; exercise all nine leadsTo case-by-corruption replay cells
+  with exact diagnostics; compare the complete legacy object-wrapper envelopes
+  while rejecting wrong keys, value types, and extra root keys; compare the
+  complete stable `refine` envelope projection with a live, reasoned exclusion for
+  solver-selected implementation traces; and own all sixteen stable induction
+  envelope/exit cases with live exclusions and negative controls before the Python
+  parity harnesses are retired.
+- Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and fail-closed tracked-script enumeration, plus a calibrated direct-syntax Bash-version guard lint that scans expansions in unquoted heredocs, ignores literal heredoc data, and documents its dynamic-execution boundary.
+- Required (#761): the sixteen induction CLI cases the retired Python parity harness compared
+  are now owned by a native golden contract (`induction_cli_contract.rs`) — full stable
+  envelopes with reason-coded, live-hit-checked exclusions, a calibrated cache-mode control,
+  and an idempotent golden regeneration path.
+- Required (#761): refinement corpus parity now compares the full stable projection of every
+  corpus envelope against a checked-in golden with reason-coded exclusions and a
+  dead-exclusion check, replacing the result/kind/exit-only assertion the retired Python
+  harness was stronger than.
+- Documented (#757): recorded the first natural production partial re-run — a GitHub-side
+  artifact-service transient failed one test shard on a docs-only PR, `gh run rerun --failed`
+  re-ran only that shard, and the aggregator accepted the mixed-attempt cohort
+  (`attempts=1,1,2`), recovering in one shard's time instead of a full three-shard re-run.
+- Documented (#761): recorded all 17 Python/Rust parity-harness dispositions and deletion preconditions without deleting a harness, including seven native-owner gaps, the full-envelope helper dependency, the parked Phase-3 comparison, three native-migration candidates, and five bounded manual controls.
+- Documented (#904): accepted the #761 native BFS/BMC migration plan, including the
+  checked 20-model decision matrix, bidirectional witness validation, terminal-aware
+  deadlock repair, rejecting controls, and safe Python-harness and helper-binary
+  retirement order.
+- Required (#906): the induction contract golden is now part of the release-commit
+  regeneration set. It records each envelope's `versions` block, so a version bump made the
+  complete product gate fail comparing the previous version against the new one; `docs/RELEASE.md`
+  step 6 now names its `UPDATE_INDUCTION_CLI_CONTRACT` regeneration and
+  `is_release_bump_path` names the golden, keeping the release commit exempt from a
+  fragment for that path.
+
 ## [4.4.0] - 2026-08-25
 
 - Changed (#760): native CLI tests now cover deterministic DOT and Mermaid
@@ -5641,7 +5702,8 @@ The de facto first release. FSL (AI-native formal specification language) and th
   an example conformance test against a plain Python implementation.
 - A one-liner installer (with ZIP-download support) and an Agent Skill for AI agents.
 
-[Unreleased]: https://github.com/ymm-oss/fsl/compare/v4.4.0...HEAD
+[Unreleased]: https://github.com/ymm-oss/fsl/compare/v4.4.1...HEAD
+[4.4.1]: https://github.com/ymm-oss/fsl/compare/v4.4.0...v4.4.1
 [4.4.0]: https://github.com/ymm-oss/fsl/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/ymm-oss/fsl/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/ymm-oss/fsl/compare/v4.1.0...v4.2.0

--- a/changelog.d/742-design-citation-lint.required.md
+++ b/changelog.d/742-design-citation-lint.required.md
@@ -1,0 +1,4 @@
+Required (#742): merge readiness now rejects Git-tracked citations to missing
+`docs/DESIGN-*.md` sections, including colon and explicit-section forms, without
+letting untracked documents satisfy them; calibrated folded, list-tail, historical,
+and accepting controls preserve the boundary.

--- a/changelog.d/742-design-citation-lint.required.md
+++ b/changelog.d/742-design-citation-lint.required.md
@@ -1,4 +1,0 @@
-Required (#742): merge readiness now rejects Git-tracked citations to missing
-`docs/DESIGN-*.md` sections, including colon and explicit-section forms, without
-letting untracked documents satisfy them; calibrated folded, list-tail, historical,
-and accepting controls preserve the boundary.

--- a/changelog.d/746-coupled-change-metatest.required.md
+++ b/changelog.d/746-coupled-change-metatest.required.md
@@ -1,1 +1,0 @@
-Required (#746): the five frozen-Python and DESIGN-index coupled-change metatests now run in the required pre-merge automation lane while remaining outside the Rust-native product gate.

--- a/changelog.d/746-coupled-change-metatest.required.md
+++ b/changelog.d/746-coupled-change-metatest.required.md
@@ -1,0 +1,1 @@
+Required (#746): the five frozen-Python and DESIGN-index coupled-change metatests now run in the required pre-merge automation lane while remaining outside the Rust-native product gate.

--- a/changelog.d/757-natural-rerun-observation.documented.md
+++ b/changelog.d/757-natural-rerun-observation.documented.md
@@ -1,0 +1,4 @@
+Documented (#757): recorded the first natural production partial re-run — a GitHub-side
+artifact-service transient failed one test shard on a docs-only PR, `gh run rerun --failed`
+re-ran only that shard, and the aggregator accepted the mixed-attempt cohort
+(`attempts=1,1,2`), recovering in one shard's time instead of a full three-shard re-run.

--- a/changelog.d/757-natural-rerun-observation.documented.md
+++ b/changelog.d/757-natural-rerun-observation.documented.md
@@ -1,4 +1,0 @@
-Documented (#757): recorded the first natural production partial re-run — a GitHub-side
-artifact-service transient failed one test shard on a docs-only PR, `gh run rerun --failed`
-re-ran only that shard, and the aggregator accepted the mixed-attempt cohort
-(`attempts=1,1,2`), recovering in one shard's time instead of a full three-shard re-run.

--- a/changelog.d/761-legacy-wrapper-exactness.fixed.md
+++ b/changelog.d/761-legacy-wrapper-exactness.fixed.md
@@ -1,0 +1,6 @@
+Fixed (#761): the legacy replay trace object wrapper is now exactly `{"events": [...]}` —
+a misspelled key (for example `eventz`), a non-array `events` value, or extra keys are
+rejected with the wrapper diagnostic instead of being silently tolerated. Focused native
+accepting and rejecting contracts pin the wrapper and its full public projection, and a
+new liveness-witness replay matrix rejects isolated state, action, and loop corruptions
+of every `leadsTo` lasso case the retired Python comparison covered.

--- a/changelog.d/761-legacy-wrapper-exactness.fixed.md
+++ b/changelog.d/761-legacy-wrapper-exactness.fixed.md
@@ -1,6 +1,0 @@
-Fixed (#761): the legacy replay trace object wrapper is now exactly `{"events": [...]}` —
-a misspelled key (for example `eventz`), a non-array `events` value, or extra keys are
-rejected with the wrapper diagnostic instead of being silently tolerated. Focused native
-accepting and rejecting contracts pin the wrapper and its full public projection, and a
-new liveness-witness replay matrix rejects isolated state, action, and loop corruptions
-of every `leadsTo` lasso case the retired Python comparison covered.

--- a/changelog.d/761-native-owners-f1-f2.required.md
+++ b/changelog.d/761-native-owners-f1-f2.required.md
@@ -1,1 +1,6 @@
-Required (#761): native Rust tests now bind every corpus `verify` result class to its exact public process exit code and pin the business, requirements, and governance induction CLI contracts before the Python parity harnesses are retired.
+Required (#761): native Rust tests now bind every corpus `verify` result class to
+its exact public process exit code; pin the business, requirements, and governance
+induction CLI contracts; exercise all nine leadsTo case-by-corruption replay cells
+with exact diagnostics; and compare the complete legacy object-wrapper envelopes
+while rejecting wrong keys, value types, and extra root keys before the Python
+parity harnesses are retired.

--- a/changelog.d/761-native-owners-f1-f2.required.md
+++ b/changelog.d/761-native-owners-f1-f2.required.md
@@ -1,9 +1,0 @@
-Required (#761): native Rust tests now bind every corpus `verify` result class to
-its exact public process exit code; pin the business, requirements, and governance
-induction CLI contracts; exercise all nine leadsTo case-by-corruption replay cells
-with exact diagnostics; compare the complete legacy object-wrapper envelopes
-while rejecting wrong keys, value types, and extra root keys; compare the
-complete stable `refine` envelope projection with a live, reasoned exclusion for
-solver-selected implementation traces; and own all sixteen stable induction
-envelope/exit cases with live exclusions and negative controls before the Python
-parity harnesses are retired.

--- a/changelog.d/761-native-owners-f1-f2.required.md
+++ b/changelog.d/761-native-owners-f1-f2.required.md
@@ -1,6 +1,7 @@
 Required (#761): native Rust tests now bind every corpus `verify` result class to
 its exact public process exit code; pin the business, requirements, and governance
 induction CLI contracts; exercise all nine leadsTo case-by-corruption replay cells
-with exact diagnostics; and compare the complete legacy object-wrapper envelopes
-while rejecting wrong keys, value types, and extra root keys before the Python
-parity harnesses are retired.
+with exact diagnostics; compare the complete legacy object-wrapper envelopes
+while rejecting wrong keys, value types, and extra root keys; and compare the
+complete stable `refine` envelope projection with a live, reasoned exclusion for
+solver-selected implementation traces before the Python parity harnesses are retired.

--- a/changelog.d/761-native-owners-f1-f2.required.md
+++ b/changelog.d/761-native-owners-f1-f2.required.md
@@ -1,0 +1,1 @@
+Required (#761): native Rust tests now bind every corpus `verify` result class to its exact public process exit code and pin the business, requirements, and governance induction CLI contracts before the Python parity harnesses are retired.

--- a/changelog.d/761-native-owners-f1-f2.required.md
+++ b/changelog.d/761-native-owners-f1-f2.required.md
@@ -2,6 +2,8 @@ Required (#761): native Rust tests now bind every corpus `verify` result class t
 its exact public process exit code; pin the business, requirements, and governance
 induction CLI contracts; exercise all nine leadsTo case-by-corruption replay cells
 with exact diagnostics; compare the complete legacy object-wrapper envelopes
-while rejecting wrong keys, value types, and extra root keys; and compare the
+while rejecting wrong keys, value types, and extra root keys; compare the
 complete stable `refine` envelope projection with a live, reasoned exclusion for
-solver-selected implementation traces before the Python parity harnesses are retired.
+solver-selected implementation traces; and own all sixteen stable induction
+envelope/exit cases with live exclusions and negative controls before the Python
+parity harnesses are retired.

--- a/changelog.d/761-record-parity-harness-dispositions.documented.md
+++ b/changelog.d/761-record-parity-harness-dispositions.documented.md
@@ -1,1 +1,0 @@
-Documented (#761): recorded all 17 Python/Rust parity-harness dispositions and deletion preconditions without deleting a harness, including seven native-owner gaps, the full-envelope helper dependency, the parked Phase-3 comparison, three native-migration candidates, and five bounded manual controls.

--- a/changelog.d/761-record-parity-harness-dispositions.documented.md
+++ b/changelog.d/761-record-parity-harness-dispositions.documented.md
@@ -1,0 +1,1 @@
+Documented (#761): recorded all 17 Python/Rust parity-harness dispositions and deletion preconditions without deleting a harness, including seven native-owner gaps, the full-envelope helper dependency, the parked Phase-3 comparison, three native-migration candidates, and five bounded manual controls.

--- a/changelog.d/786-conformance-harness-failures.fixed.md
+++ b/changelog.d/786-conformance-harness-failures.fixed.md
@@ -1,0 +1,4 @@
+Fixed (#786): the frozen Python compatibility reference now lets an explicit
+inline `implements` action correspondence override the same requirements-process
+auto map, so the manual dialect-conformance corpus no longer rejects a valid
+arity-changing refinement mapping.

--- a/changelog.d/786-conformance-harness-failures.fixed.md
+++ b/changelog.d/786-conformance-harness-failures.fixed.md
@@ -1,4 +1,0 @@
-Fixed (#786): the frozen Python compatibility reference now lets an explicit
-inline `implements` action correspondence override the same requirements-process
-auto map, so the manual dialect-conformance corpus no longer rejects a valid
-arity-changing refinement mapping.

--- a/changelog.d/826-init-root-collision.fixed.md
+++ b/changelog.d/826-init-root-collision.fixed.md
@@ -1,1 +1,0 @@
-Fixed (#826): unresolved indexed `init` writes now conservatively collide with every concrete key on the same logical map root instead of silently accepting aliasing writes with equal values.

--- a/changelog.d/826-init-root-collision.fixed.md
+++ b/changelog.d/826-init-root-collision.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#826): unresolved indexed `init` writes now conservatively collide with every concrete key on the same logical map root instead of silently accepting aliasing writes with equal values.

--- a/changelog.d/832-compose-check-alias-members.fixed.md
+++ b/changelog.d/832-compose-check-alias-members.fixed.md
@@ -1,0 +1,8 @@
+Fixed (#832): native `fslc check` now fails closed for compose alias and typed
+binder resolution gaps that `verify` already rejected. A declared alias no
+longer authorizes a nonexistent qualified type such as `core.NoSuchType`, and
+an undeclared alias-shaped expression in an `init if` condition receives the
+same type check as an assignment right-hand side. Unknown typed binder names
+are also rejected uniformly in properties, action postconditions, and init.
+Errors retain the author's spelling and source location; valid imported types,
+binder types, and state conditions remain accepted.

--- a/changelog.d/832-compose-check-alias-members.fixed.md
+++ b/changelog.d/832-compose-check-alias-members.fixed.md
@@ -1,8 +1,0 @@
-Fixed (#832): native `fslc check` now fails closed for compose alias and typed
-binder resolution gaps that `verify` already rejected. A declared alias no
-longer authorizes a nonexistent qualified type such as `core.NoSuchType`, and
-an undeclared alias-shaped expression in an `init if` condition receives the
-same type check as an assignment right-hand side. Unknown typed binder names
-are also rejected uniformly in properties, action postconditions, and init.
-Errors retain the author's spelling and source location; valid imported types,
-binder types, and state conditions remain accepted.

--- a/changelog.d/841-nested-option-support.documented.md
+++ b/changelog.d/841-nested-option-support.documented.md
@@ -1,0 +1,1 @@
+Documented (#841): accepted the implementation design for full recursive nested `Option` support, including fail-closed type boundaries, lossless JSON/replay, and cross-engine agreement.

--- a/changelog.d/898-shellcheck-wiring.required.md
+++ b/changelog.d/898-shellcheck-wiring.required.md
@@ -1,0 +1,1 @@
+Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and fail-closed tracked-script enumeration, plus a calibrated direct-syntax Bash-version guard lint that scans expansions in unquoted heredocs, ignores literal heredoc data, and documents its dynamic-execution boundary.

--- a/changelog.d/898-shellcheck-wiring.required.md
+++ b/changelog.d/898-shellcheck-wiring.required.md
@@ -1,1 +1,0 @@
-Required (#898): Merge readiness now runs ShellCheck with masked-return analysis and fail-closed tracked-script enumeration, plus a calibrated direct-syntax Bash-version guard lint that scans expansions in unquoted heredocs, ignores literal heredoc data, and documents its dynamic-execution boundary.

--- a/changelog.d/904-bfs-terminal-deadlock.fixed.md
+++ b/changelog.d/904-bfs-terminal-deadlock.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#904): legacy solver-free BFS now excludes intended `terminal` states from deadlock reporting while preserving true deadlocks, matching explicit BFS and symbolic BMC.

--- a/changelog.d/904-bfs-terminal-deadlock.fixed.md
+++ b/changelog.d/904-bfs-terminal-deadlock.fixed.md
@@ -1,1 +1,0 @@
-Fixed (#904): legacy solver-free BFS now excludes intended `terminal` states from deadlock reporting while preserving true deadlocks, matching explicit BFS and symbolic BMC.

--- a/changelog.d/904-bfsbmc-migration-design.documented.md
+++ b/changelog.d/904-bfsbmc-migration-design.documented.md
@@ -1,0 +1,4 @@
+Documented (#904): accepted the #761 native BFS/BMC migration plan, including the
+checked 20-model decision matrix, bidirectional witness validation, terminal-aware
+deadlock repair, rejecting controls, and safe Python-harness and helper-binary
+retirement order.

--- a/changelog.d/904-bfsbmc-migration-design.documented.md
+++ b/changelog.d/904-bfsbmc-migration-design.documented.md
@@ -1,4 +1,0 @@
-Documented (#904): accepted the #761 native BFS/BMC migration plan, including the
-checked 20-model decision matrix, bidirectional witness validation, terminal-aware
-deadlock repair, rejecting controls, and safe Python-harness and helper-binary
-retirement order.

--- a/changelog.d/906-induction-envelope-owner.required.md
+++ b/changelog.d/906-induction-envelope-owner.required.md
@@ -1,4 +1,0 @@
-Required (#761): the sixteen induction CLI cases the retired Python parity harness compared
-are now owned by a native golden contract (`induction_cli_contract.rs`) — full stable
-envelopes with reason-coded, live-hit-checked exclusions, a calibrated cache-mode control,
-and an idempotent golden regeneration path.

--- a/changelog.d/906-induction-envelope-owner.required.md
+++ b/changelog.d/906-induction-envelope-owner.required.md
@@ -1,0 +1,4 @@
+Required (#761): the sixteen induction CLI cases the retired Python parity harness compared
+are now owned by a native golden contract (`induction_cli_contract.rs`) — full stable
+envelopes with reason-coded, live-hit-checked exclusions, a calibrated cache-mode control,
+and an idempotent golden regeneration path.

--- a/changelog.d/907-refinement-full-projection.required.md
+++ b/changelog.d/907-refinement-full-projection.required.md
@@ -1,0 +1,4 @@
+Required (#761): refinement corpus parity now compares the full stable projection of every
+corpus envelope against a checked-in golden with reason-coded exclusions and a
+dead-exclusion check, replacing the result/kind/exit-only assertion the retired Python
+harness was stronger than.

--- a/changelog.d/907-refinement-full-projection.required.md
+++ b/changelog.d/907-refinement-full-projection.required.md
@@ -1,4 +1,0 @@
-Required (#761): refinement corpus parity now compares the full stable projection of every
-corpus envelope against a checked-in golden with reason-coded exclusions and a
-dead-exclusion check, replacing the result/kind/exit-only assertion the retired Python
-harness was stronger than.

--- a/docs/DESIGN-annotations.md
+++ b/docs/DESIGN-annotations.md
@@ -261,11 +261,11 @@ identity, while the generated invariant separately points to the authored rule,
 artifact/environment entry, and column declarations that caused it.
 
 `tools/check_rust_surface_parity.py`'s `SUPPORTED_SPECIALIZED_FRONTENDS`
-already includes `ai-component`/`db`/`domain`; since no new field was
-projected into any of these three dialects' `kernel_ast_v1()`, corpus parity is
-unaffected by construction (the tool is not CI-wired — see the Python
-compatibility gate note in the repository's CLAUDE.md — but was still run
-manually against the corpus to confirm).
+includes `ai-component`/`db`/`domain`. The tool is an optional developer-run
+frozen-Python compatibility check, triggered only by an intentional change to
+that registered subset or its parse-error locations; it is not CI or product
+evidence and must not constrain Rust-only language evolution. The browser runner's
+document-kind selection is candidate routing, not a surface-AST comparison.
 
 ## Validation and semantic isolation
 

--- a/docs/DESIGN-bfs-bmc-native-migration.md
+++ b/docs/DESIGN-bfs-bmc-native-migration.md
@@ -1,0 +1,414 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Native BFS/BMC parity matrix for issue #761
+
+Status: Accepted. Acceptance baseline: `df96d094a658eb7e91c24a8ef1beb494e9b31e5c`
+(`origin/main` on 2026-08-26).
+
+## 1. Decision
+
+Retire the frozen-Python BFS/BMC differential only after its still-live detectors are
+owned by one native, API-level matrix. The matrix belongs under
+`rust/fslc/tests/typed_agreement/`; it calls `fsl_runtime::Monitor`,
+`fsl_runtime::bfs`, `fsl_runtime::verify_explicit`,
+`fsl_verifier::verify_bounded`, and the existing replay/agreement APIs directly. It
+does not spawn Python or the temporary `fsl-bmc` / `fsl-replay-actions` binaries.
+
+The migration has four rules:
+
+1. Preserve the current 20-model breadth with a checked native inventory; do not
+   inherit `kernel_cases()` or `can_monitor()` from Python.
+2. Compare semantic projections, not presentation envelopes or solver-selected
+   witness bytes. A witness is valid when the other lineage accepts the same steps
+   and terminal classification.
+3. Make earliest reportable deadlock agree with the language definition: a state
+   satisfying `terminal` is not a deadlock. This resolves, rather than preserves,
+   the current conflict between the language/design contract and legacy BFS.
+4. Do not compare `states_explored` across engines. It is an algorithmic/cost
+   observation, not an FSL-language result. Keep its focused memory-regression owner.
+
+This is cross-engine agreement with two semantic lineages, not a vote and not a new
+public assurance class. The symbolic lineage is BMC/native Z3. `Monitor`, legacy
+BFS, and explicit BFS share the concrete evaluator and are one declared concrete
+lineage, not three independent observers.
+
+## 2. Authority and confirmed current state
+
+The language contract excludes intended terminal states from deadlock checking
+(`docs/LANGUAGE.md:44-48,748-756`). BMC implements that exclusion before recording
+`deadlock_step` (`rust/fsl-verifier/src/bmc.rs:370-425`), and explicit BFS does the
+same (`rust/fsl-runtime/src/explicit.rs:189-207,268-283`). Legacy
+`fsl_runtime::bfs` currently records every state with no enabled action as a
+deadlock, without checking `terminal` (`rust/fsl-runtime/src/lib.rs:2021-2028`).
+
+That implementation difference is reflected in two conflicting native records:
+
+- `rust/fslc/tests/typed_agreement/inventory.v1.json:54-58` excludes `deadlock_step` as
+  intentionally non-identical.
+- the accepted current-architecture record requires Monitor, legacy BFS, and
+  symbolic verification to agree on earliest deadlock before the Python harnesses
+  are retired (`docs/DESIGN-rust-component-internals.md:587-600`).
+
+The language and accepted migration precondition win. The inventory exclusion must
+self-retire when legacy BFS becomes terminal-aware. Merely renaming the legacy value
+to “quiescence” would preserve a field whose public name and Python detector both say
+deadlock, and would leave the accepted three-way anchor unsatisfied.
+
+Existing native ownership was checked at the cited assertions, not inferred from
+test names:
+
+- normalized `(kind, name, step)` verdicts are compared at
+  `rust/fslc/tests/typed_agreement/engines.rs:346-350,363-437`;
+- clean-run reachability and action coverage are compared at
+  `rust/fslc/tests/typed_agreement/engines.rs:439-485`;
+- explicit/BMC violation traces are compared and both replayed at
+  `rust/fslc/tests/typed_agreement/engines.rs:496-526`;
+- generated depth/closure metadata is checked at
+  `rust/fslc/tests/typed_agreement/engines.rs:351-357,368-423`;
+- the broad native corpus test compares explicit/BMC result, exit, and violation
+  depth, but not reachability/deadlock/coverage, at
+  `rust/fslc/tests/explicit_engine.rs:291-355`;
+- the focused reachable owner compares only the shortest witness step at
+  `rust/fslc/tests/explicit_engine.rs:482-495`;
+- P2 compares symbolic and explicit violation kind, name, step, complete trace, and
+  source span, and corrupts state/step/kind/name/action/location independently
+  (`rust/fslc/tests/triangulated/p2_witness_replay.rs:162-181,184-233`);
+- the production BMC output gate replays violation, leadsTo, reachable, and deadlock
+  traces (`rust/fslc/src/verification_output.rs:737-771`), but its current rejecting witness
+  mutation is a violation-state mutation (`rust/fslc/tests/solver_fail_closed.rs:451-474`), not a
+  reachable/deadlock-specific calibration.
+
+The acceptance baseline also includes the broader #761 native-owner work that
+landed after the analysis baseline. F1 corpus result/exit conservation and F2
+dialect induction are native-owned (`rust/fslc/tests/corpus_check_sweep.rs:245-365`;
+`rust/fslc/tests/dialect_induction_contract.rs:80-145`). F3's sixteen induction
+envelopes and exits are native-owned
+(`rust/fslc/tests/induction_cli_contract.rs:423-512`), F4's three-case liveness
+lasso replay and nine isolated corruptions landed in #903
+(`rust/fslc/tests/liveness_witness_replay.rs:124-147,167-242`), and F6's complete
+stable refinement projection and live exclusion control are native-owned
+(`rust/fslc/tests/refine_corpus_parity.rs:116-175,887-985`). These completed
+owners do not change the BFS/BMC matrix decision. The terminal/deadlock defect
+on which its first implementation PR depends is filed as
+[#904](https://github.com/ymm-oss/fsl/issues/904).
+
+## 3. What the Python harnesses actually detect
+
+### 3.1 Model roster
+
+Both BFS and BMC harnesses call `kernel_cases(root)` before filtering to direct
+children of `specs/`, then exclude `can_monitor == false`
+(`tools/check_rust_bfs_parity.py:90-100`;
+`tools/check_rust_bmc_parity.py:178-193`). At this
+baseline, filtering the surface candidates before kernel export yields exactly 20
+supported models and no `can_monitor` exclusions:
+
+| Family | Current paths |
+|---|---|
+| Direct specs (18) | `audit_log`, `auth_lockout`, `bank`, `bank_impl`, `cart_buggy`, `cart_fixed`, `cart_impl`, `cart_v1`, `cart_v1_buggy`, `inventory_reservation`, `job_pipeline`, `mutex_queue`, `order_workflow`, `payment`, `rate_limiter`, `repair_loop`, `seat_booking`, `seat_booking_impl` |
+| Compose (2) | `bank_system`, `order_system` |
+| Explicit non-model exclusions (3) | `bank_refines.fsl`, `cart_refines.fsl`, `seat_refines.fsl` |
+
+The current Python selector is itself no longer a reliable inventory API:
+`kernel_cases()` exports every surface `spec`/`compose` before the `specs/` filter,
+and presently stops on
+`examples/gallery/errors/semantics_compose_component_parse_failure.fsl`. This is the
+same stable stale-membership precondition recorded by the PR #896 review. Native
+migration must therefore encode the 20 paths directly and check the roster in both
+directions; it must not transliterate the failing helper order.
+
+`mutex_queue.fsl` is the only listed model with `leadsTo`. Legacy BFS does not
+evaluate that property and explicit verification rejects the whole model
+(`rust/fslc/tests/typed_agreement/engines.rs:313-323,376-393`). Its matrix posture is therefore
+explicit: compare the safety/reachability/deadlock/coverage projection on
+Monitor↔legacy-BFS↔BMC, assert the explicit rejection reason contains `leadsTo`, and
+leave liveness verdict/replay to the dedicated liveness owners. It must not be
+silently skipped.
+
+### 3.2 Complete detector ledger
+
+“Owned” below means the current native assertion detects the same field-level drift.
+“Residual” means related code exists but the exact old detector, model breadth, or
+direction is not yet calibrated. `P` is frozen Python, `M` direct native Monitor
+enumeration, `LB` legacy `fsl_runtime::bfs`, `E` native explicit BFS, and `S` native
+symbolic BMC.
+
+| ID | Compared field / condition | Python harness models and direction | Confirmed native owner | Disposition |
+|---|---|---|---|---|
+| D01 | roster membership and unsupported accounting | 20 selected `specs/` models; selector→case loop | Broad `E↔S` corpus scan exists (`rust/fslc/tests/explicit_engine.rs:291-355`) but is not the same checked roster | **Residual:** native bidirectional inventory |
+| D02 | `spec` identity | all cases; `P↔LB`, and `P↔LB` + `P↔S` in BMC | Result structs carry `spec`, but cited agreement assertions do not compare it | **Residual:** assert every observation equals `model.name` |
+| D03 | `states_explored` | all BFS cases; exact `P↔LB` (`tools/check_rust_bfs_parity.py:52-63,78-87,111-119`) | One focused value is pinned by `rust/fsl-runtime/tests/issue_730_bfs_memory_ceiling.rs:60-89`; symbolic BMC has no analogue | **Residual retired:** do not migrate engine equality |
+| D04 | violation presence | all cases; exact optional projection on `P↔LB` and `P↔S` | `Verdict` equality (`rust/fslc/tests/typed_agreement/engines.rs:94-108,346-350,426-437`) | Owned |
+| D05 | violation kind | violating cases, same directions | Same `Verdict`; P2 also compares kind (`rust/fslc/tests/triangulated/p2_witness_replay.rs:171-179`) | Owned |
+| D06 | violation name | violating cases, same directions | Same `Verdict`; P2 also compares name | Owned |
+| D07 | earliest violation step | violating cases, same directions | Same `Verdict`; broad corpus also compares depth (`rust/fslc/tests/explicit_engine.rs:336-340`) | Owned |
+| D08 | reached-property key set / presence | all BFS cases; clean-only in BMC, `P↔LB` and `P↔S` | Full maps are compared on clean generated runs (`rust/fslc/tests/typed_agreement/engines.rs:439-471`) | Owned primitive; apply checked roster |
+| D09 | earliest reachable step per key | same as D08 | Same assertion; focused shortest-step control (`rust/fslc/tests/explicit_engine.rs:482-495`) | Owned primitive; apply checked roster |
+| D10 | earliest reportable `deadlock_step` | all BFS cases; clean-only in BMC, `P↔LB` and `P↔S` | Explicit and BMC each implement terminal-aware detection, but no cited cross-engine assertion; inventory excludes it | **Residual:** resolve terminal conflict and compare |
+| D11 | action-coverage key set | all BFS cases; clean-only in BMC, `P↔LB` and `P↔S` | Full maps compared on clean generated runs (`rust/fslc/tests/typed_agreement/engines.rs:472-485`) | Owned primitive; apply checked roster |
+| D12 | action covered/uncovered Boolean | same as D11 | Same assertion | Owned primitive; apply checked roster |
+| D13 | violation witness: step/state/action/params/changes and identity, `S→concrete` | every emitted BMC violation; Rust BMC→Rust Monitor and Rust BMC→Python Monitor (`tools/check_rust_bmc_parity.py:83-119,201-204`) | P2 exact identity/replay and isolated corruptions; production replay gate | Owned |
+| D14 | reachable witness semantic replay, `S→concrete` | every emitted BMC reachable witness (`tools/check_rust_bmc_parity.py:88-90,95-119`) | Generic production replay exists, but no reachable-specific rejecting corruption over the 20-model matrix | **Residual:** matrix application + calibration |
+| D15 | deadlock witness semantic replay, `S→concrete` | every emitted BMC deadlock witness (`tools/check_rust_bmc_parity.py:92-119`) | Generic production replay exists, but no deadlock-specific rejecting corruption | **Residual:** matrix application + calibration |
+| D16 | violation witness, `concrete→S` | Python BMC→Rust Monitor in the old direction; native analogue is explicit/Monitor→symbolic | P2 exact `E↔S` trace/identity and typed-agreement exact violation trace | Owned |
+| D17 | reachable witness, `concrete→S` | Python BMC→Rust Monitor for every reachable trace (`tools/check_rust_bmc_parity.py:121-175`) | Only shortest step is compared; the concrete trace is not checked symbolically | **Residual:** validate every edge and final reachable predicate |
+| D18 | deadlock witness, `concrete→S` | Python BMC→Rust Monitor for every deadlock trace | No native reverse semantic witness check | **Residual:** validate every edge and final non-terminal deadlock |
+
+Aggregate: **18 detector classes: 10 exactly owned, 8 not exactly owned**. Seven
+residuals move to native tests (D01, D02, D10, D14, D15, D17, D18); D03 is explicitly
+retired rather than converted into a language contract.
+
+The old BMC decision projection deliberately omits `states_explored`, and includes
+reachability/deadlock/coverage only when no violation exists
+(`tools/check_rust_bmc_parity.py:59-76,194-220`). The native matrix keeps that
+stop-order caveat: compare auxiliary maps across all engines only for clean runs,
+and use focused single-purpose cases for each non-clean branch. It must not compare
+partially accumulated post-violation observations.
+
+## 4. Native test design
+
+### 4.1 Files and responsibilities
+
+Extend the existing integration-test crate rather than introduce another semantic
+owner:
+
+```text
+rust/fslc/tests/typed_agreement.rs
+rust/fslc/tests/typed_agreement/
+  engines.rs              # existing normalized observations and common comparator
+  corpus_matrix.rs        # checked 20-path inventory and field/edge matrix
+  witness_matrix.rs       # S→M replay and E/M→S semantic witness validation
+  inventory.v1.json       # add matrix edges and self-retire deadlock exclusion
+```
+
+`corpus_matrix.rs` owns a source-coupled constant table with path, depth, expected
+axes, and engine posture. A completeness test scans only repository-root
+`specs/*.fsl`, classifies the three `*_refines.fsl` files explicitly as mappings,
+and requires exact set equality with the 20 model rows. Every matrix row must parse
+and build through native `parse_kernel_source` + `build_model`; a failed build is a
+test failure, not a skip. A new model or mapping is therefore an explicit inventory
+change.
+
+The breadth tier runs all 20 models at depth 2, preserving the old harness default
+without making the expensive corpus the sole detector. Existing small fixtures make
+each branch live cheaply:
+
+| Axis | Focused case and bound | Required observation |
+|---|---|---|
+| clean cyclic | `specs/bank.fsl`, depth 2 | no violation/deadlock, reachable and coverage live |
+| non-initial violation | `specs/cart_buggy.fsl`, depth 4 | invariant violation at the bound |
+| reachable witness | `explicit_reachable_witnessed.fsl`, depth 2 | `HitTwo` witness |
+| unintended deadlock | `explicit_deadlock.fsl`, depth 1 | earliest reportable deadlock + trace |
+| intended terminal | `assurance_terminal_once.fsl`, depth 1 | no reportable deadlock |
+| terminal negative sibling | `assurance_terminal_once_missing.fsl`, depth 1 | the same stop is a deadlock |
+| uncovered action | `scenario_blocked_action.fsl`, depth 1 | covered/uncovered Boolean split |
+
+The focused rows are controls, not replacements for the 20-model breadth. Their
+expected values are declared before execution so a matrix with no violation or no
+deadlock cannot pass vacuously.
+
+### 4.2 Normalized observations and edges
+
+Extend the test-only direct-Monitor enumeration already started by
+`observe_monitor` (`rust/fslc/tests/typed_agreement/engines.rs:226-293`). Its observation records:
+
+- model name and requested depth;
+- normalized first violation `(kind, name, step)`;
+- every reachable name with `Option<earliest_step>`;
+- terminal-aware earliest deadlock and its trace;
+- a complete action-name→covered map;
+- parent links needed only when a witness is found.
+
+Do not add `states_explored` to the comparable projection. It may be printed as
+debug evidence, but the comparator type must make it impossible to equate that
+field accidentally.
+
+Required edges are:
+
+1. `M↔LB`: exact name, safety verdict, reachability, earliest terminal-aware
+   deadlock, and coverage for every matrix case.
+2. `LB↔E`: the same projection for the 19 non-`leadsTo` cases.
+3. `E↔S`: the same projection for those 19 cases; auxiliary maps only on clean
+   runs.
+4. `LB↔S`: the safety projection for `mutex_queue.fsl`, while an assertion proves
+   why `E` is absent.
+5. `S-witness→M`: call the existing `replay_bmc_witnesses` / `replay_trace`
+   path for every violation, reachable, and deadlock witness.
+6. `E/M-witness→S`: for every successful edge call
+   `transition_matches_step`; for a violating final outcome use
+   `transition_outcome_matches_step`; then independently check the final reachable
+   predicate or reportable-deadlock predicate in the symbolic lineage.
+
+The reverse deadlock edge needs one small backend-neutral agreement helper in
+`rust/fsl-verifier/src/agreement.rs`, analogous to `expression_matches_value`: pin a
+complete concrete state, prove every action instance disabled, evaluate terminal
+with definedness, and return true only for `disabled && !terminal`. It must not call
+the concrete `terminal_holds` helper. The reachable reverse edge can use the
+existing symbolic expression-value agreement API. This preserves two reviewably
+different decision lineages.
+
+Witness trace bytes are never compared between independently selected witnesses.
+`docs/LANGUAGE.md:1098-1102` explicitly permits non-unique BMC witnesses; exact
+equality is valid only where P2 deliberately uses the same fixed model to bind
+identity.
+
+### 4.3 Earliest-deadlock repair
+
+Move explicit BFS's terminal evaluation into a private shared runtime helper and
+use it from both explicit and legacy BFS. Legacy BFS then records
+`deadlock_step = min(step)` only when `enabled.is_empty() && !terminal_holds`.
+Undefined/partial terminal evaluation must follow the existing explicit/BMC
+fail-closed behavior, including `_partial_property_terminal`, rather than being
+folded into either deadlock or terminal.
+
+After the positive and negative terminal siblings pass, remove
+`excluded_observation_fields.deadlock_step` from
+`rust/fslc/tests/typed_agreement/inventory.v1.json` and add
+`earliest_deadlock` to the required edges. A source-coupled inventory test must fail
+if the exclusion and required edge are both absent or both present.
+
+### 4.4 Rejecting-control calibration
+
+Each label below is earned by executing an isolated known-bad observation. The test
+must assert the produced `AgreementFailure.field` and produced value beside the
+expected value.
+
+| Detector | Isolated mutation | Expected cut |
+|---|---|---|
+| roster | remove one known model row; separately add an unregistered synthetic path | exact-set check reports missing / extra path |
+| spec identity | replace one observation's model name | `field=spec` |
+| violation | toggle presence; then mutate kind, name, and step one at a time | the corresponding verdict field |
+| reachability | remove a reached key; change its earliest step | `reachable_presence`, then `reachable_step` |
+| deadlock | shift `deadlock_step`; classify the terminal fixture as deadlocked | `deadlock_step`, then `terminal_deadlock` |
+| coverage | delete one action key; flip one known covered Boolean | `coverage_key`, then `coverage_value` |
+| generic trace integrity | mutate step, state, action, params, and changes separately | concrete replay rejects the named field |
+| reachable `S→M` | corrupt an intermediate state; separately keep a valid trace but relabel its final state as satisfying the target | replay, then reachable classification rejects |
+| deadlock `S→M` | append an enabled action or replace the final state with a live one | replay/deadlock classification rejects |
+| reachable `M/E→S` | change one successor while retaining action/params; separately use a final state where the target is false | symbolic transition, then symbolic target check rejects |
+| deadlock `M/E→S` | change the final state to one with an enabled action; separately use an intended terminal | symbolic disabledness, then terminal exclusion rejects |
+
+P2's current state/step/kind/name/action/location mutations remain and are not
+relabelled as reachable/deadlock detectors. New tests add params and changes because
+`replay_trace` promises both (`rust/fsl-runtime/src/lib.rs:2749-2873`). Every new or
+changed control runs twice in one session before being reported stable.
+
+No mutation asserts cross-engine `states_explored`. The existing Linux memory
+ceiling and its fixed reproducer count remain a performance-preservation control,
+not evidence of general semantic equality.
+
+## 5. Binary and Python-harness retirement order
+
+`fsl-bfs` remains. `issue_730_bfs_memory_ceiling.rs` launches it under `RLIMIT_AS`
+and asserts the reproducer's state count
+(`rust/fsl-runtime/tests/issue_730_bfs_memory_ceiling.rs:60-89`),
+so replacing that process boundary is not part of this migration.
+
+The safe removal sequence is:
+
+1. Land the terminal-aware legacy BFS and native corpus/witness matrix with all
+   rejecting controls.
+2. Delete `tools/check_rust_bfs_parity.py` and `tools/check_rust_bmc_parity.py`;
+   delete `rust/fslc/src/bin/fsl-bmc.rs`; update every disposition/reference.
+3. In the same cleanup train, delete `tools/check_rust_scenarios_parity.py` only after its
+   accepted downstream condition is met: native scenario identity tests remain,
+   BMC/cover/deadlock witnesses are replay-gated, and the new matrix owns the shared
+   witness semantics. This script imports `DEFAULT_REPLAY_BIN` and
+   `_json_normalize` from the BMC harness
+   (`tools/check_rust_scenarios_parity.py:19-30`), so deleting
+   BMC first without deleting or detaching scenarios leaves a broken import.
+4. F4's native lasso replay matrix has landed in #903, including all three legacy
+   cases and isolated state/action/loop corruptions
+   (`rust/fslc/tests/liveness_witness_replay.rs:124-147,167-242`). Do **not** delete
+   `fsl-replay-actions` merely because BFS/BMC/scenarios are gone: the retained
+   Python consumer still imports its path and executes it
+   (`tools/check_rust_leadsto_parity.py:22,70-100,148-155`). Remove the binary in
+   the cleanup that deletes that consumer, or after deliberately migrating the
+   retained consumer to a production replay surface. This is a hard dependency,
+   not optional cleanup.
+
+Before deleting either binary, use repository-wide reference checks, then `cargo
+build --workspace --locked` to prove Cargo's auto-discovered bin targets and tests no
+longer require them. Update at least `docs/RUST-PORTING.md`,
+`docs/DESIGN-rust-integration.md`, `docs/DESIGN-ci.md`,
+`docs/DESIGN-rust-component-internals.md`, `rust/README.md`, the
+`tools/check_rust_full_envelope.py` witness-ownership comment, and a `changelog.d/`
+fragment. Do not edit `CHANGELOG.md` directly.
+
+## 6. Triangulated-assurance posture
+
+The matrix satisfies the AGENTS invariant that symbolic verification, concrete
+Monitor behavior, and solver-free BFS agree, while keeping runtime independent of
+solver crates: all symbolic calls live in the `fslc-rust` integration-test target;
+`fsl-runtime` gains no solver dependency.
+
+No new `TriangulatedClaim` is required if the result is described accurately as
+native cross-engine agreement. P2 remains the registered triangulated claim for the
+fixed invariant-witness identity scope
+(`rust/fslc/tests/triangulated/p2_witness_replay.rs:29-100`). The broad matrix may
+cite P2 but may not claim that Monitor, legacy BFS, and explicit BFS are independent
+observers; they share the concrete evaluator.
+
+If a later PR labels the broad matrix “triangulated” or expands P2's registered
+scope, it must also expand the claim contract in
+`docs/DESIGN-triangulated-assurance.md:25-49,51-79`: preserve the raw trace before
+classification, declare symbolic and concrete lineages, execute model↔world,
+oracle↔world, and model↔oracle edges, cite accepting and rejecting controls, and
+state the exact manifest revision/depth/backend/platform scope. The matrix never
+promotes `bounded` or changes a process exit
+(`docs/DESIGN-triangulated-assurance.md:21-23`).
+
+## 7. PR split and verification
+
+Use four dependent PRs. “About 300 lines” applies to added/changed implementation
+and test logic; mechanical deletion of the old harness bodies is counted and
+reviewed separately.
+
+| PR | Scope | Approximate logical delta | Focused verification |
+|---|---|---:|---|
+| 1. Terminal-aware legacy BFS | shared terminal helper; legacy BFS behavior; terminal positive/rejecting tests; inventory exclusion self-retirement | ≤250 lines | `cargo test -p fsl-runtime --locked`; focused typed-agreement deadlock test twice; `cargo fmt --all -- --check`; targeted Clippy |
+| 2. Checked corpus decision matrix | `corpus_matrix.rs`, exact 20+3 inventory, D01/D02/D04-D12 edges and comparator corruptions | ≤300 lines | roster test twice; corpus matrix twice; existing `typed_agreement` and `explicit_engine`; targeted Clippy |
+| 3. Bidirectional witness matrix | `witness_matrix.rs`, symbolic final-state/deadlock helper, D14-D18 controls; retain P2 scope | ≤300 lines | witness matrix twice; `transition_agreement`; `triangulated_assurance`; focused P2 fault operators |
+| 4. Retirement and docs | delete BFS/BMC/scenarios harnesses and `fsl-bmc`; delete the now-native-owned F4 Python consumer with `fsl-replay-actions`; update docs/changelog | additions ≤200; deletions larger | no dangling references; `cargo test --workspace --locked`; `cargo build --workspace --locked`; `./tools/check-native-integration.sh` |
+
+PR 1 must land first. PR 2 and PR 3 may be developed after PR 1, but both touch the
+typed-agreement support surface and should merge serially. PR 4 is last and is
+blocked on PRs 1-3. The F4 native-owner condition for `fsl-replay-actions` was
+satisfied by #903; its retained Python consumer and the binary still move together.
+
+Respect the two-cargo-track limit:
+
+- track A is solver-free (`fsl-runtime` and its tests);
+- track B is solver-backed (`fsl-verifier` / `fslc-rust`, native Z3).
+
+At most one command per track may run concurrently, and shared target-directory
+locking may require serial execution. Never launch a third cargo process to make up
+for a slow Z3 build. The full workspace and product gate run once, serially, after
+the focused checks. PR 4 is not complete until the full native product evidence is
+green; merge readiness alone is insufficient.
+
+## 8. Exit criteria and risks
+
+Migration is complete only when:
+
+- the 20-model inventory and three mapping exclusions agree exactly with `specs/`;
+- every required edge runs at the same declared bound and all focused branches are
+  witnessed;
+- terminal and non-terminal stopping siblings distinguish reportable deadlock;
+- every BMC violation/reachable/deadlock witness replays concretely, and every
+  concrete witness is admitted and classified symbolically;
+- every named rejecting mutation fails for the expected field, twice;
+- no Python process or helper binary is used by the new matrix;
+- no cross-engine `states_explored` assertion has been introduced;
+- the retained F4 consumer is reconciled before `fsl-replay-actions` deletion.
+
+The primary risk is accidentally canonizing legacy “no enabled action, including an
+intended terminal” as deadlock just to preserve old parity. That would contradict the
+language contract and could make all engines agree on the wrong semantics. The
+terminal sibling pair and removal of the stale inventory exclusion are therefore the
+first PR, not cleanup deferred until after the broad matrix.
+
+The stale Python selector and remaining migration controls are dispositioned by
+existing issue [#761](https://github.com/ymm-oss/fsl/issues/761). The terminal
+mismatch is separately filed as [#904](https://github.com/ymm-oss/fsl/issues/904)
+because it is an existing language-contract defect and the first migration
+prerequisite, not merely matrix implementation work.

--- a/docs/DESIGN-causal.md
+++ b/docs/DESIGN-causal.md
@@ -635,9 +635,10 @@ never contradict, the sections above.
   checker via the pre-dispatch `is_causal_source` sniff (the same mechanism as
   legacy AI project files); `causal` is deliberately not in the dialect
   registry, so the frozen Python `DIALECT_KEYWORDS` parity check
-  (`tests/test_coupled_change_meta.py` — manual compatibility evidence, not a
-  CI gate; see `docs/DESIGN-coupled-change-metatest.md`) does not move. LSP
-  diagnostics and the document index apply the same sniff.
+  (`tests/test_coupled_change_meta.py` — required pre-merge repository evidence
+  through the automation lane, not product-gate evidence; see
+  `docs/DESIGN-coupled-change-metatest.md`) does not move. LSP diagnostics and
+  the document index apply the same sniff.
 - **Worker waiver**: the browser Worker exposes only `check`/`verify` by
   standing policy; causal commands are CLI-only and fall through to the
   Worker's deny-by-default error. This is an explicit waiver, not an omission.

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -1091,6 +1091,13 @@ by `rust/Cargo.toml` through a direct `with: toolchain:` input. Local reusable
 workflows are audited as workflow files; external reusable workflows are outside
 this repository's source authority.
 
+The same automation lane runs the five tests in
+`tests/test_coupled_change_meta.py`. They keep the frozen Python dialect, AI
+project-block, grammar, and CLI registries coupled to their native or
+DESIGN-document counterparts, and keep the DESIGN-document index bidirectional.
+This is required pre-merge repository/compatibility evidence, not product
+evidence, and it does not add Python to `./tools/check-native-integration.sh`.
+
 The privileged post-merge reporter receives `issues: write`, so its workflow
 also has a deliberately narrow parser-backed shape contract. It requires the
 fixed `jobs.reconcile` boundary, the exact trusted default-branch condition,

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -77,7 +77,17 @@ independent lanes succeed:
    recurrence updates, recovery closure, and workflow-level failure handling. It also runs the
    checked-in Codex/Claude task-harness contracts with the system Python: a discovered soundness
    finding must remain in the worktree ledger until fixed, linked to an issue, or explicitly marked
-   as awaiting issue-creation authorization.
+   as awaiting issue-creation authorization. The same lane runs the standard-library-only DESIGN
+   section-citation selftest and live audit. The audit examines Git-tracked UTF-8 text under
+   `.github/`, `tools/`, `rust/`, `docs/`, and `skills/`; a quoted section paired with a
+   `docs/DESIGN-*.md` path must exactly match an H2-H6 ATX heading after symmetric normalization of
+   presentation-only numbering, inline-code backticks, whitespace, and issue/slice suffixes. It
+   recognizes comma, colon, parenthesis, possessive, and explicit `section` separators, reports every
+   source location, and fails closed on unreadable input, a missing document, or a citation target
+   outside the same Git-tracked input set. An untracked worktree document therefore cannot satisfy a
+   tracked citation.
+   Repository-root `CHANGELOG.md` is deliberately outside that scope because it is an immutable
+   historical record whose old section names must not make current automation fail.
 
 The lanes run in parallel through `tools/check-merge-readiness.sh`. Native-CLI/default-feature
 compilation, all-target compilation, Clippy, native Z3 verification, the complete LSP/corpus suites,

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -18,6 +18,18 @@ A post-merge failure can therefore still expose a temporarily broken `main`, but
 platform-specific defect. The failed check and its deduplicated issue are blocking evidence for
 production/release promotion and must be repaired or reverted; they are not informational warnings.
 
+`tools/check_rust_*.py` is not a discovery convention: no workflow or native gate runs files merely
+because they match that name. The five bounded frozen-Python compatibility checks documented in
+`RUST-PORTING.md` are developer-run only, triggered by an intentional change to their shared
+projection. They are outside merge readiness, the product gate, scheduled promotion, and release,
+and a manual pass cannot replace or waive native evidence. Native/Worker full-envelope comparison
+is owned by `rust/fsl-wasm/test-browser.mjs`; native semantic agreement is owned by the Rust
+agreement and replay suites. The Phase-3 Python comparison is separately parked until `ai compare`
+has a focused native contract test. #761's documentation phase deletes no harness:
+`check_rust_full_envelope.py` is deletion-ready only after its shared helpers move safely; seven
+parity harnesses remain because related native coverage does not yet detect their exact drift
+(F1–F7 in `RUST-PORTING.md`); and the BFS/BMC/scenarios trio remains pending native semantic migration.
+
 ### Why the split falls here
 
 Measured on the batch that motivated this revision:

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -98,6 +98,46 @@ independent lanes succeed:
    source location, and fails closed on unreadable input, a missing document, or a citation target
    outside the same Git-tracked input set. An untracked worktree document therefore cannot satisfy a
    tracked citation.
+   The lane also runs ShellCheck over every `tools/*.sh` and `.github/scripts/*.sh`, explicitly
+   enabling `check-extra-masked-returns` (SC2312), and rejects suppressions without an inline reason.
+   Discovery must contain every Git-tracked direct `*.sh` child of both directories and must be
+   non-empty; untracked matching additions are also checked. A separate fixture contains
+   `check-*.sh`, `run-*.sh`, and `.github/scripts/report-*.sh` canaries, so narrowing either glob or
+   dropping either directory fails the inventory selftest before ShellCheck runs.
+   A standard-library Python lint first asks Bash to parse each script, then requires scripts using
+   `mapfile`/`readarray`, associative arrays, or array expansion under `set -u` to put a fail-closed
+   Bash-4+ guard immediately after the shebang. Its token classifier follows this executable-context
+   table; indentation never changes a result:
+
+   | Feature class | Executable token form | Quoted command word | Argument literal | Comment |
+   | --- | --- | --- | --- | --- |
+   | map input | exact simple-command word `mapfile` or `readarray`, including through `builtin` | detected | single- or double-quoted text is ignored | ignored |
+   | associative array | simple-command word `declare`, `typeset`, or `local` plus an option token containing `A`, including combined flags | detected | single- or double-quoted text is ignored | ignored |
+   | nounset array expansion | executable `set -u`, combined `-euo`, or `set -o nounset` plus executable `${name[@]}` | detected; `${name[@]}` inside double quotes still expands | plain `"set -u"` and single-quoted `${name[@]}` are ignored | ignored |
+   | nested execution | command substitutions and backticks are recursively tokenized, even inside double quotes | detected | outer literal text remains ignored | ignored |
+
+   Forty-six parser-accepted table cases plus accepting, missing-guard, late-guard,
+   indented-declare, local-associative, heredoc, and single/double-quoted-decoy fixtures calibrate
+   both bypass and false-positive directions. Heredoc classification is deliberately quantified by
+   delimiter and body-pattern class:
+
+   | Delimiter class | Literal command-position text | Expansion syntax |
+   | --- | --- | --- |
+   | quoted (`<<'EOF'`, `<<-"EOF"`, or any partially quoted word) | ignored | ignored because Bash does not expand the body |
+   | unquoted (`<<EOF` or `<<-EOF`) | ignored as data | parameter, command, backtick, and arithmetic expansions are scanned |
+
+   Each of these four cells has separate accepting and rejecting fixtures (eight fixtures total).
+   The rejecting controls also establish that executable code immediately after a terminator remains
+   visible. Thus heredoc exclusion applies to literal data, not to expansions Bash executes in an
+   unquoted body.
+
+   This lint's detection claim is deliberately limited to direct syntactic feature use. Dynamic
+   execution through `eval` or a variable-expanded command word is outside the static-detection
+   boundary and is not included in the detection claim. Selftests pin literal `eval` and variable
+   command examples as expected non-detections so this boundary cannot be mistaken for implicit
+   coverage. Local macOS development requires `brew install shellcheck`; a missing executable fails
+   the lane instead of skipping it. CI's ShellCheck version is authoritative; CI detects findings
+   that a different local version does not report, and the checker records the version it used.
    Repository-root `CHANGELOG.md` is deliberately outside that scope because it is an immutable
    historical record whose old section names must not make current automation fail.
 

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -443,6 +443,15 @@ attempts=1,2,1 shards=1,2,3` and `check-shard-artifact-cohort: PASS --
 lane=semantic-mutation-operators run_id=32798975136 attempts=1,2,1 shards=1,2,3`. This satisfies the
 probe precondition above; the probe commit itself was then removed from the branch.
 
+**First natural production observation (recorded 2026-08-26, run `32931874941` on PR #908).**
+A docs-only PR's `rust tests (3/3)` shard failed on a GitHub-side transient — five
+`ArtifactService/ListArtifacts` and `CreateArtifact` request timeouts with the tests themselves
+green — exactly the transient class this design targets. `gh run rerun --failed` re-ran only that
+shard; attempt 2 completed `success` overall and the aggregator accepted the mixed cohort:
+`check-shard-artifact-cohort: PASS -- lane=rust-tests run_id=32931874941 attempts=1,1,2
+shards=1,2,3`. Before this design, that recovery would have required a full ~60-minute re-run of
+every shard.
+
 **Agent-configuration-exempt pull requests still work.** Every shard job runs
 `check-product-gate-scope.sh` itself and early-exits its own later steps when `run=false`, so the
 shard's job result is still `success` and no artifact is ever uploaded. Both aggregators therefore

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -247,30 +247,36 @@ A green corpus therefore said nothing about `fslc refine`. Before this manifest 
 `tools/check_rust_refinement_parity.py` comparison script that no workflow and no
 `tools/check-native-integration.sh` lane invoked. The other 22 were executed by
 nothing. `rust/fslc/tests/refine_corpus_parity.rs` is now the native owner; it derives
-the complete mapping roster and checks declared result, violation kind, and exit status. It does
-not yet own the Python harness's broader stable envelope projection (F6 in `RUST-PORTING.md`), so the script
-remains pending a complete observed-field comparison with reasoned, self-retiring exclusions.
+the complete mapping roster and checks the complete observed stable envelope projection plus exit
+status. Its only projection exclusion is the solver-selected `impl_trace` witness; the test states
+why that value cannot be compared while retaining all stable failure summaries, and fails if the
+excluded key disappears from both observed and expected envelopes. This closes F6 in
+`RUST-PORTING.md`; the Python compatibility script remains retained but is not a product or CI gate.
 
 `rust/fslc/tests/refine_corpus_parity.rs` owns the mapping corpus the way
-`tests/dialect_registry.py` owns the dialect corpus, on three rules:
+`tests/dialect_registry.py` owns the dialect corpus, on four rules:
 
 - **The roster is derived, never listed.** The test walks `specs/` + `examples/`
   for `refinement`-dialect files and requires each to hold a manifest row or an
   exclusion. Adding a mapping fails the test until it is registered, and a
   registered path that no longer exists fails as a stale entry. A hard-coded list
   is the shape #577 retired 28 stale instances of.
-- **Expectations are transcribed from declarations, not from output.** Each row
-  carries `declared_by`, the `path:line` of the README row, documented command
-  comment, or fixture header that states the expected verdict. Recording what the
-  binary prints would pin a defect as the contract the moment one exists — which
-  is exactly the state `examples/layers/return_impl_refines.fsl` is in
-  (issue #615). Where no declaration exists, the correct move is to write one, not
-  to transcribe a measurement. `depth` is deliberately *not* part of that contract:
-  it bounds the search rather than declaring the verdict, so it is taken from the
-  documented command line where one exists.
-- **Both channels, every row.** `result`, `kind`, and the process exit code are all
-  compared (#537 C4). An envelope that disagrees with its exit status is how #554
-  and #600 escaped.
+- **Verdict expectations are transcribed from declarations, not from output.** Each
+  row carries `declared_by`, the `path:line` of the README row, documented command
+  comment, or fixture header that states the expected `result`/`kind`. Recording an
+  observed verdict would pin a defect as the contract the moment one exists — which
+  is exactly the state `examples/layers/return_impl_refines.fsl` was in (issue #615).
+  Where no declaration exists, the correct move is to write one, not to transcribe a
+  measurement. The additional public envelope fields are necessarily an observed
+  contract and live in the reviewed projection golden; the test separately requires
+  its `result`/`kind` to agree with the declaration-backed row. `depth` is deliberately
+  *not* part of the declared verdict contract: it bounds the search rather than
+  declaring the verdict, so it is taken from the documented command line where one
+  exists.
+- **Both channels, every stable field.** The complete observed stable JSON envelope
+  and process exit code are compared (#537 C4). `impl_trace` alone is excluded for
+  the reason above, and the exclusion must match an emitted or expected key. An
+  envelope that disagrees with its exit status is how #554 and #600 escaped.
 - **The citation is checked, not trusted.** Where a mapping declares its own
   expectation in the gallery `expected-command`/`expected-result`/`expected-kind`
   header convention, the row must agree with it — including the `--depth` inside
@@ -279,7 +285,7 @@ remains pending a complete observed-field comparison with reasoned, self-retirin
   exists to prevent. It caught one on introduction: the `refinement_failed_map.fsl`
   row ran at depth 4 against a header declaring `--depth 3`.
 
-  22 of the 26 rows additionally carry a `declaration` anchor, and the harness
+  23 of the 27 rows additionally carry a `declaration` anchor, and the harness
   requires the cited file to still contain a line stating this row's verdict.
   That is what keeps each declaration single-owner. `governance_semantic_mapping`
   is declared by the broken *implementation* it maps
@@ -293,7 +299,7 @@ remains pending a complete observed-field comparison with reasoned, self-retirin
   than a verdict on one line; they are the manifest's residual trust.
 
 Depth is the one field the corpus is allowed to leave open, and where it is
-declared the declaration wins. 24 of the 26 rows run at the depth their README
+declared the declaration wins. 25 of the 27 rows run at the depth their README
 command line or fixture header states. The two that do not —
 `specs/bank_refines.fsl` and `specs/seat_refines.fsl` — had no documented command
 at all; each now carries one in its abstraction's header (`specs/bank.fsl:2-3`,

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -232,16 +232,24 @@ inputs.
   `fslc ai`/`db import`/domain replay) are out of scope by extension — the scan
   is `*.fsl` only.
 
+The frozen-Python compatibility checks are a separate developer-run boundary, not part of this
+conformance harness or any CI/product gate. The bounded command list lives in `RUST-PORTING.md`;
+its parser/kernel/snapshot comparisons preserve only explicitly shared compatibility projections
+and cannot waive native corpus, Kernel, replay, or Worker evidence.
+
 ## Refinement mapping manifest (#537 C4, issue #593)
 
 The corpus sweeps above are `check`-shaped, and `check` is structurally blind to a
 refinement mapping: a mapping file has no `state` block, so `fslc check` answers
 `semantics`/"spec has no state block" for one whether or not the mapping is sound.
-A green corpus therefore said nothing about `fslc refine`. Until this manifest only
-6 of the 28 corpus mappings had ever been run through `refine`, by a script
-(`tools/check_rust_refinement_parity.py`) that no workflow and no
+A green corpus therefore said nothing about `fslc refine`. Before this manifest only
+6 of the 28 corpus mappings had ever been run through `refine`, by the retained
+`tools/check_rust_refinement_parity.py` comparison script that no workflow and no
 `tools/check-native-integration.sh` lane invoked. The other 22 were executed by
-nothing.
+nothing. `rust/fslc/tests/refine_corpus_parity.rs` is now the native owner; it derives
+the complete mapping roster and checks declared result, violation kind, and exit status. It does
+not yet own the Python harness's broader stable envelope projection (F6 in `RUST-PORTING.md`), so the script
+remains pending a complete observed-field comparison with reasoned, self-retiring exclusions.
 
 `rust/fslc/tests/refine_corpus_parity.rs` owns the mapping corpus the way
 `tests/dialect_registry.py` owns the dialect corpus, on three rules:

--- a/docs/DESIGN-conformance-harness.md
+++ b/docs/DESIGN-conformance-harness.md
@@ -329,7 +329,8 @@ test:
 | Category | Owning test |
 |---|---|
 | kernel/dialect spec, bare `check` | `corpus_check_sweep.rs::every_corpus_spec_checks_ok_or_declares_its_error` |
-| `check`/`verify`/exit conservation law | `corpus_check_sweep.rs::check_result_and_exit_status_never_contradict` |
+| `check` envelope/exit conservation law | `corpus_check_sweep.rs::check_result_and_exit_status_never_contradict` |
+| `verify` envelope/exact-exit conservation law | `corpus_check_sweep.rs::verify_result_and_exit_status_never_contradict` |
 | `ledger` vs its `verify` baseline | `corpus_check_sweep.rs::ledger_exit_status_agrees_with_its_verify_baseline` |
 | refinement mapping | `refine_corpus_parity.rs` (this section, above) |
 | declared `examples/gallery/{valid,errors,adversarial}` fixture | `corpus_expectation_manifest.rs` |

--- a/docs/DESIGN-coupled-change-metatest.md
+++ b/docs/DESIGN-coupled-change-metatest.md
@@ -37,20 +37,29 @@ resolution, and the stdio lifecycle.
 
 ## 2. DESIGN-doc coverage (dialect/feature ↔ docs/DESIGN-*.md)
 
-`tests/test_coupled_change_meta.py` keeps three assertions whose inspected
-surfaces remain Python-owned or language-neutral:
+`tests/test_coupled_change_meta.py` keeps five tests whose inspected surfaces
+remain frozen-Python-owned or language-neutral:
 
-1. **README map is bidirectional** — the `DESIGN-*.md` links in
+1. **`test_retained_python_dialect_registry_matches_native_authority`** — the
+   frozen Python dialect registry exactly matches the native dispatch registry.
+   This is compatibility evidence, not an evolving language authority.
+2. **`test_native_ai_project_block_gate_matches_retained_parser`** — the native
+   AI project-block gate exactly matches the retained Python parser's block set.
+3. **`test_design_docs_readme_map_bidirectional`** — the `DESIGN-*.md` links in
    `docs/README.md` exactly match the design files on disk.
-2. **Frozen Python dialect registry remains explicit** — its registered
-   dialects and AI project blocks are compared with the native authority. This
-   is compatibility evidence, not an evolving language authority.
-3. **Frozen Python CLI map remains explicit** — every compatibility CLI command
-   maps to an existing design document or a reviewed waiver reason.
+4. **`test_top_level_dialects_map_to_design_docs`** — the frozen Python
+   grammar's `top_def` alternatives exactly match `TOP_DEF_DESIGN_DOCS`, and
+   every mapped design document exists.
+5. **`test_cli_commands_map_to_design_docs`** — every frozen Python
+   compatibility CLI command maps to an existing design document or a reviewed
+   waiver reason.
 
-These Python checks remain manual compatibility evidence. The native LSP corpus
-test runs as part of the Rust workspace and the required
-`./tools/check-native-integration.sh` product gate.
+These five Python tests run as required pre-merge repository/compatibility
+evidence through `tools/check-merge-readiness.sh automation` and the
+`merge readiness / automation contracts` job. They are not product evidence
+and are not invoked by the Rust-native `./tools/check-native-integration.sh`
+gate. The native LSP corpus/index test remains part of the Rust workspace and
+the required product gate.
 
 ## Non-goals
 

--- a/docs/DESIGN-docs-site.md
+++ b/docs/DESIGN-docs-site.md
@@ -226,15 +226,14 @@ readable in Japanese, accepting the resulting maintenance cost.
     and does not execute Python," and this check needs the third-party `markdown` package plus
     pytest. This check is not product evidence in `docs/DESIGN-ci.md`'s sense either — it protects
     a documentation artifact, not Rust/solver/Monitor behavior.
-  - Not `merge-readiness.yml`'s `automation-contracts` lane (or a new sibling lane inside that
-    workflow): that lane deliberately stays stdlib-only with no pytest and no third-party
-    dependency (`tools/check-merge-readiness.sh`'s `check_automation` comment). This is a
-    dependency-contract objection, not a latency one — measured, `automation-contracts` runs in
-    ~5s against `core-contracts`'s ~45s critical path (the three `merge-readiness.yml` lanes run
-    in parallel, so the workflow's wall-clock is set by the slowest lane), so adding a ~10s
-    pip-install-plus-pytest step there would cost the workflow zero wall-clock. What it would
-    cost is the lane's stdlib-only contract, which `tools/check-merge-readiness.sh` states is
-    deliberate independent of speed.
+  - At the time of this decision, not `merge-readiness.yml`'s `automation-contracts` lane (or a
+    new sibling lane inside that workflow): that lane was stdlib-only with no pytest or
+    third-party dependency. Later accepted CI decisions superseded that dependency assumption:
+    `merge readiness / automation contracts` now installs Python 3.12 and `.[dev]` and runs
+    parser-backed pytest calibration suites (`docs/DESIGN-ci.md`, "Automation contracts use
+    parser-backed workflow inspection"). The site snapshot remains in its standalone required
+    workflow because that workflow owns generated-reference freshness, not because the current
+    automation lane forbids Python or pytest.
 
   The new workflow covers all **4** generated pages (`language.{ja,en}.html` and
   `cli.{ja,en}.html`), not just the 2 `language.*` pages, because `test_site_reference_snapshot.py`
@@ -247,13 +246,13 @@ readable in Japanese, accepting the resulting maintenance cost.
   that; `#688` stays open and is the place that asymmetry gets decided, not this check.
 
   **This workflow is now enforced, and that costs nothing the placement above was protecting.**
-  The original objection conflated two different moves: joining this check to *another*
-  workflow's job graph, and requiring *this* workflow's own context on the ruleset. The first
-  would have broken a real contract — `ci.yml` is Rust-native by `AGENTS.md`'s "one Rust-native
-  entrypoint, no Python" clause, and `merge-readiness.yml`'s `automation-contracts` lane is
-  stdlib-only by `tools/check-merge-readiness.sh`'s own comment — and that objection still holds;
-  neither workflow gained a Python dependency. The second move breaks nothing: `site reference
-  freshness` runs as its own standalone workflow on every pull request with no path filter
+  The original placement distinguished joining this check to *another* workflow's job graph from
+  requiring *this* workflow's own context on the ruleset. The Rust-native `ci.yml` product gate
+  still cannot gain Python under AGENTS.md's "one Rust-native entrypoint, no Python" clause. The
+  later parser-backed automation-contract decision did add Python to merge readiness and therefore
+  superseded this section's separate stdlib-only premise; it did not change the site workflow's
+  ownership of generated-reference freshness. Requiring the standalone context breaks nothing:
+  `site reference freshness` runs as its own standalone workflow on every pull request with no path filter
   (`pull_request`/`merge_group`, unconditioned), so it cannot deadlock a pull request the way a
   deferred, `FSL_OPTIMISTIC_CI`-gated context would (`docs/DESIGN-ci.md`, "Ruleset drift audit").
   `.github/ruleset-contract.json` now lists it as the sixth required context alongside `merge

--- a/docs/DESIGN-document-dialect-adapters.md
+++ b/docs/DESIGN-document-dialect-adapters.md
@@ -56,7 +56,8 @@ honest v1:
   a plausible-looking document whose source-only declarations are silently
   unaccounted for.
 - **`compose` needs nothing new.** It is already rejected at two independent
-  layers: the Public Kernel export contract (`docs/DESIGN-kernel-contract.md`:
+  layers: the Public Kernel export contract in `docs/DESIGN-kernel-contract.md`
+  states that
   "Compose lowering currently loses the component filename... Public Kernel
   v1 therefore rejects `compose` input explicitly... A future schema version
   may add multi-source provenance once it is retained by the checked

--- a/docs/DESIGN-document-requirement-claim-ir.md
+++ b/docs/DESIGN-document-requirement-claim-ir.md
@@ -199,9 +199,9 @@ enforces that `MetaTag.id` never becomes an origin identity). Each claim carries
   `generated_from_source`, `generated_only`, `unknown`.
 
 **The origin registry (`OriginChain`/`OriginSite`) is sparse outside the domain
-dialect today** (`docs/DESIGN-kernel-origin-v2.md`: "the carrier is currently
-richest for the domain dialect"); a real `requirements`/`spec` spec's actions and
-properties routinely have zero bound `OriginChain`s. Relying on the registry alone
+dialect today** (`docs/DESIGN-kernel-origin-v2.md` records that "the carrier is
+currently richest for the domain dialect"); a real `requirements`/`spec` spec's actions
+and properties routinely have zero bound `OriginChain`s. Relying on the registry alone
 would report `unknown` for nearly every claim in the two dialects RCIR v1 targets,
 which is truthful but not useful. `provenance_for` therefore prefers the origin
 registry when it has a chain for a target (it is the richer signal where present,

--- a/docs/DESIGN-nested-option-support.md
+++ b/docs/DESIGN-nested-option-support.md
@@ -1,0 +1,597 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Issue #841: nested `Option` full-support implementation design
+
+Status: Accepted. Acceptance baseline: `155203331d95a12f912b39a84e8803fa79f45ed1`
+(current `HEAD` on 2026-08-27).
+
+## 1. Decision and scope
+
+The maintainer decision is option B: nested `Option` is a supported language
+capability. This document does not reconsider options A or C.
+
+The supported capability is recursive rather than special-cased at depth two:
+
+```text
+Scalar          ::= Int | Bool | Range | Domain | Enum
+OptionalScalar  ::= Scalar | Option<OptionalScalar>
+```
+
+Thus `Option<Option<Bit>>`, `Option<Option<Option<Bit>>>`, and the same
+`OptionalScalar` in an allowed struct field or Map value are legal. A fixed
+two-level implementation would merely move the current unsound cliff to depth
+three and is not acceptable.
+
+`Option<Struct>`, `Option<Set<_>>`, `Option<Map<_, _>>`,
+`Option<Seq<_, _>>`, `Option<relation _ -> _>`, nested structs, and collection
+fields in structs remain unsupported. Every surface form that resolves to one
+of those shapes must fail during `check`, with `kind: "type"`, exit 2, and the
+state/struct-field declaration `loc`. No verifier or runtime is allowed to be
+the first component to reject such a model.
+
+One-line semantic design:
+
+> Resolve the assignment target type before evaluating its right-hand side;
+> recursively encode each Option layer as `(present, payload)` in BMC and as
+> `None | Some(value)` concretely, then require BMC, Monitor, and explicit BFS
+> to agree on the three distinct states `none`, `some(none)`, and
+> `some(some(v))`.
+
+## 2. Evidence and present failure
+
+The following citations were re-read at the acceptance baseline.
+
+| Observation | Current evidence | Consequence |
+|---|---|---|
+| The written contract rejects nested Option | `docs/LANGUAGE.md:559-567`, `docs/LANGUAGE.ja.md:540-548`, and `skills/fsl/reference.md:736-750` | These three authorities must be changed to `OptionalScalar`; this is an intentional contract change, not silent drift. |
+| Syntax and public AST are already recursive | `rust/fsl-syntax/src/surface.rs:20-29`, `rust/fsl-syntax/src/parser.rs:1593-1631`, and `TypeExpr::kernel_ast_v1` at `surface.rs:732-747` | No grammar production or AST variant is needed. Parser preservation controls are still required. |
+| The resolved kernel model is already recursive | `rust/fsl-core/src/model.rs:18-49`; `resolve_type` at `model.rs:1337-1367`; defaults at `model.rs:214-247` | No new `FslValue` or `TypeRef` variant is needed. `Value`'s derived `Eq`/`Ord` already distinguishes the three values. |
+| Typechecking already propagates an assignment expectation | `rust/fsl-core/src/typecheck.rs:189-201`, `438-450`, and `952-967` | `x = some(none)` is correctly accepted for `x: Option<Option<T>>`; the verifier later discards that context. |
+| The documented state whitelist is not centrally enforced | The state builder at `rust/fsl-core/src/model.rs:603-678` rejects `Map<Int, _>` and resolves arbitrary `TypeExpr`, but has no total state-shape validation; the only recursive struct-field gate is `model.rs:1017-1058` | Add one exhaustive resolved-type gate. Do not infer safety from top-level parser/type counts. |
+| The BMC failure is an untyped inner `none` | `rust/fsl-verifier/src/eval.rs:65-76` evaluates `Some` without an expectation and emits `"some() requires a typed value"` at line 71 | The failure is contextual typing, not a missing symbolic Option representation. |
+| Comparison happens to work | Equality evaluates its opposite operand with `eval_expected` at `eval.rs:1533-1599`; that helper already recurses through `Some` | Preserve the comparison test, but do not mistake it for assignment coverage. |
+| Init and action assignment drop the expectation | `rust/fsl-verifier/src/transition.rs:443-456` and `579-599` call plain `eval`; `assign` only discovers/coerces to the target type later at `transition.rs:658-674` and sibling indexed/field arms | Determine the lvalue type first and call contextual evaluation before `assign`. |
+| Whole-struct and conditional expressions have the same sibling hole | `eval_struct_literal` calls plain `eval` before `coerce` at `eval.rs:1219-1244`; conditional branches call plain `eval` at `eval.rs:146-161` | Context propagation must cover constructors and branches, not only root-variable assignment. |
+| Symbolic representation and bounds already recurse | `rust/fsl-verifier/src/value.rs:20-62`, `719-742`, and `869-909`; induction bound discovery at `rust/fsl-verifier/src/induction.rs:103-114` | Reuse the representation; do not introduce an alternate nested-Option encoding. |
+| Concrete evaluation already preserves nesting | `rust/fsl-runtime/src/lib.rs:96-109` and `value_conforms` at `lib.rs:3707-3765` | Monitor requires controls, not a new value representation. |
+| Explicit BFS uses Monitor states and steps | `rust/fsl-runtime/src/explicit.rs:127-175`; the frontier/seen sets contain the concrete `State` | Explicit and Monitor are two execution surfaces but one concrete semantic lineage. |
+| Current verifier failure loses source location | `VerifyError` from the verifier is rendered as a generic semantics error in `rust/fslc/src/verification.rs:1122-1141` | Legal nested Option must no longer reach this path; illegal shapes must fail from a spanned `ModelError`. |
+| Ordinary state JSON collapses the new distinction | `rust/fsl-core/src/trace_json.rs:78-105` renders both `None` and `Some(None)` as `null`; replay input decodes `null` as the outer `None` at `rust/fslc/src/main.rs:15989-16065` | Full support requires a lossless ordinary trace/replay form while retaining legacy bytes for `Option<scalar>`. |
+| Conformance JSON is already lossless | `rust/fslc/src/lib.rs:412-490` recursively emits tagged Option values; `docs/DESIGN-kernel-contract.md:202-205` states the distinction | Preserve this separate, fully tagged contract and strengthen its exact assertions. |
+| Existing tests acknowledge but do not close the assignment gap | `rust/fsl-verifier/tests/expression_agreement.rs:250-268`, `rust/fslc/tests/kernel_contract.rs:207-247`, and `rust/fslc/src/coverage.rs:691-696,993-995` | Keep all three; add assignment-side and exact-value controls. |
+
+The reported path is therefore:
+
+```text
+checked assignment
+  -> typecheck knows Option<Option<T>>
+  -> transition::collect_init_statement / compute_statement calls eval(rhs)
+  -> eval(Some(none)) calls eval(none)
+  -> SymbolicValue::None has no ty()
+  -> eval.rs:71 VerifyError("some() requires a typed value")
+  -> generic CLI semantics error, no loc, exit 2
+```
+
+## 3. Normative state-type boundary
+
+### 3.1 Total resolved-type predicates
+
+Implement the boundary in `fsl-core` over resolved `TypeRef` and `TypeDef`,
+not by matching source strings and not independently in each engine. The
+implementation should use exhaustive `match` expressions without `_` arms.
+
+```text
+scalar(T) =
+  T is Int, Bool, Range, or Named(Domain|Enum)
+
+bounded_scalar(T) =
+  T is Bool, Range, or Named(Domain|Enum)
+
+optional_scalar(T) =
+  scalar(T), or T is Option<U> and optional_scalar(U)
+
+struct_value(T) =
+  T is Named(Struct fields) and every field type is optional_scalar
+
+legal_state(T) =
+  optional_scalar(T)
+  or struct_value(T)
+  or T is Map<K,V> and bounded_scalar(K)
+       and (optional_scalar(V) or struct_value(V))
+  or T is Set<K> and bounded_scalar(K)
+  or T is Seq<V,N> and scalar(V)
+  or T is Relation<A,B> and bounded_scalar(A) and bounded_scalar(B)
+```
+
+`Int` remains a scalar but is not a bounded collection key. `Option` is legal
+only through `optional_scalar`; it is never a generic wrapper around another
+otherwise-legal state shape. A named struct is legal only at the state root or
+as a Map value, never through `Option` and never as another struct field.
+
+This inventory covers every current `TypeRef` variant: `Int`, `Bool`, `Range`,
+`Named(Domain)`, `Named(Enum)`, `Named(Struct)`, `Option`, `Map`, `Set`, `Seq`,
+and `Relation`. Unknown named types continue to fail during resolution before
+the shape gate.
+
+### 3.2 Placement matrix
+
+| Placement | Legal examples | Rejected controls |
+|---|---|---|
+| State root | `Option<Option<Bit>>`, `Option<Option<Option<Bit>>>` | `Option<Box>`, `Option<Set<Bit>>`, `Option<Map<Id,Bit>>`, `Option<Seq<Bit,1>>`, `Option<relation Id -> Id>` |
+| Struct field | `Option<Option<Bit>>` | a struct field whose resolved type is struct, Set, Map, Seq, relation, or Option of any of those |
+| Map value | `Option<Option<Bit>>`, or a struct with `OptionalScalar` fields | Set, Map, Seq, relation, or Option-wrapped struct/collection |
+| Set element / Map key / relation endpoint | existing bounded scalar only | Option at any depth, struct, collection, and unbounded `Int` |
+| Seq element | existing scalar only | Option at any depth, struct, and collection |
+
+The same gate runs after type resolution for direct Kernel source and for
+dialect-lowered `KernelModel` construction. It must not leave a path by which a
+dialect can construct a model that source `check` would reject.
+
+### 3.3 Diagnostics
+
+For each rejected state field, return a `ModelError` at `field.span` before
+initializer or verifier execution. For a rejected struct field, retain the
+declaration span used by `model.rs:1020-1037`, because `TypeExpr` has no
+component span. The public result is:
+
+```json
+{
+  "result": "error",
+  "kind": "type",
+  "message": "state variable 'x' has unsupported state type",
+  "hint": "state types allow scalars, nested Option around a scalar, structs with those fields, Map<bounded scalar, scalar-or-nested-Option-or-struct>, Set<bounded scalar>, Seq<scalar,N>, and bounded-scalar relations; Option cannot wrap a collection or struct",
+  "loc": {"line": 3, "column": 3}
+}
+```
+
+The wording may be polished once, but tests must fix `kind`, nonempty actionable
+hint, and exact `loc`. Add the new message class to
+`verification_output::semantic_error_kind`; otherwise the model rejects at the
+right time but is mislabeled `semantics`. Update the existing struct-field hint
+from `Option<scalar>` to nested Option around scalar. CLI and shared LSP
+diagnostics must remain identical.
+
+## 4. Execution semantics
+
+### 4.1 Logical value
+
+For a scalar `T`, `Option<Option<T>>` has these disjoint logical values:
+
+| FSL value | Concrete `FslValue` | Symbolic representation |
+|---|---|---|
+| `none` | `None` | outer `present = false`; payload is the canonical default of `Option<T>` and is semantically ignored |
+| `some(none)` | `Some(None)` | outer `present = true`; inner `present = false`; scalar payload is canonical default and ignored |
+| `some(some(v))` | `Some(Some(v))` | both presence bits true; scalar payload is `v` |
+
+Equality is recursive logical equality: presence bits must agree and payloads
+are compared only when the corresponding presence bit is true. Bounds likewise
+apply only under every enclosing `present`. Existing `logical_equal`, `coerce`,
+`bounds`, and `has_bounds` already implement that recursion and remain the one
+semantic definition.
+
+### 4.2 Contextual symbolic evaluation
+
+Add `KernelModel::state_lvalue_type(&LValue) -> Result<TypeRef, ModelError>` in
+`fsl-core` as the one target-type lookup. It starts only from `model.state` and
+`model.types`, covers root, Map/Relation index, root struct field, and Map-value
+struct field targets, and does not validate the index expression itself.
+Typechecking validates the index separately and translates
+this helper's error to its authored statement span; the verifier translates it
+to `VerifyError`. The verifier must not rediscover the target type differently
+from the checked model.
+
+Expose the existing evaluator helper within `fsl-verifier` as
+`pub(crate) eval_expected(expr, expected)` and make it the contextual entry
+point:
+
+1. `none` expected as `Option<U>` becomes a typed symbolic Option with
+   `present=false` and `default(U)` payload.
+2. `some(e)` expected as `Option<U>` becomes a typed symbolic Option with
+   `present=true` and `eval_expected(e, U)` payload.
+3. A struct constructor evaluates every field with its declared field type.
+4. Both branches of a conditional are evaluated with the same expected type
+   before `ite_value` joins them.
+5. Set/Seq/empty-relation literals retain their existing expected collection
+   coercion behavior.
+6. All other expressions use ordinary `eval` followed by the existing
+   `coerce`.
+
+Both init and action assignment resolve the target expectation first, evaluate
+the RHS with it, and then call `assign`. This covers inline initializers because
+`model.rs:655-665` normalizes them to init assignments. Apply the same rule to
+root, indexed, field, and Map-value field assignments; a fix only in the root
+arm is incomplete.
+
+Uncontextualized `none` and `some(none)` remain invalid where the typechecker
+has no expected type, such as a type-less local expression. That is not a
+runtime/verifier error path: checked-model construction must reject it with the
+authored expression span.
+
+### 4.3 Monitor and explicit BFS
+
+Monitor keeps `Expr::Some(e) -> Value::Some(eval(e))` and recursively checks
+`value_conforms`. Add no second normalization layer. Its accepting controls
+must show the exact sequence `None -> Some(None) -> Some(Some(1)) -> None`.
+
+Explicit BFS continues to store full concrete `State` values in `frontier`,
+`seen`, and `parents`, and to obtain successors through `Monitor`. Since
+`FslValue` derives `Eq` and `Ord`, the three values remain distinct during
+deduplication and trace reconstruction. A dedicated wiring detector must still
+prove that explicit exploration inserts the Monitor successor rather than its
+parent; sharing the evaluator does not prove correct BFS wiring.
+
+### 4.4 Three-way agreement and the triangulation boundary
+
+Use `rust/fslc/tests/typed_agreement/engines.rs::compare_agreement` as the main
+three-surface control. It already compares Monitor BFS, explicit, and BMC
+verdicts/reachable steps/action coverage, replays evidence, and sends sampled
+Monitor successors through `transition_matches_step`. Add the nested-Option
+case and exact concrete state assertions instead of inventing another partial
+comparator.
+
+This is an engine-agreement claim, not a `TriangulatedClaim` under
+`docs/DESIGN-triangulated-assurance.md`. Monitor, Monitor BFS, and explicit all
+share `fsl_runtime::eval`; the existing inventory correctly records only two
+semantic lineages: concrete and symbolic. Therefore this work must not label
+three process surfaces as three independent observers. If a future change
+claims triangulation, it must separately preserve a raw observation, declare
+two independent decision lineages, execute model-world/oracle-world/model-oracle
+edges, and calibrate them as required by that accepted design.
+
+## 5. Lossless public observation and replay
+
+Full language support is incomplete if engines distinguish `none` from
+`some(none)` internally but ordinary traces, generated harnesses, or replay
+collapse them. Preserve the legacy `null`/value bytes for `Option<scalar>` and
+introduce a tag only when the declared payload is itself an Option:
+
+| Type and value | Canonical ordinary JSON |
+|---|---|
+| `Option<T> = none` | `null` |
+| `Option<T> = some(1)` | `1` |
+| `Option<Option<T>> = none` | `null` |
+| `Option<Option<T>> = some(none)` | `{"kind":"some","value":null}` |
+| `Option<Option<T>> = some(some(1))` | `{"kind":"some","value":1}` |
+| `Option<Option<Option<T>>> = some(some(none))` | `{"kind":"some","value":{"kind":"some","value":null}}` |
+
+The canonical typed rule is:
+
+```text
+encode(Option<U>, None)       = null
+encode(Option<U>, Some(v))    =
+  {"kind":"some","value":encode(U,v)}  if U resolves to Option<_>
+  encode(U,v)                               otherwise
+```
+
+The implementation may retain the current untyped `fsl_value_json` API by
+recognizing a concrete `Some` whose payload is `None|Some`, because unsupported
+`Option<struct/collection>` is removed by the state gate. Decoding must remain
+type-directed. For expected `Option<Option<_>>`, accept only `null` or the exact
+closed `{kind:"some", value:...}` object and recurse; reject missing/extra keys
+and a noncanonical untagged non-null value. For expected `Option<scalar>`, keep
+the legacy `null`/value decoder.
+
+Do not detect an Option tag by object field names while recursively diffing
+JSON: a legal struct can itself have `kind` and `value` fields. Compute trace
+changes from typed `FslValue`/`TypeRef`, or mark Option values atomically before
+generic object descent. The expected change path remains the logical state path
+`x`, not `x[kind]` or `x[value]`. `state_summary` must render nested values as
+`some(none)` / `some(some(1))`, not `null`.
+
+The existing conformance-vector format remains fully tagged at every Option
+layer (`{"kind":"none"}` / `{"kind":"some","value":...}`); it is a separate
+versioned contract and must not be changed to the hybrid ordinary form.
+Public-Kernel type JSON is already recursively typed and requires no schema
+major bump. Replay/testgen state schemas already admit arbitrary state-value
+JSON objects, so their schema identifiers remain unchanged; their design docs
+must define the newly canonical nested-Option value. Add schema/golden tests to
+prove that this is an additive representation for a newly supported type and
+that every previously supported `Option<scalar>` byte stays unchanged.
+
+## 6. Coupled-surface inventory (25 surfaces)
+
+“No change” means the surface was inspected and has an executable preservation
+control; it does not mean it may be omitted from review.
+
+| # | Surface | Current disposition and required change |
+|---:|---|---|
+| 1 | Grammar and surface AST (`rust/fsl-syntax`) | Recursive already; no production/variant change. Add depth-3 parse/Kernel-AST preservation. |
+| 2 | Type resolution/lowering (`fsl-core::resolve_type`) | Recursive already; no representation change. Verify direct and dialect-lowered models pass the same gate. |
+| 3 | Typed model/defaults/state-shape gate (`rust/fsl-core/src/model.rs`) | Add the exhaustive `legal_state` gate and reuse `optional_scalar` for struct fields. Preserve recursive defaults. |
+| 4 | Typechecking/pattern binding (`rust/fsl-core/src/typecheck.rs`) | Preserve recursive expected typing and `is some(v)` binding (`v` has the inner Option type). Share target-type lookup with verifier. |
+| 5 | Symbolic expression semantics (`rust/fsl-verifier/src/eval.rs`) | Generalize contextual evaluation for Option, struct fields, and conditionals. |
+| 6 | Symbolic init/action transitions (`rust/fsl-verifier/src/transition.rs`) | Evaluate every assignment RHS against its target type before assignment/coercion. |
+| 7 | Symbolic bounds, induction, refinement, and trace projection | Existing recursion is preserved; add nested bounded-domain and refinement/trace controls so a sibling walker cannot stay hollow. |
+| 8 | Concrete Monitor (`rust/fsl-runtime/src/lib.rs`) | No representation change; add exact nested-value, pattern-binding, and assignment controls. |
+| 9 | Explicit BFS (`rust/fsl-runtime/src/explicit.rs`) | No alternate semantics; add exact successor/closure/witness control and wiring mutation. |
+| 10 | Public Kernel AST/type export and v1/v2 schemas | Recursive `option.item` already exists; preserve golden bytes for prior types and add nested recursive schema validation. |
+| 11 | Conformance vectors and coverage (`rust/fslc/src/lib.rs`, `coverage.rs`) | Keep fully tagged form; strengthen current broad `kind == some` assertion to exact `some(none)` and `some(some(1))`. |
+| 12 | Ordinary value/state/trace JSON, summaries, and changes (`fsl-core::trace_json`) | Add the canonical hybrid nested tag, type-safe diff behavior, and exact round trips. |
+| 13 | Replay, testgen trace, and generated target adapters (`rust/fslc`) | Extend type-directed snapshot decode; ensure generators compare the nested object without flattening. Update replay/kernel contract docs. |
+| 14 | Native CLI diagnostics/envelope/exit | Add `type` classification and hint for the centralized gate; legal verification must no longer expose the unlocated verifier error. |
+| 15 | Browser Worker (`rust/fsl-wasm`) | Shared verifier/output should inherit behavior; add native/Worker JSON parity and nested trace rendering controls. No native-Z3 dependency. |
+| 16 | Regression/agreement/fault-operator infrastructure | Add focused three-way cases, rejecting matrix, exact comparator checks, and registered implementation fault operators. |
+| 17 | `docs/LANGUAGE.md` | Replace `Option<scalar>` with recursively defined optional scalar; remove nested Option from the prohibition while retaining all other exclusions. |
+| 18 | `docs/LANGUAGE.ja.md` | Make the section-aligned 1:1 Japanese change; retain the same 18 `##` sections in the same order. |
+| 19 | Generated site references (`docs/intro/language.{en,ja}.html`) | Regenerate with `tools/build_site_reference.py`; freshness CI remains the authority for generated bytes. |
+| 20 | `skills/fsl/reference.md` | Update the type table, struct note, and whitelist to `OptionalScalar`; state the unsupported wrappers explicitly. |
+| 21 | Accepted design notes | Add `docs/DESIGN-nested-option-support.md`; mark only the nested-Option rejection sentence in `docs/DESIGN-option-struct.md:10-13` as superseded, retaining its v2.1 history. Update replay/kernel design notes for the ordinary/tagged boundary. |
+| 22 | `changelog.d/` | Add `changelog.d/841-nested-option.added.md`; do not edit `CHANGELOG.md`. |
+| 23 | LSP (`rust/fsl-lsp/src/index.rs` and diagnostic tests) | No new declaration, binder, or reference form: `Option` is already a keyword and nested `some` uses the existing pattern binder. No index code change; update CLI/LSP diagnostic identity tests for rejected shapes. |
+| 24 | Dialect registry (`tests/dialect_registry.py`) | No new top-level construct, dialect, or `specs/`/`examples/` directory. No registry edit; record this reviewed no-change disposition. |
+| 25 | Frozen Python compatibility reference (`src/fslc`) | No product behavior change. Native Rust is authoritative and this feature is not an explicitly requested compatibility change. Any observed difference is documented, not “fixed” in Python. |
+
+## 7. Executable controls and calibration
+
+### 7.1 Accepting controls
+
+Use a checked fixture with a deterministic cycle and two reachability goals:
+
+```fsl
+spec NestedOptionAssignment {
+  type Bit = 0..1
+  state { x: Option<Option<Bit>> }
+  init { x = none }
+
+  action wrap() {
+    requires x == none
+    x = some(none)
+  }
+  action fill() {
+    requires x == some(none)
+    x = some(some(1))
+  }
+  action clear() {
+    requires x == some(some(1))
+    x = none
+  }
+
+  invariant Shape {
+    x == none or x == some(none) or
+    x == some(some(0)) or x == some(some(1))
+  }
+  reachable Wrapped { x == some(none) }
+  reachable Filled { x == some(some(1)) }
+}
+```
+
+At depth 3, require:
+
+1. direct Monitor steps equal `None`, `Some(None)`, `Some(Some(Int(1)))`,
+   `None` in order;
+2. a test-only Monitor traversal reaches exactly the three logical states;
+   explicit reaches closure and witnesses `Wrapped` at step 1 and `Filled` at
+   step 2 without exposing its internal state-count as a language contract;
+3. BMC produces the same reachability steps and clean verdict;
+4. `transition_matches_step` accepts both concrete successors and rejects a
+   deliberately substituted `None` for `Some(None)`;
+5. a companion invariant-violation fixture after `fill` makes explicit and BMC
+   compare the complete trace, and both traces replay through Monitor;
+6. ordinary JSON and replay round-trip the three distinct values; conformance
+   JSON emits exact fully tagged counterparts.
+
+Add placement cases for inline init, root assignment, Map index assignment,
+struct-field assignment, whole-struct construction, Map-value struct field,
+and a conditional whose branch is `some(none)`. Add one depth-3 nested Option
+case to prove recursion rather than a two-level special case. Add a bounded
+payload case to exercise conditional bounds and induction.
+
+The existing comparison-only test, conformance test, and coverage detail are
+retained. The comparison test remains a preservation control. The conformance
+test is strengthened from “some exists” to exact nested tags, but it is not
+presented as BMC coverage. A new assignment control owns that claim.
+
+### 7.2 Rejecting controls
+
+A table-driven `check` test covers every unsupported family in section 3,
+including direct state, struct-field, and Map-value positions. For every row it
+asserts the full stable result:
+
+```text
+process exit = 2
+result       = error
+kind         = type
+message      = exact selected wording
+hint         = exact actionable wording
+loc          = exact authored declaration line/column
+```
+
+The core control calls `build_model` directly and proves rejection before any
+verifier API is invoked. CLI and LSP receive the same source and compare
+message/kind/span/hint exactly.
+
+### 7.3 Comparison scope
+
+Compare stable semantic observations in full: verdict/result, violation kind
+and name, reachable names and witness steps, action coverage, logical state,
+action/params, property/action locations, trace changes, replay result,
+closure, and comparable depth. Build any exclusion list from actual emitted
+objects, and fail if an excluded key is absent on both sides.
+
+Do not compare `cost`, elapsed time, solver statistics, cache provenance, or
+`states_explored` for equality across engines. Check such ambient fields only
+for their declared type/range/membership. In particular,
+`typed_agreement/inventory.v1.json` already records that BMC has no concrete
+state-count analogue; this change must not turn `states_explored` into language
+semantics. Run every new or changed control twice in the same session.
+
+### 7.4 Detector mutations
+
+Register the seven implementation-seam mutations below as minimal patches
+under `rust/fslc/tests/fault_operators/`; keep the comparator corruption as its
+existing in-process test-only control. Each mutation is isolated; report the
+produced value beside the expected value. After each manual calibration,
+revert and prove exact equality to the named baseline with `git diff --exit-code
+155203331d95a12f912b39a84e8803fa79f45ed1 -- <paths>` (or the implementation
+PR's recorded pre-mutation commit).
+
+| Detector label | Isolated mutation | Expected detector observation |
+|---|---|---|
+| Symbolic context detector | Change the new assignment call from `eval_expected(rhs,target_ty)` back to plain `eval(rhs)` | Produced `Err("some() requires a typed value")`; expected clean agreement and `Wrapped@1`. The new assignment test fails; the old equality test may keep passing and is explicitly the blind preservation control. |
+| Recursive Option detector | In the expected `Some` arm, evaluate the child without its inner expectation | Depth-2/3 construction produces the same untyped error or a type mismatch; expected `Some(None)` / depth-3 state. The depth-3 case prevents a depth-2 patch from masquerading as recursion. |
+| Concrete wrapper detector | Mutate concrete `Expr::Some(e)` to return `eval(e)` without `Value::Some` | Produced state after `wrap` is `None`; expected `Some(None)`. Exact Monitor state and successor-admission tests fail. |
+| Explicit wiring detector | Insert/requeue the parent state instead of the Monitor successor in explicit exploration | Produced closure lacks `Wrapped@1`/`Filled@2`; expected both witnesses. Monitor and symbolic direct controls remain green, showing the detector owns explicit wiring. |
+| State-shape gate detector | Remove the `Option` payload rejection for one collection branch | Produced `check` exit 0 for `Option<Set<Bit>>`; expected exit 2/type/located error. The corresponding table row fails. |
+| Diagnostic-location detector | Drop `.at(field.span)` from the new state-shape error | Produced correct type message with absent `loc`; expected exact `loc`. CLI/LSP identity test fails for the right field. |
+| Ordinary JSON detector | Restore unconditional `Some(v) => fsl_value_json(v)` flattening | Produced `none == null` and `some(none) == null`; expected `null` versus `{"kind":"some","value":null}`. Exact JSON, changes-path, testgen, and replay round-trip controls fail. |
+| Comparator detector | Corrupt one normalized BMC reachable step or nested state after observation, before comparison | Produced `Filled` step/state differs; expected exact equality. The comparator's existing negative-control pattern rejects the corruption. |
+
+Each registered operator names a primary failing target and an unrelated blind
+target, as required by `operators.txt`. A patch that stops applying is a loud
+failure. A preservation control that remains green is reported only as a blind
+control, never as the detector.
+
+## 8. Four-PR implementation sequence
+
+Each PR stays at roughly 300 authored logical lines or less and has one review
+topic. Generated HTML and schema/golden bytes are reported separately from the
+authored-line budget. Each semantic PR includes a narrow regression test; PR 4
+hardens and calibrates the controls rather than leaving earlier behavior
+untested.
+
+### PR 1 — typed boundary and three-engine semantics (about 280 lines)
+
+Changes:
+
+- add recursive `optional_scalar` / total `legal_state` validation and located
+  type diagnostics;
+- share target-type lookup and use contextual RHS evaluation for init/action,
+  index, field, constructor, and conditional paths;
+- add narrow core/verifier/runtime regressions for root assignment and rejected
+  shapes.
+
+Verification, with the new focused tests run twice:
+
+```bash
+cargo fmt --manifest-path rust/Cargo.toml --all -- --check
+cargo test --manifest-path rust/Cargo.toml --locked -p fsl-core --test state_type_boundary nested_option_state_shape -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fsl-verifier --test transition_agreement nested_option_assignments_are_context_typed -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fsl-runtime --test explicit_engine nested_options_remain_distinct -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fsl-core --test state_type_boundary nested_option_state_shape -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fsl-verifier --test transition_agreement nested_option_assignments_are_context_typed -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fsl-runtime --test explicit_engine nested_options_remain_distinct -- --exact
+./tools/check-native-integration.sh fsl-logic pr
+```
+
+The test names above are the names to create; they are deliberately stable
+contract labels, not existing claims.
+
+### PR 2 — lossless JSON, replay, testgen, and Worker projection (about 280 lines)
+
+Changes:
+
+- implement the canonical ordinary nested-Option encoding, typed decode,
+  logical change path, and summary;
+- preserve fully tagged conformance encoding and legacy `Option<scalar>` bytes;
+- add exact replay/testgen/conformance and native/Worker rendering controls.
+
+Verification, with each focused changed control repeated:
+
+```bash
+cargo fmt --manifest-path rust/Cargo.toml --all -- --check
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test kernel_contract conformance_distinguishes_nested_options_and_guard_partials -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test replay_trace_contract nested_option_state_round_trips_without_flattening -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test testgen_contract nested_option_expected_state_is_lossless -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fsl-wasm tests::nested_option_trace_matches_native_encoding -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test kernel_contract conformance_distinguishes_nested_options_and_guard_partials -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test replay_trace_contract nested_option_state_round_trips_without_flattening -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test testgen_contract nested_option_expected_state_is_lossless -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fsl-wasm tests::nested_option_trace_matches_native_encoding -- --exact
+./tools/check-native-integration.sh fsl-logic pr
+```
+
+### PR 3 — normative docs and coupled surfaces (about 220 authored lines)
+
+Changes:
+
+- update both language references, skill reference, accepted nested-Option
+  design note, replay/kernel design boundary, and old-note supersession;
+- regenerate both language site pages;
+- add the changelog fragment and update the shared CLI/LSP diagnostic test;
+- record no-change dispositions for LSP indexing, dialect registry, and frozen
+  Python in the PR description.
+
+Verification:
+
+```bash
+python3 tools/build_site_reference.py
+python3 -m pytest tests/test_site_reference_snapshot.py -v
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test lsp_diagnostic_contract
+python3 -m pytest tests/test_site_reference_snapshot.py -v
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test lsp_diagnostic_contract
+./tools/aggregate_changelog.sh check
+cargo fmt --manifest-path rust/Cargo.toml --all -- --check
+```
+
+The site snapshot test is the required EN/JA section-count/order/freshness
+check. The Python package remains frozen; using its docs generator is not a
+Python language-semantics change.
+
+### PR 4 — calibrated cross-engine and fault controls (about 290 lines)
+
+Changes:
+
+- add the clean and violating nested fixtures to `typed_agreement`, exact
+  state/successor comparison, placement matrix, and unsupported-shape matrix;
+- register the minimal source fault operators from section 7.4;
+- update the typed-agreement inventory only for actual observed/excluded keys.
+
+Verification:
+
+```bash
+cargo fmt --manifest-path rust/Cargo.toml --all -- --check
+cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test typed_agreement nested_option_assignment_agrees_across_all_engines -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test cli_regression unsupported_nested_option_payloads_fail_check_with_locations -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test typed_agreement nested_option_assignment_agrees_across_all_engines -- --exact
+cargo test --manifest-path rust/Cargo.toml --locked -p fslc-rust --test cli_regression unsupported_nested_option_payloads_fail_check_with_locations -- --exact
+./tools/check-native-integration.sh fault-operators
+./tools/check-native-integration.sh fsl-logic scheduled
+cargo test --manifest-path rust/Cargo.toml --workspace --locked
+cargo build --manifest-path rust/Cargo.toml --workspace --locked
+./tools/check-native-integration.sh
+```
+
+The last command is the complete product gate and remains required for the
+merged `main` state and release promotion even if merge-readiness evidence is
+already green.
+
+## 9. Risks and mitigations
+
+| Risk | Why it matters | Mitigation / evidence |
+|---|---|---|
+| **Most important: semantic state is losslessly distinct internally but flattened at the public JSON/replay boundary** | A false agreement can be reported while `none` and `some(none)` replay as the same state; generated adapters can accept a wrong implementation. | Canonical hybrid encoding, exact state/change/replay/testgen controls, and the JSON-flattening fault operator. |
+| Context is fixed only for root assignment | Struct literals, conditionals, Map entries, or field updates retain the fail-late error. | One contextual evaluator; placement matrix across every lvalue/constructor path. |
+| A depth-2 special case is shipped | Depth 3 recreates the same hollow accepted construct. | Recursive predicates/evaluation and an explicit depth-3 accepting/mutation control. |
+| The generic recursive type model admits unsupported containers | Solver/runtime code may later crash or, worse, appear verified without supported semantics. | Total resolved-type whitelist with one rejecting row per `TypeRef` family and located diagnostics. |
+| Three processes are mistaken for three independent semantics | Monitor BFS and explicit can share the same wrong evaluator and outvote BMC in rhetoric. | No majority voting; identify two semantic lineages; compare every required edge; do not claim triangulation. |
+| Payload defaults constrain absent Options | A solver may accidentally require an absent inner scalar to be in range, causing false negatives. | Preserve `present => bounds(payload)` recursively and mutate/check bounded nested payloads. |
+| Trace object tags collide with ordinary struct fields | A generic JSON walker can emit `x[kind]` and hide the logical Option change. | Type/value-aware change computation; exact logical-path assertion. |
+| Existing `Option<scalar>` clients see a breaking byte change | Always-tagged output would silently break replay and generated adapters. | Tags only when the payload type is Option; byte-for-byte legacy golden preservation. |
+| Ambient counters make agreement flaky or become de facto semantics | Cache, backend, and traversal order can change counts without a language change. | Exact stable projection, membership checks for ambient fields, dead-exclusion checks, and two runs per changed control; never equate `states_explored` across engines. |
+| State-space cost grows with Option depth | `Option^n<T>` has additional presence combinations and can increase explicit/BMC cost. | Keep budgets/cost as operational observations, add small depth-3 probes, and use scheduled tier for breadth; do not cap the language at depth 2 without a separate contract decision. |
+
+## 10. Completion criteria
+
+The implementation is complete only when all of the following are true:
+
+1. every legal placement in section 3 checks and executes without a verifier
+   typing error;
+2. BMC, Monitor, and explicit produce the exact distinctions and agreement in
+   section 7, including replayable traces;
+3. every unsupported family fails `check` with the authored declaration `loc`
+   and never reaches a solver/runtime;
+4. ordinary and conformance JSON each follow their documented, distinct
+   canonical forms, and existing `Option<scalar>` bytes do not change;
+5. all 25 coupled surfaces have their specified change or reviewed no-change
+   control;
+6. every named detector has been executed against its isolated mutation, its
+   produced/expected values recorded in the PR evidence, and its exact revert
+   proved;
+7. the focused controls pass twice, the scheduled FSL-logic lane passes, and
+   the complete native integration gate passes.
+
+There is no remaining product-policy question in this design. The only fixed
+choice is full recursive support for nested Option around scalar payloads;
+expanding Option to structs or collections would be a separate language
+change.

--- a/docs/DESIGN-replay-trace.md
+++ b/docs/DESIGN-replay-trace.md
@@ -144,10 +144,12 @@ JSON false mismatches.
 ## Compatibility and adjacent trace formats
 
 The pre-v1 bare array and `{ "events": [...] }` action-only shapes remain an
-explicit unversioned compatibility adapter. They retain current action/display
-name matching and do not claim snapshot evidence. Migration consists of adding
-the v1 root, recording complete init, numbering events, and recording every
-complete post-state. No heuristic conversion or fallback is performed.
+explicit unversioned compatibility adapter. The object form is closed: its root
+contains exactly the single `events` key, and that key's value is an array. They
+retain current action/display name matching and do not claim snapshot evidence.
+Migration consists of adding the v1 root, recording complete init, numbering
+events, and recording every complete post-state. No heuristic conversion or
+fallback is performed.
 
 `testgen-trace.v1` is a fixed-seed generated-test oracle with `steps[].expected`;
 verifier counterexample trace JSON carries source locations and changes. Neither

--- a/docs/DESIGN-rust-component-internals.md
+++ b/docs/DESIGN-rust-component-internals.md
@@ -584,7 +584,12 @@ altered symbolic successors, and corrupted outcome evidence. A refinement contro
 prefilter and `Monitor::step` disagree deliberately and reject the result rather than report
 `abs_requires_failed` as a trustworthy refinement failure.
 
-The legacy `bfs` currently has only its bundled `fsl-bfs` binary consumer and no Rust agreement test.
+The legacy `bfs` is exercised directly by `rust/fslc/tests/typed_agreement.rs` and its
+`typed_agreement/engines.rs` support, which compare Monitor, legacy BFS, explicit BFS, and BMC
+semantic outcomes. Its bundled `fsl-bfs` process driver also owns the focused runtime memory-ceiling
+contract. Earliest-deadlock and auxiliary witness-field agreement remain migration work before the
+old BFS/BMC Python harnesses can be retired; general cross-engine state-count equality is not a
+language contract.
 Before any runtime move, add a three-way anchor over the same finite deterministic models and depth:
 symbolic verification, direct Monitor enumeration, and legacy BFS must agree on accepted
 successors, bounded invariant/reachability verdicts, earliest deadlock, and action coverage. Its
@@ -944,10 +949,14 @@ rediscovering, one incident at a time, keys the frozen reference had never remov
 narrow `PROJECTED_KERNEL_KEYS` again should read that history first — the pre-migration behavior for
 `domain check` was "project nothing", not "project these sixteen".
 
-The difference survived from the migration to #663 because it lived *inside* `kernel`, and the parity
-harness covering these commands excludes that object from comparison
-(`tools/check_rust_phase3_commands.py`'s `project()`); the harness was also never wired into any
-runner. That blind spot is its own issue, #689, and it is still what hides #687.
+The difference survived from the migration to #663 because it lived *inside* `kernel`, and the
+parked developer-run comparison in `tools/check_rust_phase3_commands.py` excludes that object from
+comparison; the harness is not wired into any runner. It must not be deleted until its still-unowned
+`ai compare` metric/delta contract has a focused native owner. AI work is currently parked, so that
+prerequisite is follow-up work rather than part of #761's current deletion set. The historical blind
+spot is tracked by #689 and is still what hides #687; the authoritative DB/domain projection owners
+are `issue_663_kernel_projection_owner.rs`, `issue_600_db_check_folds_kernel_verdict.rs`, and
+`issue_515_domain_check_false_green.rs`.
 
 `rust/fslc/src/outcome.rs` owns the single answer: `classify_kernel_key(key: &str) ->
 Option<KernelKeyFate>`, its `PROJECTED_KERNEL_KEYS` emission order, and `project_kernel(kernel:

--- a/docs/DESIGN-rust-integration.md
+++ b/docs/DESIGN-rust-integration.md
@@ -34,8 +34,26 @@ part of the Rust product gate.
 The removed `tests/test_rust_cli_contract.py` compared the evolving Rust CLI with a frozen Python
 parser plus a large exception file. That made the frozen implementation a second authority. The
 native tests instead compare every live help path with the checked-in embedded contract and directly
-validate the published result/schema contracts. Existing Python parity utilities remain historical
-or explicitly invoked compatibility evidence only.
+validate the published result/schema contracts. No parity utility is deleted under #761's
+documentation phase. `check_rust_full_envelope.py` is eligible for deletion because calibrated
+native/Worker parity owns its named drift, but it remains until its `_diff`/`_normalize` helpers move
+without breaking three retained consumers. Seven other utilities remain deletion-deferred because
+their exact native contract gaps (F1–F7) are recorded in `RUST-PORTING.md`.
+`check_rust_phase3_commands.py` remains parked,
+outside every gate, until its
+unowned `ai compare` metric/delta projection receives a focused native contract test; AI work is
+currently parked. The five bounded manual utilities below are explicitly invoked compatibility
+evidence only; the seven F1–F7-deferred parity harnesses retain their existing detector role
+until the named native controls exist.
+
+That bounded manual suite is exactly `check_rust_ast_parity.py`,
+`check_rust_grammar_fuzz.py`, `check_rust_surface_parity.py`,
+`check_rust_kernel_parity.py`, and `check_rust_cli_snapshot.py`. Their scopes are respectively the
+registered expression fixture, deterministic seed-195 grammar sample, registered surface/error-
+location subset, Python-shaped compatible kernel projection, and provenance-recorded 190-entry CLI
+snapshot. They must not be generalized into product correctness claims or regenerated/allowlisted
+merely to accept native evolution. A nonzero result is an unresolved compatibility decision, not a
+native product failure and not permission to broaden exclusions.
 
 The checked-in `rust/fslc/cli-contract.json` is therefore native-authored authority, not a snapshot
 to regenerate from the frozen Python parser. It enumerates all 50 live native leaves, including the

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@
 | [`DESIGN-induction.md`](DESIGN-induction.md) | The k-induction engine (proved / unknown_cti / CTI) |
 | [`DESIGN-induction-lemmas.md`](DESIGN-induction-lemmas.md) | `verify --engine induction --lemma`: independent candidate proof, CTI exclusion/retry, JSON and cache contract |
 | [`DESIGN-explicit-engine.md`](DESIGN-explicit-engine.md) | `verify --engine explicit` (Rust-native): Z3-free concrete-state BFS, closure ⇒ `proved`, `unknown_budget` truncation, deterministic-init and binder-domain fail-closed gates; plus the `--engine auto` composite (explicit first, transparent BMC fallback, `engine`/`engine_fallback` tracking) |
+| [`DESIGN-bfs-bmc-native-migration.md`](DESIGN-bfs-bmc-native-migration.md) | Accepted #761 migration plan for replacing frozen-Python BFS/BMC parity with a checked native Monitor/legacy-BFS/explicit-BFS/BMC decision and bidirectional witness matrix |
 | [`DESIGN-literate.md`](DESIGN-literate.md) | Literate Markdown FSL: in-place blanking extraction of ` ```fsl ` fenced blocks, materialization, position-preserving diagnostics, scope boundaries (WASM waiver, LSP deferral) |
 | [`DESIGN-from-state.md`](DESIGN-from-state.md) | Predictive BMC from a complete Monitor/replay logical-state snapshot (`verify --from-state`), including type validation, faithfulness metadata, cache/symmetry boundaries, and induction exclusion |
 | [`DESIGN-trans.md`](DESIGN-trans.md) | `trans` (transition invariant / two-state safety) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@
 | [`DESIGN-seq.md`](DESIGN-seq.md) | Seq<T,N> (partial_op, type whitelist) |
 | [`DESIGN-seq-partial-operations.md`](DESIGN-seq-partial-operations.md) | Accepted Seq partial-operation semantics: out-of-prefix reads report `partial_op` consistently across engines while guarded short-circuit reads remain defined |
 | [`DESIGN-option-struct.md`](DESIGN-option-struct.md) | Option fields in structs |
+| [`DESIGN-nested-option-support.md`](DESIGN-nested-option-support.md) | Accepted #841 implementation plan for full recursive nested `Option` support, fail-closed state-type boundaries, lossless JSON/replay, and cross-engine agreement |
 | [`DESIGN-divmod.md`](DESIGN-divmod.md) | Integer division `/` and remainder `%` (total definition of division by zero, partial_op, Euclidean) |
 | [`DESIGN-forbidden.md`](DESIGN-forbidden.md) | `forbidden` (negative acceptance criteria / must-forbid) — detecting under-constraint |
 | [`DESIGN-vacuity.md`](DESIGN-vacuity.md) | Vacuity checking (invariants whose antecedent is unreachable, leadsTo whose trigger is unreachable, always-true requires) |

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -92,9 +92,22 @@ It also rejects a dynamic dependency on `libz3`.
    snapshot is regenerated, never hand-edited; any other change in that diff is
    a contract change that does not belong in a release commit.
 
+   Regenerate the induction contract golden for the same reason — it records each
+   envelope's `versions` block:
+
+   ```bash
+   UPDATE_INDUCTION_CLI_CONTRACT=1 \
+     cargo test --manifest-path rust/Cargo.toml -p fslc-rust \
+     --test induction_cli_contract --locked
+   ```
+
+   Apply the same review rule: version strings only. Skipping this fails the complete
+   product gate, not merge-readiness — observed on the v4.4.1 candidate, where
+   `induction_cli_contract` compared 4.4.0 against 4.4.1.
+
    **Steps 4–6 above touch `rust/Cargo.toml`, `rust/Cargo.lock`, the domain characterization
-   baseline, `editors/vscode/package.json`, and `editors/vscode/package-lock.json`.** The first
-   three are product surfaces under `tools/aggregate_changelog.sh`'s `is_product_surface_path`,
+   baseline, the induction contract golden, `editors/vscode/package.json`, and
+   `editors/vscode/package-lock.json`.** The first four are product surfaces under `tools/aggregate_changelog.sh`'s `is_product_surface_path`,
    and are exactly what `is_release_bump_path` names — the fixed set the merge-readiness
    `check-pr` gate exempts from needing a fragment once this diff's `CHANGELOG.md` edit is a
    validated release move (H1/F3; review, #737, comments 2026-08-07 third round and 2026-08-08

--- a/docs/RUST-PORTING.md
+++ b/docs/RUST-PORTING.md
@@ -137,8 +137,11 @@ and liveness verification, full native CLI envelopes, replay, scenarios,
 snapshot projection, and bidirectional counterexample gates all pass their
 declared corpora. Phase 2 is complete without changing these Phase-1 contracts.
 Phase 4's production Worker and cancellation/native-verdict gates are also
-complete. Phase 3 is complete: its large raw-output/report bodies and stable
-projections pass command-by-command parity without a Python command fallback.
+complete. Phase 3's historical Python/Rust comparison is not product evidence. Its
+script remains parked as a developer-run diagnostic because `ai compare` does not yet
+have a focused native metric/delta contract test; AI work is currently parked, so the
+missing owner is follow-up work. Native command tests and the Rust/WASM envelope
+comparison remain authoritative for the command families they own.
 The native release binaries provide `fslc` and `fslc-lsp`; the Python package
 remains available only as the frozen compatibility/parity oracle.
 
@@ -162,31 +165,68 @@ failure reporting, and release-blocking semantics.
 
 ## 5. Commands
 
+The current 17-harness disposition is authoritative for maintenance work:
+
+| Disposition | Harnesses | Preconditions / scope |
+|---|---|---|
+| Manual compatibility (5) | `ast_parity`, `grammar_fuzz`, `surface_parity`, `kernel_parity`, `cli_snapshot` | Run only for an intentional change to the named frozen-Python projection; never product-gate evidence. |
+| F1 deletion deferred | `corpus_cli_parity` | Bind every corpus `verify` result class to its process exit and calibrate a rejecting mutation. |
+| F2 deletion deferred | `dialect_parity` | Add focused induction output contracts for the business, requirements, and governance paths. |
+| F3 deletion deferred | `induction_parity` | Own the 16-case CLI stable fields/exits with explicit exclusions and negative controls. |
+| F4 deletion deferred | `leadsto_parity` | Add a native liveness-lasso replay matrix with isolated state/action/loop corruptions. |
+| F5 deletion deferred | `phase2_commands` | Assert `--keep-going` failure continuation and the human-readable `Layer` stderr table. |
+| F6 deletion deferred | `refinement_parity` | Compare the complete observed stable projection with reasoned exclusions and dead-exclusion checks. |
+| F7 deletion deferred | `replay_parity` | Add positive and rejecting native tests for the legacy unversioned `{ "events": [...] }` wrapper. |
+| Deletion-ready after helper move (1) | `full_envelope` | Native/Worker parity owns the detector; first move `_diff`/`_normalize` without breaking its three consumers. |
+| Parked (1) | `phase3_commands` | Add a focused native `ai compare` metric/delta contract; AI work is currently parked. |
+| Native migration phase (3) | `bfs_parity`, `bmc_parity`, `scenarios_parity` | Complete the native BFS/BMC/deadlock/reachability/action-coverage/witness matrix before deletion. |
+
 ```bash
-# Python reference AST is deterministic and covers the whole corpus.
+# Historical migration inventory; not a current product gate.
 PYTHONPATH=src python tools/export_ast.py --corpus --compact > /tmp/fsl-python-ast.json
 PYTHONPATH=src python tools/inventory_rust_port.py --check rust/phase0-inventory.json
 
-# Rust syntax checks and live Python↔Rust expression differential.
+# Authoritative native workspace checks.
 cd rust
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo test --workspace --locked
 cargo build --workspace --locked
 cd ..
+
+# Optional frozen-Python compatibility checks. Run only when intentionally changing
+# the named shared projection; none belongs to merge readiness, product, promotion,
+# or release gates, and none can waive native evidence.
 PYTHONPATH=src python tools/check_rust_ast_parity.py
+PYTHONPATH=src python tools/check_rust_grammar_fuzz.py
 PYTHONPATH=src python tools/check_rust_surface_parity.py
 PYTHONPATH=src python tools/check_rust_kernel_parity.py
+PYTHONPATH=src python tools/check_rust_cli_snapshot.py
+
+# A nonzero result requires an explicit compatible-subset decision. Do not turn
+# native-only evolution into a broad allowlist or regenerate the snapshot to pass.
+
+# Deletion deferred: related native coverage does not yet own the exact detector.
+# F1-F7 above name the required native controls for these seven scripts.
+PYTHONPATH=src python tools/check_rust_corpus_cli_parity.py --depth 3
+PYTHONPATH=src python tools/check_rust_dialect_parity.py
+PYTHONPATH=src python tools/check_rust_induction_parity.py
+PYTHONPATH=src python tools/check_rust_leadsto_parity.py --depth 5
+PYTHONPATH=src python tools/check_rust_phase2_commands.py
+PYTHONPATH=src python tools/check_rust_refinement_parity.py
+PYTHONPATH=src python tools/check_rust_replay_parity.py
+
+# Native owner confirmed, but deletion waits for shared-helper extraction because
+# dialect, induction, and Phase-2 tools import `_diff`/`_normalize` from this module.
+PYTHONPATH=src python tools/check_rust_full_envelope.py --depth 5
+
+# Awaiting native semantic migration; not part of the bounded manual suite above.
 PYTHONPATH=src python tools/check_rust_bfs_parity.py --depth 3
 PYTHONPATH=src python tools/check_rust_bmc_parity.py --depth 3
-PYTHONPATH=src python tools/check_rust_cli_snapshot.py
-PYTHONPATH=src python tools/check_rust_full_envelope.py --depth 5
-PYTHONPATH=src python tools/check_rust_leadsto_parity.py --depth 5
-PYTHONPATH=src python tools/check_rust_induction_parity.py
-PYTHONPATH=src python tools/check_rust_refinement_parity.py
 PYTHONPATH=src python tools/check_rust_scenarios_parity.py --depth 5
-PYTHONPATH=src python tools/check_rust_replay_parity.py
-PYTHONPATH=src python tools/check_rust_corpus_cli_parity.py --depth 3
+
+# Parked: not a gate and not safe to delete until `ai compare` has a focused native owner.
+PYTHONPATH=src python tools/check_rust_phase3_commands.py
 
 # Official npm backend spike.
 cd rust/spikes/z3js-worker

--- a/docs/RUST-PORTING.md
+++ b/docs/RUST-PORTING.md
@@ -175,7 +175,7 @@ The current 17-harness disposition is authoritative for maintenance work:
 | F3 deletion deferred | `induction_parity` | Own the 16-case CLI stable fields/exits with explicit exclusions and negative controls. |
 | F4 deletion deferred | `leadsto_parity` | Add a native liveness-lasso replay matrix with isolated state/action/loop corruptions. |
 | F5 deletion deferred | `phase2_commands` | Assert `--keep-going` failure continuation and the human-readable `Layer` stderr table. |
-| F6 deletion deferred | `refinement_parity` | Compare the complete observed stable projection with reasoned exclusions and dead-exclusion checks. |
+| F6 native-owned; harness retained | `refinement_parity` | `refine_corpus_parity` compares the complete observed stable projection, excludes only the solver-selected `impl_trace` witness with a stated reason, and rejects a dead exclusion. |
 | F7 deletion deferred | `replay_parity` | Add positive and rejecting native tests for the legacy unversioned `{ "events": [...] }` wrapper. |
 | Deletion-ready after helper move (1) | `full_envelope` | Native/Worker parity owns the detector; first move `_diff`/`_normalize` without breaking its three consumers. |
 | Parked (1) | `phase3_commands` | Add a focused native `ai compare` metric/delta contract; AI work is currently parked. |

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fsl-vscode",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fsl-vscode",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fsl-vscode",
   "displayName": "FSL",
   "description": "Language support for FSL specifications.",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "publisher": "fslc",
   "license": "Apache-2.0",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-core"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-syntax",
  "serde_json",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-lsp"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "crossbeam-channel",
  "fsl-core",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-runtime"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-core",
  "serde_json",
@@ -373,14 +373,14 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fsl-solver-z3"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-solver",
  "z3",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-solver-z3js"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-solver",
  "js-sys",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-syntax"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-tools"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-core",
  "fsl-syntax",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-verifier"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "fsl-wasm"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "fsl-core",
  "fsl-runtime",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "fslc-rust"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.4.0"
+version = "4.4.1"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,7 +1,7 @@
 # fslc Rust workspace
 
 This workspace is the native implementation for issue #195. Phases 0–4 are
-complete over their declared differential, replay, report, and browser gates;
+complete over their native replay, report, and browser gates;
 the Rust CLI and Worker replace the Python execution path without a permanent
 Python command fallback.
 
@@ -9,30 +9,29 @@ Current covered slice:
 
 - `fsl-syntax`: typed source locations, lexer, Pratt expression parser, and
   typed kernel `spec` surface declarations/statements/actions/properties;
-- exact Python↔Rust expression AST projection parity;
-- exact surface AST parity for all 79 kernel specs in the corpus;
-- exact surface AST parity for all 26 refinement mappings in the corpus;
-- exact surface AST parity for all 36 requirements, 7 business, 2 compose,
-  and 1 governance documents in the corpus;
-- exact typed specialized-IR parity for all 22 database, 4 domain, and 1 AI
-  component documents in the corpus;
+- optional frozen-Python expression, surface, and specialized-IR compatibility
+  projections, run only when their deliberately shared subset changes;
 - `fsl-core`: capture-safe named predicate and entity/number domain lowering,
   plus resolver-backed compose lowering, with exact kernel AST parity for all
   81 corpus spec/compose documents;
 - `fsl-runtime`: solver-independent concrete evaluation, Monitor semantics, and
-  BFS parity with Python for all 20 monitorable `specs/` programs at depth 3;
+  native explicit-state agreement;
 - `fsl-solver` and `fsl-solver-z3`: the async-check backend contract and pinned
   native Z3 4.16.0 implementation;
-- `fsl-verifier`: incremental symbolic BMC with Python BFS = Rust BFS = Rust BMC
-  decision parity for all 20 `specs/` programs at depth 3, plus deadlock,
+- `fsl-verifier`: incremental symbolic BMC with native Monitor/BFS/BMC agreement,
+  plus deadlock,
   deadline, and fair-lasso bounded `leadsTo` checks;
-- `fslc-rust`: native `check`, `verify`, and `scenarios` slices with 23/23
-  stable `specs/` snapshot projection parity, 43/43 full command-envelope parity,
-  and bidirectional replay of BMC, liveness, and scenario witnesses;
+- `fslc-rust`: native `check`, `verify`, and `scenarios` contracts with calibrated
+  native/Worker envelope comparison and replay of BMC, liveness, and scenario witnesses;
 - native induction, refinement, sweep, project-chain, database compatibility,
   SQL/Prisma import, AI hard-contract/stochastic evidence, domain structural
-  checks/replay/scaffolds, and the report-tool command surface; the committed
-  Phase-3 differential matches 107/107 command cases. It covers complete
+  checks/replay/scaffolds, and the report-tool command surface. The historical
+  Phase-3 differential is parked, not a gate, and awaits a focused native
+  `ai compare` metric/delta contract before deletion. Seven other Python parity
+  harnesses also remain deletion-deferred pending the exact native controls in
+  `RUST-PORTING.md` F1–F7. The redundant full-envelope comparison is deletion-ready but
+  remains until its helpers move without breaking retained consumers.
+  Native tests cover
   typestate, full built-in/external mutation adjudication, invariant and
   reachable counterfactuals with source-backed blame, all five alternate
   testgen targets, core/refinement/project analysis projections and exports,

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -380,7 +380,22 @@ fn error_at(message: impl Into<String>, span: fsl_syntax::Span) -> CoreError {
         message: message.into(),
         line: span.start.line,
         column: span.start.column,
-        origin: None,
+        origin: Some(Box::new(crate::OriginChain {
+            id: crate::OriginId(format!(
+                "compose:error:{}:{}",
+                span.start.offset, span.end.offset
+            )),
+            dialect: "compose".to_owned(),
+            primary: Some(crate::OriginSite {
+                source_file: None,
+                span: Some(span),
+                dialect: "compose".to_owned(),
+                declaration_path: Vec::new(),
+            }),
+            secondary: Vec::new(),
+            lowering_steps: Vec::new(),
+            generated: false,
+        })),
         name_resolution: false,
     }
 }
@@ -914,7 +929,7 @@ fn rewrite_compose_item(
             annotations,
         } => SpecItem::Invariant {
             name,
-            expr: Box::new(resolve_alias_expr(*expr, components)?),
+            expr: Box::new(resolve_alias_expr_with_span(*expr, components, Some(span))?),
             span,
             meta,
             annotations,
@@ -927,7 +942,7 @@ fn rewrite_compose_item(
             annotations,
         } => SpecItem::Trans {
             name,
-            expr: Box::new(resolve_alias_expr(*expr, components)?),
+            expr: Box::new(resolve_alias_expr_with_span(*expr, components, Some(span))?),
             span,
             meta,
             annotations,
@@ -940,7 +955,7 @@ fn rewrite_compose_item(
             annotations,
         } => SpecItem::Reachable {
             name,
-            expr: Box::new(resolve_alias_expr(*expr, components)?),
+            expr: Box::new(resolve_alias_expr_with_span(*expr, components, Some(span))?),
             span,
             meta,
             annotations,
@@ -995,7 +1010,7 @@ fn resolve_alias_statement(
             statements,
             span,
         } => Statement::ForAll {
-            binder: resolve_alias_binder(binder, components)?,
+            binder: resolve_alias_binder(binder, components, Some(span))?,
             statements: statements
                 .into_iter()
                 .map(|statement| resolve_alias_statement(statement, components))
@@ -1014,7 +1029,7 @@ fn sync_action(
         .params
         .iter()
         .cloned()
-        .map(|param| resolve_alias_param(param, components))
+        .map(|param| resolve_alias_param(param, components, action.span))
         .collect::<Result<Vec<_>, _>>()?;
     let mut items = Vec::new();
     let mut fair_constituents = Vec::new();
@@ -1117,11 +1132,13 @@ fn sync_action(
 fn resolve_alias_param(
     param: Param,
     components: &BTreeMap<String, Component>,
+    span: fsl_syntax::Span,
 ) -> Result<Param, CoreError> {
     Ok(match param {
-        Param::Typed(name, qualified) => {
-            Param::Typed(name, resolve_alias_qualified_name(qualified, components)?)
-        }
+        Param::Typed(name, qualified) => Param::Typed(
+            name,
+            resolve_alias_qualified_name(qualified, components, Some(span))?,
+        ),
         Param::Range(name, lo, hi) => Param::Range(
             name,
             resolve_alias_expr(lo, components)?,
@@ -1133,16 +1150,33 @@ fn resolve_alias_param(
 fn resolve_alias_qualified_name(
     qualified: QualifiedName,
     components: &BTreeMap<String, Component>,
+    span: Option<fsl_syntax::Span>,
 ) -> Result<QualifiedName, CoreError> {
     if let Some(alias) = qualified.namespace {
-        if !components.contains_key(&alias) {
-            return Err(CoreError {
-                message: format!("unknown alias '{alias}'"),
-                line: 1,
-                column: 1,
-                origin: None,
-                name_resolution: false,
-            });
+        let component = components.get(&alias).ok_or_else(|| {
+            span.map_or_else(
+                || CoreError {
+                    message: format!("unknown alias '{alias}'"),
+                    line: 1,
+                    column: 1,
+                    origin: None,
+                    name_resolution: false,
+                },
+                |span| error_at(format!("unknown alias '{alias}'"), span),
+            )
+        })?;
+        if !component.names.types.contains(&qualified.name) {
+            let message = format!("unknown type '{alias}.{}'", qualified.name);
+            return Err(span.map_or_else(
+                || CoreError {
+                    message: message.clone(),
+                    line: 1,
+                    column: 1,
+                    origin: None,
+                    name_resolution: false,
+                },
+                |span| error_at(message.clone(), span),
+            ));
         }
         Ok(QualifiedName {
             namespace: None,
@@ -1156,6 +1190,7 @@ fn resolve_alias_qualified_name(
 fn resolve_alias_binder(
     binder: Binder,
     components: &BTreeMap<String, Component>,
+    span: Option<fsl_syntax::Span>,
 ) -> Result<Binder, CoreError> {
     Ok(match binder {
         Binder::Typed {
@@ -1164,7 +1199,7 @@ fn resolve_alias_binder(
             where_expr,
         } => Binder::Typed {
             name,
-            type_name: resolve_alias_qualified_name(type_name, components)?,
+            type_name: resolve_alias_qualified_name(type_name, components, span)?,
             where_expr: where_expr
                 .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
                 .transpose()?,
@@ -1201,69 +1236,129 @@ fn resolve_alias_expr(
     expr: Expr,
     components: &BTreeMap<String, Component>,
 ) -> Result<Expr, CoreError> {
+    resolve_alias_expr_with_span(expr, components, None)
+}
+
+#[allow(clippy::too_many_lines)]
+fn resolve_alias_expr_with_span(
+    expr: Expr,
+    components: &BTreeMap<String, Component>,
+    diagnostic_span: Option<fsl_syntax::Span>,
+) -> Result<Expr, CoreError> {
     Ok(match expr {
         Expr::Field(base, name) => {
             if let Expr::Var(alias) = base.as_ref() {
                 if components.contains_key(alias) {
                     Expr::Var(prefix(alias, &name))
                 } else {
-                    Expr::Field(Box::new(resolve_alias_expr(*base, components)?), name)
+                    Expr::Field(
+                        Box::new(resolve_alias_expr_with_span(
+                            *base,
+                            components,
+                            diagnostic_span,
+                        )?),
+                        name,
+                    )
                 }
             } else {
-                Expr::Field(Box::new(resolve_alias_expr(*base, components)?), name)
+                Expr::Field(
+                    Box::new(resolve_alias_expr_with_span(
+                        *base,
+                        components,
+                        diagnostic_span,
+                    )?),
+                    name,
+                )
             }
         }
-        Expr::Some(expr) => Expr::Some(Box::new(resolve_alias_expr(*expr, components)?)),
+        Expr::Some(expr) => Expr::Some(Box::new(resolve_alias_expr_with_span(
+            *expr,
+            components,
+            diagnostic_span,
+        )?)),
         Expr::Set(items) => Expr::Set(
             items
                 .into_iter()
-                .map(|item| resolve_alias_expr(item, components))
+                .map(|item| resolve_alias_expr_with_span(item, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
         ),
         Expr::Seq(items) => Expr::Seq(
             items
                 .into_iter()
-                .map(|item| resolve_alias_expr(item, components))
+                .map(|item| resolve_alias_expr_with_span(item, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
         ),
         Expr::Struct { name, fields } => Expr::Struct {
             name,
             fields: fields
                 .into_iter()
-                .map(|(name, expr)| Ok((name, resolve_alias_expr(expr, components)?)))
+                .map(|(name, expr)| {
+                    Ok((
+                        name,
+                        resolve_alias_expr_with_span(expr, components, diagnostic_span)?,
+                    ))
+                })
                 .collect::<Result<_, CoreError>>()?,
         },
         Expr::Call { name, args, span } => Expr::Call {
             name,
             args: args
                 .into_iter()
-                .map(|arg| resolve_alias_expr(arg, components))
+                .map(|arg| resolve_alias_expr_with_span(arg, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
             span,
         },
         Expr::Index(base, index) => Expr::Index(
-            Box::new(resolve_alias_expr(*base, components)?),
-            Box::new(resolve_alias_expr(*index, components)?),
+            Box::new(resolve_alias_expr_with_span(
+                *base,
+                components,
+                diagnostic_span,
+            )?),
+            Box::new(resolve_alias_expr_with_span(
+                *index,
+                components,
+                diagnostic_span,
+            )?),
         ),
         Expr::Method {
             receiver,
             name,
             args,
         } => Expr::Method {
-            receiver: Box::new(resolve_alias_expr(*receiver, components)?),
+            receiver: Box::new(resolve_alias_expr_with_span(
+                *receiver,
+                components,
+                diagnostic_span,
+            )?),
             name,
             args: args
                 .into_iter()
-                .map(|arg| resolve_alias_expr(arg, components))
+                .map(|arg| resolve_alias_expr_with_span(arg, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
         },
         Expr::Binary { op, left, right } => Expr::Binary {
             op,
-            left: Box::new(resolve_alias_expr(*left, components)?),
-            right: Box::new(resolve_alias_expr(*right, components)?),
+            left: Box::new(resolve_alias_expr_with_span(
+                *left,
+                components,
+                diagnostic_span,
+            )?),
+            right: Box::new(resolve_alias_expr_with_span(
+                *right,
+                components,
+                diagnostic_span,
+            )?),
         },
-        Expr::Neg(expr) => Expr::Neg(Box::new(resolve_alias_expr(*expr, components)?)),
-        Expr::Not(expr) => Expr::Not(Box::new(resolve_alias_expr(*expr, components)?)),
+        Expr::Neg(expr) => Expr::Neg(Box::new(resolve_alias_expr_with_span(
+            *expr,
+            components,
+            diagnostic_span,
+        )?)),
+        Expr::Not(expr) => Expr::Not(Box::new(resolve_alias_expr_with_span(
+            *expr,
+            components,
+            diagnostic_span,
+        )?)),
         Expr::Conditional {
             condition,
             then_expr,
@@ -1271,12 +1366,28 @@ fn resolve_alias_expr(
             spans,
         } => Expr::Conditional {
             spans,
-            condition: Box::new(resolve_alias_expr(*condition, components)?),
-            then_expr: Box::new(resolve_alias_expr(*then_expr, components)?),
-            else_expr: Box::new(resolve_alias_expr(*else_expr, components)?),
+            condition: Box::new(resolve_alias_expr_with_span(
+                *condition,
+                components,
+                diagnostic_span,
+            )?),
+            then_expr: Box::new(resolve_alias_expr_with_span(
+                *then_expr,
+                components,
+                diagnostic_span,
+            )?),
+            else_expr: Box::new(resolve_alias_expr_with_span(
+                *else_expr,
+                components,
+                diagnostic_span,
+            )?),
         },
         Expr::Is { expr, pattern } => Expr::Is {
-            expr: Box::new(resolve_alias_expr(*expr, components)?),
+            expr: Box::new(resolve_alias_expr_with_span(
+                *expr,
+                components,
+                diagnostic_span,
+            )?),
             pattern,
         },
         Expr::Quantified {
@@ -1285,8 +1396,12 @@ fn resolve_alias_expr(
             body,
         } => Expr::Quantified {
             quantifier,
-            binder: resolve_alias_binder(binder, components)?,
-            body: Box::new(resolve_alias_expr(*body, components)?),
+            binder: resolve_alias_binder(binder, components, diagnostic_span)?,
+            body: Box::new(resolve_alias_expr_with_span(
+                *body,
+                components,
+                diagnostic_span,
+            )?),
         },
         Expr::Aggregate {
             kind,
@@ -1294,20 +1409,34 @@ fn resolve_alias_expr(
             value,
         } => Expr::Aggregate {
             kind,
-            binder: resolve_alias_binder(binder, components)?,
+            binder: resolve_alias_binder(binder, components, diagnostic_span)?,
             value: value
-                .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
+                .map(|expr| {
+                    resolve_alias_expr_with_span(*expr, components, diagnostic_span).map(Box::new)
+                })
                 .transpose()?,
         },
         Expr::UnaryNamed { name, expr, span } => Expr::UnaryNamed {
             name,
-            expr: Box::new(resolve_alias_expr(*expr, components)?),
+            expr: Box::new(resolve_alias_expr_with_span(
+                *expr,
+                components,
+                diagnostic_span,
+            )?),
             span,
         },
         Expr::BinaryNamed { name, left, right } => Expr::BinaryNamed {
             name,
-            left: Box::new(resolve_alias_expr(*left, components)?),
-            right: Box::new(resolve_alias_expr(*right, components)?),
+            left: Box::new(resolve_alias_expr_with_span(
+                *left,
+                components,
+                diagnostic_span,
+            )?),
+            right: Box::new(resolve_alias_expr_with_span(
+                *right,
+                components,
+                diagnostic_span,
+            )?),
         },
         Expr::TernaryNamed {
             name,
@@ -1316,9 +1445,21 @@ fn resolve_alias_expr(
             third,
         } => Expr::TernaryNamed {
             name,
-            first: Box::new(resolve_alias_expr(*first, components)?),
-            second: Box::new(resolve_alias_expr(*second, components)?),
-            third: Box::new(resolve_alias_expr(*third, components)?),
+            first: Box::new(resolve_alias_expr_with_span(
+                *first,
+                components,
+                diagnostic_span,
+            )?),
+            second: Box::new(resolve_alias_expr_with_span(
+                *second,
+                components,
+                diagnostic_span,
+            )?),
+            third: Box::new(resolve_alias_expr_with_span(
+                *third,
+                components,
+                diagnostic_span,
+            )?),
         },
         other => other,
     })

--- a/rust/fsl-core/src/typecheck.rs
+++ b/rust/fsl-core/src/typecheck.rs
@@ -123,7 +123,15 @@ pub(crate) fn binder_type(
     model: &KernelModel,
 ) -> Result<TypeRef, TypecheckError> {
     match binder {
-        Binder::Typed { type_name, .. } => Ok(TypeRef::Named(qualified_name(type_name)?)),
+        Binder::Typed { type_name, .. } => {
+            let name = qualified_name(type_name)?;
+            match name.as_str() {
+                "Bool" => Ok(TypeRef::Bool),
+                "Int" => Ok(TypeRef::Int),
+                _ if model.types.contains_key(&name) => Ok(TypeRef::Named(name)),
+                _ => Err(error(format!("unknown type '{name}'"))),
+            }
+        }
         Binder::Range { lo, hi, .. } => {
             ensure_assignable(lo, &TypeRef::Int, env, model, unknown_span())?;
             ensure_assignable(hi, &TypeRef::Int, env, model, unknown_span())?;
@@ -759,7 +767,7 @@ fn validate_binder(
     model: &KernelModel,
     span: Span,
 ) -> Result<TypeRef, TypecheckError> {
-    let ty = binder_type(binder, env, model)?;
+    let ty = binder_type(binder, env, model).map_err(|error| error.with_span(span))?;
     let (name, where_expr) = match binder {
         Binder::Typed {
             name, where_expr, ..
@@ -1072,33 +1080,28 @@ fn validate_statement_assignments(
             validate_expression(value, env, model, *span, Some(&ty))
         }
         Statement::If {
+            condition,
             then_statements,
             else_statements,
-            ..
-        } => then_statements
-            .iter()
-            .chain(else_statements)
-            .try_for_each(|item| validate_statement_assignments(item, env, model, visible_consts)),
-        Statement::ForAll {
-            binder, statements, ..
+            span,
         } => {
-            let (name, ty) = match binder {
-                Binder::Typed {
-                    name, type_name, ..
-                } => (name, TypeRef::Named(qualified_name(type_name)?)),
-                Binder::Range { name, .. } => (name, TypeRef::Int),
-                Binder::Collection {
-                    name, collection, ..
-                } => {
-                    let collection_ty = resolve(model, &infer_type(collection, env, model, None)?)?;
-                    let (TypeRef::Set(item) | TypeRef::Seq(item, _)) = collection_ty else {
-                        return Err(error("collection binder requires Set or Seq"));
-                    };
-                    (name, *item)
-                }
-            };
+            validate_expression(condition, env, model, *span, Some(&TypeRef::Bool))?;
+            then_statements
+                .iter()
+                .chain(else_statements)
+                .try_for_each(|item| {
+                    validate_statement_assignments(item, env, model, visible_consts)
+                })
+        }
+        Statement::ForAll {
+            binder,
+            statements,
+            span,
+        } => {
+            let name = binder_name(binder);
+            let ty = validate_binder(binder, env, model, *span)?;
             let mut local = env.clone();
-            local.insert(name.clone(), ty);
+            local.insert(name.to_owned(), ty);
             let mut local_visible_consts = visible_consts.clone();
             local_visible_consts.remove(name);
             statements.iter().try_for_each(|item| {

--- a/rust/fsl-core/tests/compose_alias_forall.rs
+++ b/rust/fsl-core/tests/compose_alias_forall.rs
@@ -59,12 +59,66 @@ fn undeclared_alias_in_forall_binder_returns_core_error_not_panic() {
         .expect_err("an undeclared alias must fail, not panic");
 
     assert_eq!(error.message, "unknown alias 'nonexistent'");
-    // This location is a placeholder, not a real source position: the
-    // qualified-name resolver (`resolve_alias_qualified_name`) has no span
-    // to draw from, so it always reports (1, 1) regardless of where the
-    // binder actually appears.
+    // The statement span now gives the qualified-name resolver the real
+    // source position instead of the former (1, 1) placeholder.
     assert_eq!(error.line, 1);
-    assert_eq!(error.column, 1);
+    assert_eq!(error.column, 42);
+}
+
+/// Rejecting detector for issue #832 shape A: a declared alias does not make
+/// an absent member a valid binder type. The diagnostic keeps author spelling
+/// and the `forall` statement's real location.
+#[test]
+fn declared_alias_with_unknown_forall_type_returns_located_core_error() {
+    let source = r#"compose Broken {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    forall u: core.NoSuchType {
+      x = 0
+    }
+  }
+}"#;
+
+    let error = parse_kernel_source(source, &resolver())
+        .expect_err("an unknown member of a declared alias must fail during lowering");
+
+    assert_eq!(error.message, "unknown type 'core.NoSuchType'");
+    assert_eq!(error.line, 5);
+    assert_eq!(error.column, 5);
+    assert!(
+        error
+            .origin
+            .as_deref()
+            .is_some_and(|origin| origin.id.0.starts_with("compose:error:"))
+    );
+}
+
+/// Rejecting detector for the expression-binder path: a qualified type in an
+/// invariant must retain the authored property's location while resolving the
+/// alias member.
+#[test]
+fn declared_alias_with_unknown_invariant_binder_returns_located_core_error() {
+    let source = r#"compose Broken {
+  use Core as core from "core.fsl"
+  state { x: Int }
+    invariant Bad { forall u: core.NoSuchType { true } }
+}"#;
+
+    let error = parse_kernel_source(source, &resolver())
+        .expect_err("an unknown invariant binder member must fail during lowering");
+
+    assert_eq!(error.message, "unknown type 'core.NoSuchType'");
+    assert_eq!(error.line, 4);
+    assert_eq!(error.column, 5);
+    let origin = error.origin.expect("authored compose error origin");
+    assert_eq!(
+        origin
+            .primary
+            .and_then(|site| site.span)
+            .map(|span| (span.start.line, span.start.column)),
+        Some((4, 5))
+    );
 }
 
 /// Accepting control: a correctly declared alias used the same way (in a

--- a/rust/fsl-core/tests/compose_init_condition_types.rs
+++ b/rust/fsl-core/tests/compose_init_condition_types.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Issue #832 shape B: checked-model construction must type every `init if`
+//! condition, not only assignments nested below it.
+
+use std::collections::BTreeMap;
+
+use fsl_core::{CoreError, FileResolver, build_model, parse_kernel_source};
+
+struct MemoryResolver(BTreeMap<String, String>);
+
+impl FileResolver for MemoryResolver {
+    fn read(&self, path: &str) -> Result<String, CoreError> {
+        self.0.get(path).cloned().ok_or_else(|| CoreError {
+            message: format!("missing {path}"),
+            line: 1,
+            column: 1,
+            origin: None,
+            name_resolution: false,
+        })
+    }
+}
+
+const CORE_COMPONENT: &str = "spec Core { \
+    type RealType = 0..1 \
+    state { flag: Bool } \
+    init { flag = true } \
+    action noop() {} \
+}";
+
+fn resolver() -> MemoryResolver {
+    MemoryResolver(BTreeMap::from([(
+        "core.fsl".to_owned(),
+        CORE_COMPONENT.to_owned(),
+    )]))
+}
+
+/// Rejecting detector: the undeclared root of a field-shaped condition is
+/// rejected at the `if`, matching assignment-RHS type checking.
+#[test]
+fn undeclared_alias_shaped_init_condition_is_rejected() {
+    let source = r#"compose Broken {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    if nonexistent.flag {
+      x = 0
+    }
+  }
+}"#;
+    let kernel = parse_kernel_source(source, &resolver()).expect("compose lowers");
+    let error = build_model(kernel).expect_err("the unknown condition root must fail check");
+
+    assert_eq!(
+        error.message,
+        "invalid init statement: public Kernel cannot type identifier 'nonexistent'"
+    );
+    let span = error
+        .origin
+        .as_deref()
+        .and_then(|origin| origin.primary.as_ref())
+        .and_then(|site| site.span)
+        .expect("the condition error is located");
+    assert_eq!(span.start.line, 5);
+    assert_eq!(span.start.column, 5);
+}
+
+/// Accepting control: a declared component alias and real Bool member remain
+/// valid in the same `init if` condition position.
+#[test]
+fn declared_alias_init_condition_still_builds() {
+    let source = r#"compose Works {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    if core.flag {
+      x = 0
+    }
+  }
+}"#;
+    let kernel = parse_kernel_source(source, &resolver()).expect("compose lowers");
+    build_model(kernel).expect("a declared alias Bool condition must remain valid");
+}

--- a/rust/fsl-core/tests/typed_binder_resolution.rs
+++ b/rust/fsl-core/tests/typed_binder_resolution.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use fsl_core::{FsResolver, ModelError, build_model, parse_kernel_source};
+
+struct BinderPathCase {
+    owner: &'static str,
+    form: &'static str,
+    source: &'static str,
+    line: u32,
+    column: u32,
+}
+
+const BINDER_PATH_CASES: [BinderPathCase; 13] = [
+    BinderPathCase {
+        owner: "invariant",
+        form: "forall expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  invariant P { forall x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "invariant",
+        form: "exists expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  invariant P { exists x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "invariant",
+        form: "aggregate expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  invariant P { count(x: Missing) == 0 }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "ensures",
+        form: "forall expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  action stay() { flag = flag ensures forall x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "ensures",
+        form: "exists expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  action stay() { flag = flag ensures exists x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "ensures",
+        form: "aggregate expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  action stay() { flag = flag ensures count(x: Missing) == 0 }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "reachable",
+        form: "forall expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  reachable P { forall x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "reachable",
+        form: "exists expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  reachable P { exists x: Missing { true } }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "reachable",
+        form: "aggregate expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = false }\n  reachable P { count(x: Missing) == 0 }\n}",
+        line: 4,
+        column: 3,
+    },
+    BinderPathCase {
+        owner: "init",
+        form: "forall statement",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { forall x: Missing { flag = false } }\n}",
+        line: 3,
+        column: 10,
+    },
+    BinderPathCase {
+        owner: "init",
+        form: "forall expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { flag = forall x: Missing { true } }\n}",
+        line: 3,
+        column: 10,
+    },
+    BinderPathCase {
+        owner: "init",
+        form: "exists expression",
+        source: "spec Bad {\n  state { flag: Bool }\n  init { if exists x: Missing { true } { flag = false } }\n}",
+        line: 3,
+        column: 10,
+    },
+    BinderPathCase {
+        owner: "init",
+        form: "aggregate expression",
+        source: "spec Bad {\n  state { total: Int }\n  init { total = count(x: Missing) }\n}",
+        line: 3,
+        column: 10,
+    },
+];
+
+fn rejected_model(case: &BinderPathCase) -> ModelError {
+    let kernel = parse_kernel_source(case.source, &FsResolver::new("."))
+        .unwrap_or_else(|error| panic!("{} / {} did not lower: {error}", case.owner, case.form));
+    match build_model(kernel) {
+        Err(error) => error,
+        Ok(model) => panic!(
+            "{} / {} unexpectedly built: {}",
+            case.owner, case.form, model.name
+        ),
+    }
+}
+
+/// Mechanical inventory of every authored owner called out by issue #832.
+///
+/// Quantified and aggregate expressions recurse through the same
+/// `validate_expression` arms regardless of owner. Init additionally has a
+/// statement-form `forall`, so it gets one row for that distinct AST path and
+/// separate expression rows for `forall`, `exists`, and aggregates.
+#[test]
+fn unknown_typed_binders_are_rejected_in_every_authored_owner_and_ast_form() {
+    for case in &BINDER_PATH_CASES {
+        let error = rejected_model(case);
+        assert_eq!(
+            error.message,
+            if case.owner == "init" {
+                "invalid init statement: unknown type 'Missing'"
+            } else {
+                "invalid model expression: unknown type 'Missing'"
+            },
+            "{} / {}",
+            case.owner,
+            case.form
+        );
+        let span = error
+            .origin
+            .as_deref()
+            .and_then(|origin| origin.primary.as_ref())
+            .and_then(|site| site.span)
+            .or(error.span)
+            .unwrap_or_else(|| panic!("{} / {} lost its location", case.owner, case.form));
+        assert_eq!(
+            (span.start.line, span.start.column),
+            (case.line, case.column),
+            "{} / {}",
+            case.owner,
+            case.form
+        );
+    }
+}
+
+#[test]
+fn real_typed_binder_remains_accepted() {
+    let source = "spec Good {\n  type Item = 0..1\n  state { flag: Bool }\n  init { flag = false }\n  invariant P { forall x: Item { true } }\n}";
+    let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("lower valid binder");
+    build_model(kernel).expect("build valid binder");
+}
+
+/// Every spec-like dialect that can carry the shared expression AST either
+/// reaches the checked-model binder gate or rejects the name earlier while
+/// resolving its own typed domain vocabulary.
+#[test]
+fn all_binder_capable_dialects_reject_unknown_typed_names() {
+    let checked_model_cases = [
+        (
+            "spec",
+            "spec Bad { state { flag: Bool } init { flag = false } invariant P { forall x: Missing { true } } }",
+        ),
+        (
+            "requirements",
+            "requirements Bad { process Claim { stages Draft, Done initial Draft transition finish Draft -> Done by System } invariant P { forall x: Missing { true } } } verify { instances Claim = 1 }",
+        ),
+        (
+            "business",
+            "business Bad { actor System entity Claim process Claim { stages Draft, Done initial Draft transition finish Draft -> Done by System } goal G \"bad\" { forall x: Missing { true } } } verify { instances Claim = 1 }",
+        ),
+        (
+            "compose",
+            "compose Bad { state { flag: Bool } init { flag = false } invariant P { forall x: Missing { true } } }",
+        ),
+    ];
+
+    for (dialect, source) in checked_model_cases {
+        let kernel = parse_kernel_source(source, &FsResolver::new("."))
+            .unwrap_or_else(|error| panic!("{dialect} did not lower: {error}"));
+        let Err(error) = build_model(kernel) else {
+            panic!("{dialect} accepted unknown binder type");
+        };
+        assert!(
+            error.message.contains("unknown type 'Missing'"),
+            "{dialect}: {error}"
+        );
+    }
+
+    let domain = "domain Bad { type Status = Draft | Done aggregate Claim { state { status: Status = Draft; } command Finish {} event Finished {} decide Finish { emits Finished } evolve Finished { status = Done } invariant bad { forall x: Missing { true } } } }";
+    let error = parse_kernel_source(domain, &FsResolver::new("."))
+        .expect_err("domain type resolution must reject an unknown binder type");
+    assert!(error.message.contains("Missing"), "domain: {error}");
+}

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -13,7 +13,7 @@ use fsl_core::{
 use super::trace::{ParentLink, reconstruct_trace, state_changes};
 use super::{
     Bindings, Monitor, RuntimeError, State, Violation, eval, runtime_error, runtime_error_at,
-    with_total_division,
+    terminal_holds, with_total_division,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -268,24 +268,6 @@ pub fn verify_explicit_selected(
 
     result.states_explored = seen.len();
     Ok(result)
-}
-
-fn terminal_holds(monitor: &Monitor) -> Result<bool, RuntimeError> {
-    let Some(terminal) = &monitor.model.terminal else {
-        return Ok(false);
-    };
-    with_total_division(|| {
-        match eval(
-            terminal,
-            &monitor.state,
-            &mut Bindings::new(),
-            &monitor.model,
-            None,
-        )? {
-            Value::Bool(value) => Ok(value),
-            _ => Err(runtime_error("terminal expression must be Boolean")),
-        }
-    })
 }
 
 fn record_reachables(

--- a/rust/fsl-runtime/src/explicit.rs
+++ b/rust/fsl-runtime/src/explicit.rs
@@ -12,7 +12,8 @@ use fsl_core::{
 
 use super::trace::{ParentLink, reconstruct_trace, state_changes};
 use super::{
-    Bindings, Monitor, RuntimeError, State, Violation, eval, runtime_error, with_total_division,
+    Bindings, Monitor, RuntimeError, State, Violation, eval, runtime_error, runtime_error_at,
+    with_total_division,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -76,14 +77,18 @@ pub fn verify_explicit(
 /// the symbolic engine).
 #[must_use]
 pub fn explicit_unsupported_reason(model: &KernelModel) -> Option<String> {
+    explicit_unsupported_error(model).map(|error| error.message)
+}
+
+fn explicit_unsupported_error(model: &KernelModel) -> Option<RuntimeError> {
     if let Err(error) = check_deterministic_init(model) {
-        return Some(error.message);
+        return Some(error);
     }
     if !model.leadstos.is_empty() {
-        return Some(
+        return Some(runtime_error(
             "the explicit engine does not support leadsTo properties; use --engine bmc or exclude the leadsTo property"
                 .to_owned(),
-        );
+        ));
     }
     None
 }
@@ -115,8 +120,8 @@ pub fn verify_explicit_selected(
     if max_states == 0 {
         return Err(runtime_error("explicit state budget must be at least 1"));
     }
-    if let Some(reason) = explicit_unsupported_reason(&model) {
-        return Err(runtime_error(reason));
+    if let Some(error) = explicit_unsupported_error(&model) {
+        return Err(error);
     }
 
     // The frontier carries `State` only, not `Monitor` -- a full `Monitor`
@@ -673,6 +678,85 @@ fn assignment_coverage(
     }
 }
 
+/// Enforce init's assign-once ownership rule without requiring a concrete
+/// initial state. Symbolic verification may admit partially assigned init,
+/// but it must reject two writes that can own the same state location.
+///
+/// # Errors
+///
+/// Returns [`RuntimeError`] when two writes may overlap on one logical root.
+pub fn check_init_write_ownership(model: &KernelModel) -> Result<(), RuntimeError> {
+    walk_init_write_ownership(&model.init, BTreeSet::new(), false, &BTreeMap::new(), model)?;
+    Ok(())
+}
+
+fn walk_init_write_ownership(
+    statements: &[Statement],
+    mut possibly_assigned: BTreeSet<InitWriteKey>,
+    in_forall: bool,
+    bound_names: &BTreeMap<String, Option<Vec<Value>>>,
+    model: &KernelModel,
+) -> Result<BTreeSet<InitWriteKey>, RuntimeError> {
+    for statement in statements {
+        match statement {
+            Statement::Assign { target, span, .. } => {
+                let logical = logical_var(target)
+                    .ok_or_else(|| runtime_error("invalid init assignment target"))?;
+                let contribution = assignment_coverage(target, bound_names, model);
+                let keys = init_write_keys(target, contribution.as_ref());
+                if keys.iter().any(|key| {
+                    possibly_assigned
+                        .iter()
+                        .any(|previous| init_write_keys_overlap(previous, key))
+                }) {
+                    let scope = if in_forall { "init forall" } else { "init" };
+                    return Err(runtime_error_at(
+                        format!("state variable '{logical}' assigned more than once in {scope}"),
+                        *span,
+                    ));
+                }
+                possibly_assigned.extend(keys);
+            }
+            Statement::ForAll {
+                binder, statements, ..
+            } => {
+                let binder_values = compute_binder_values(binder, model)?;
+                let mut nested_bound = bound_names.clone();
+                nested_bound.insert(binder_name(binder).to_owned(), binder_values);
+                possibly_assigned = walk_init_write_ownership(
+                    statements,
+                    possibly_assigned,
+                    true,
+                    &nested_bound,
+                    model,
+                )?;
+            }
+            Statement::If {
+                then_statements,
+                else_statements,
+                ..
+            } => {
+                let then_possible = walk_init_write_ownership(
+                    then_statements,
+                    possibly_assigned.clone(),
+                    in_forall,
+                    bound_names,
+                    model,
+                )?;
+                let else_possible = walk_init_write_ownership(
+                    else_statements,
+                    possibly_assigned,
+                    in_forall,
+                    bound_names,
+                    model,
+                )?;
+                possibly_assigned = then_possible.union(&else_possible).cloned().collect();
+            }
+        }
+    }
+    Ok(possibly_assigned)
+}
+
 #[allow(clippy::too_many_lines)]
 fn walk_init(
     statements: &[Statement],
@@ -684,16 +768,26 @@ fn walk_init(
 ) -> Result<(BTreeMap<String, Coverage>, BTreeSet<InitWriteKey>), RuntimeError> {
     for statement in statements {
         match statement {
-            Statement::Assign { target, value, .. } => {
+            Statement::Assign {
+                target,
+                value,
+                span,
+                ..
+            } => {
                 let logical = logical_var(target)
                     .ok_or_else(|| runtime_error("invalid init assignment target"))?;
                 let contribution = assignment_coverage(target, bound_names, model);
                 let keys = init_write_keys(target, contribution.as_ref());
-                if keys.iter().any(|key| possibly_assigned.contains(key)) {
+                if keys.iter().any(|key| {
+                    possibly_assigned
+                        .iter()
+                        .any(|previous| init_write_keys_overlap(previous, key))
+                }) {
                     let scope = if in_forall { "init forall" } else { "init" };
-                    return Err(runtime_error(format!(
-                        "state variable '{logical}' assigned more than once in {scope}"
-                    )));
+                    return Err(runtime_error_at(
+                        format!("state variable '{logical}' assigned more than once in {scope}"),
+                        *span,
+                    ));
                 }
                 if let LValue::Index(_, key_expr) = target {
                     check_init_expr(key_expr, &definitely_assigned, model)?;
@@ -956,18 +1050,9 @@ fn logical_var(target: &LValue) -> Option<&str> {
 /// Falls back to `InitWriteKey::Root` (whole-variable) whenever `coverage`
 /// is not `Coverage::Keys` for an `Index` target — including `Full`,
 /// `Fields`, and unresolved (`None`, e.g. a dynamic key or a nested lvalue).
-/// That fallback never *accepts* something the coarser, pre-#821
-/// `Root`-only classification would have rejected: every write this
-/// function buckets under `Root` was already bucketed there before. It is
-/// not, however, "as strict as touching the entire variable" in the
-/// collision sense: `Root(name)` never collides with
-/// `ConcreteIndex(name, _)`, so a `None`-coverage target is simply not
-/// collision-checked against any concrete key at all. A `forall`-bound
-/// index used through a non-`Var` key expression (e.g. `m[i - i]`) is one
-/// such target; two iterations of it aliasing each other, or it aliasing a
-/// separate `m[K] = ...`, can still go undetected here when the values
-/// agree. That gap is pre-existing (identical on `origin/main`) and is not
-/// fixed by this change.
+/// `init_write_keys_overlap` treats that root as touching every concrete key
+/// on the same logical variable, so unresolved indexed writes fail closed
+/// against both concrete writes and other unresolved writes (issue #826).
 fn init_write_keys(target: &LValue, coverage: Option<&Coverage>) -> BTreeSet<InitWriteKey> {
     if let (LValue::Index(name, _), Some(Coverage::Keys(keys))) = (target, coverage) {
         return keys
@@ -981,6 +1066,20 @@ fn init_write_keys(target: &LValue, coverage: Option<&Coverage>) -> BTreeSet<Ini
             .expect("kernel lvalue has a logical root")
             .to_owned(),
     )])
+}
+
+fn init_write_keys_overlap(left: &InitWriteKey, right: &InitWriteKey) -> bool {
+    match (left, right) {
+        (
+            InitWriteKey::Root(left),
+            InitWriteKey::Root(right) | InitWriteKey::ConcreteIndex(right, _),
+        )
+        | (InitWriteKey::ConcreteIndex(left, _), InitWriteKey::Root(right)) => left == right,
+        (
+            InitWriteKey::ConcreteIndex(left_root, left_key),
+            InitWriteKey::ConcreteIndex(right_root, right_key),
+        ) => left_root == right_root && left_key == right_key,
+    }
 }
 
 fn binder_name(binder: &Binder) -> &str {

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -10,7 +10,7 @@ use fsl_core::{
     ActionCorrespondenceTarget, ActionDef, ActionGuard, FslValue as Value,
     KernelAggregateKind as AggregateKind, KernelBinder as Binder, KernelExpr as Expr,
     KernelLValue as LValue, KernelModel, KernelStatement as Statement, ModelError, ParamDef,
-    Refinement, TraceAction, TraceChange, TraceStep, TypeDef, TypeRef, display_name,
+    Refinement, Span, TraceAction, TraceChange, TraceStep, TypeDef, TypeRef, display_name,
     insert_requirement_metadata, internal_origin_json, model_warnings, origin_display_name,
     state_summary, static_leadsto_bindings,
 };
@@ -20,8 +20,9 @@ mod explicit;
 mod trace;
 
 pub use explicit::{
-    ExplicitReachableWitness, ExplicitResult, ExplicitViolation, deterministic_initial_state,
-    explicit_unsupported_reason, verify_explicit, verify_explicit_selected,
+    ExplicitReachableWitness, ExplicitResult, ExplicitViolation, check_init_write_ownership,
+    deterministic_initial_state, explicit_unsupported_reason, verify_explicit,
+    verify_explicit_selected,
 };
 
 pub type State = BTreeMap<String, Value>;
@@ -60,6 +61,8 @@ fn with_total_division<T>(body: impl FnOnce() -> T) -> T {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RuntimeError {
     pub message: String,
+    /// Authored construct responsible for this runtime diagnostic, when one exists.
+    pub span: Option<Span>,
 }
 
 impl fmt::Display for RuntimeError {
@@ -74,6 +77,7 @@ impl From<ModelError> for RuntimeError {
     fn from(error: ModelError) -> Self {
         Self {
             message: error.message,
+            span: error.span,
         }
     }
 }
@@ -731,6 +735,14 @@ fn i64_len(value: usize) -> Result<i64, RuntimeError> {
 fn runtime_error(message: impl Into<String>) -> RuntimeError {
     RuntimeError {
         message: message.into(),
+        span: None,
+    }
+}
+
+fn runtime_error_at(message: impl Into<String>, span: Span) -> RuntimeError {
+    RuntimeError {
+        message: message.into(),
+        span: Some(span),
     }
 }
 

--- a/rust/fsl-runtime/src/lib.rs
+++ b/rust/fsl-runtime/src/lib.rs
@@ -1327,6 +1327,24 @@ pub struct BfsResult {
     pub action_coverage: BTreeMap<String, bool>,
 }
 
+fn terminal_holds(monitor: &Monitor) -> Result<bool, RuntimeError> {
+    let Some(terminal) = &monitor.model.terminal else {
+        return Ok(false);
+    };
+    with_total_division(|| {
+        match eval(
+            terminal,
+            &monitor.state,
+            &mut Bindings::new(),
+            &monitor.model,
+            None,
+        )? {
+            Value::Bool(value) => Ok(value),
+            _ => Err(runtime_error("terminal expression must be Boolean")),
+        }
+    })
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RefinementFailure {
     pub kind: String,
@@ -2036,7 +2054,28 @@ pub fn bfs(model: KernelModel, depth: usize) -> Result<BfsResult, RuntimeError> 
         scratch.step = step;
         let enabled = scratch.enabled()?;
         if enabled.is_empty() {
-            result.deadlock_step = Some(result.deadlock_step.map_or(step, |old| old.min(step)));
+            let terminal = match terminal_holds(&scratch) {
+                Ok(value) => value,
+                Err(error) if is_partial_operation_error(&error.message) => {
+                    let violation = Violation {
+                        kind: "partial_op".to_owned(),
+                        name: "_partial_property_terminal".to_owned(),
+                        step,
+                    };
+                    if result
+                        .violation
+                        .as_ref()
+                        .is_none_or(|old| violation.step < old.step)
+                    {
+                        result.violation = Some(violation);
+                    }
+                    return Ok(result);
+                }
+                Err(error) => return Err(error),
+            };
+            if !terminal {
+                result.deadlock_step = Some(result.deadlock_step.map_or(step, |old| old.min(step)));
+            }
         }
         for instance in &enabled {
             result.action_coverage.insert(instance.action.clone(), true);

--- a/rust/fsl-runtime/tests/explicit_engine.rs
+++ b/rust/fsl-runtime/tests/explicit_engine.rs
@@ -444,6 +444,52 @@ fn init_forall_write_collides_with_later_concrete_write_to_the_same_key() {
     assert!(result.violation.is_none());
 }
 
+/// Issue #826: an indexed init write whose key coverage cannot be resolved
+/// may touch every key of its logical map root. It therefore overlaps both
+/// concrete-key writes and another unresolved indexed write, while a lone
+/// unresolved write has no competing owner and remains admissible to BMC.
+#[test]
+fn unresolved_init_index_writes_collide_by_logical_root() {
+    let root_concrete = model(
+        "spec RootConcrete { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { forall i: Idx { m[i - i] = true } forall j: Idx { m[j] = true } } \
+         action noop() { } }",
+    );
+    let error = fsl_runtime::check_init_write_ownership(&root_concrete)
+        .expect_err("unresolved write must overlap every concrete key on the same root");
+    assert_eq!(
+        error.message,
+        "state variable 'm' assigned more than once in init forall"
+    );
+    assert!(
+        error.span.is_some(),
+        "collision must retain the second write span"
+    );
+
+    let root_root = model(
+        "spec RootRoot { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { forall i: Idx { m[i - i] = true } \
+                forall j: Idx { m[j - j] = true } } action noop() { } }",
+    );
+    let error = fsl_runtime::check_init_write_ownership(&root_root)
+        .expect_err("two unresolved writes must overlap on the same logical root");
+    assert_eq!(
+        error.message,
+        "state variable 'm' assigned more than once in init forall"
+    );
+    assert!(
+        error.span.is_some(),
+        "collision must retain the second write span"
+    );
+
+    let lone_root = model(
+        "spec LoneRoot { type Idx = 0..2 state { m: Map<Idx, Bool> } \
+         init { forall i: Idx { m[i - i] = true } } action noop() { } }",
+    );
+    fsl_runtime::check_init_write_ownership(&lone_root)
+        .expect("a lone unresolved write has no duplicate owner");
+}
+
 #[test]
 fn explicit_violation_trace_replays_through_the_monitor() {
     let model = model(

--- a/rust/fsl-runtime/tests/issue_904_terminal_deadlock.rs
+++ b/rust/fsl-runtime/tests/issue_904_terminal_deadlock.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use std::path::{Path, PathBuf};
+
+use fsl_core::{FsResolver, build_model, parse_kernel_source};
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../fslc/tests/fixtures")
+        .join(name)
+}
+
+fn run_bfs(name: &str) -> fsl_runtime::BfsResult {
+    let path = fixture(name);
+    let source = std::fs::read_to_string(&path).expect("read terminal fixture");
+    let resolver = FsResolver::new(path.parent().expect("fixture directory"));
+    let kernel = parse_kernel_source(&source, &resolver).expect("parse terminal fixture");
+    let model = build_model(kernel).expect("build terminal fixture");
+    fsl_runtime::bfs(model, 1).expect("run legacy BFS")
+}
+
+#[test]
+fn legacy_bfs_does_not_report_an_intended_terminal_state_as_deadlocked() {
+    let result = run_bfs("assurance_terminal_once.fsl");
+
+    assert_eq!(
+        result.deadlock_step, None,
+        "terminal positive control: produced {:?}, expected None",
+        result.deadlock_step
+    );
+}
+
+#[test]
+fn legacy_bfs_still_reports_the_missing_terminal_sibling_as_deadlocked() {
+    let result = run_bfs("assurance_terminal_once_missing.fsl");
+
+    assert_eq!(
+        result.deadlock_step,
+        Some(1),
+        "missing-terminal sibling: produced {:?}, expected Some(1)",
+        result.deadlock_step
+    );
+}

--- a/rust/fsl-syntax/src/causal.rs
+++ b/rust/fsl-syntax/src/causal.rs
@@ -7,8 +7,8 @@
 //! dispatch registry (`frontends!`): a causal model is a sidecar hypothesis
 //! graph, never a kernel spec, and registering it would force the frozen
 //! Python dialect registry to move (see `docs/DESIGN-causal.md` §2 and the
-//! parity check in `tests/test_coupled_change_meta.py` — a manual
-//! compatibility check, not a CI gate; see
+//! parity check in `tests/test_coupled_change_meta.py` — required pre-merge
+//! repository evidence through the automation lane, not a product-gate check; see
 //! `docs/DESIGN-coupled-change-metatest.md`). Consumers detect a causal
 //! document with [`is_causal_source`] before dialect dispatch, the same
 //! pre-dispatch sniff pattern used for legacy AI project files.

--- a/rust/fsl-tools/src/agent.rs
+++ b/rust/fsl-tools/src/agent.rs
@@ -475,8 +475,8 @@ fn reachability(
     closure
 }
 
-/// Compute the six documented `agent_structural_violation` finding kinds
-/// (`docs/DESIGN-ai-hard.md` "Rules enforced as stable semantics") over an
+/// Compute the six documented `agent_structural_violation` finding kinds from
+/// `docs/DESIGN-ai-hard.md` "Recursive Agent Composition" over an
 /// already-validated agent tree.
 #[allow(clippy::too_many_lines)]
 fn agent_findings(

--- a/rust/fsl-tools/src/ai_stochastic.rs
+++ b/rust/fsl-tools/src/ai_stochastic.rs
@@ -202,7 +202,7 @@ fn record_outcome(record: &Value) -> bool {
 
 /// The first `(case_id, slice, metric)` collision, or a record missing one
 /// of those required fields; `None` if the dataset is well-formed
-/// (`docs/DESIGN-stochastic.md`: "A missing required slice field is
+/// (`docs/DESIGN-stochastic.md` states that "A missing required slice field is
 /// `dataset_invalid`. Duplicate `(case_id, slice, metric)` records are
 /// `dataset_invalid`.").
 fn duplicate_eval_key(records: &[Value]) -> Option<Value> {

--- a/rust/fsl-tools/src/db.rs
+++ b/rust/fsl-tools/src/db.rs
@@ -692,8 +692,8 @@ fn migration_op_findings(
 
 /// The `accepts`/`responds`/`provides` capability set contributed by every
 /// `active` or `supported` artifact live at `(schema, flags)`. `may_exist`
-/// artifacts are never providers (`docs/DESIGN-db.md` "an active or
-/// supported provider").
+/// artifacts are never providers; see `docs/DESIGN-db.md` "Generic Artifact
+/// Capabilities and AI Components".
 fn provided_capability(
     environment: &DbEnvironment,
     system: &DbSystem,

--- a/rust/fsl-tools/src/html.rs
+++ b/rust/fsl-tools/src/html.rs
@@ -588,7 +588,7 @@ fn assurance(verification: &Value) -> String {
 }
 
 /// The html property `kind` to the ledger's element group
-/// (`docs/DESIGN-assurance-classes.md`: "Assurance column per property row
+/// (`docs/DESIGN-assurance-classes.md` defines "Assurance column per property row
 /// via `classify_element` (kind->group: invariant->invariants,
 /// leadsTo->leadstos, reachable->reachables, trans->transitions)").
 fn property_group(kind: &str) -> Option<&'static str> {

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -5584,6 +5584,12 @@ fn run_check(path: &Path, display_path: &Path) -> (Value, i32) {
     }
     match load_kernel_model(path) {
         Ok((_, kernel, model)) => {
+            if let Err(error) = fsl_runtime::check_init_write_ownership(&model) {
+                return (
+                    fslc_rust::verification_output::render_runtime_error(envelope(), &error),
+                    2,
+                );
+            }
             let has_trace_contract = match validate_requirement_traces(path, &model) {
                 Ok((Some(failure), _)) => return (failure, 2),
                 Ok((None, has_contract)) => has_contract,

--- a/rust/fslc/src/replay_trace.rs
+++ b/rust/fslc/src/replay_trace.rs
@@ -84,8 +84,8 @@ pub fn parse_replay_trace(data: Value) -> Result<ReplayTraceInput, String> {
     let events = match data {
         Value::Array(events) => events,
         Value::Object(mut object) => {
-            match object.remove("events") {
-                Some(Value::Array(events)) => events,
+            match (object.len(), object.remove("events")) {
+                (1, Some(Value::Array(events))) => events,
                 _ => {
                     return Err("trace JSON must be a public replay trace, an array, or {\"events\": [...]}".to_owned());
                 }
@@ -283,6 +283,16 @@ mod tests {
                 .expect_err("reserved marker must select v1")
                 .contains("invalid replay trace v1")
         );
+        for input in [
+            json!({"eventz":[]}),
+            json!({"events":{}}),
+            json!({"events":[],"extra":true}),
+        ] {
+            assert_eq!(
+                parse_replay_trace(input).expect_err("legacy wrapper shape must be exact"),
+                "trace JSON must be a public replay trace, an array, or {\"events\": [...]}"
+            );
+        }
     }
 
     #[test]

--- a/rust/fslc/src/source_diagnostic.rs
+++ b/rust/fslc/src/source_diagnostic.rs
@@ -85,24 +85,23 @@ pub fn diagnostics_with_model(
 }
 
 fn core_diagnostic(source: &str, error: &fsl_core::CoreError) -> SourceDiagnostic {
-    let message = error.to_string();
+    let diagnostic = crate::spec_load::SemanticDiagnostic::from_core_error(error);
     SourceDiagnostic {
-        kind: crate::verification_output::diagnostic_kind(&message, error.name_resolution),
+        kind: crate::verification_output::diagnostic_kind(
+            &diagnostic.message,
+            diagnostic.name_resolution,
+        ),
         code: "FSL-SEMANTIC".to_owned(),
-        message,
+        message: diagnostic.message,
         span: error
             .origin
             .as_deref()
             .and_then(|origin| origin.primary.as_ref())
             .and_then(|site| site.span)
             .unwrap_or_else(|| point_span(source, error.line, error.column)),
-        // `CoreError` carries `line: 0` as its "unknown" sentinel.
-        located: error.line != 0
-            || error
-                .origin
-                .as_deref()
-                .and_then(|origin| origin.primary.as_ref())
-                .is_some_and(|site| site.span.is_some()),
+        // `line`/`column` also carry legacy placeholders such as `(1, 1)`.
+        // Only an authored origin proves that the public location is real.
+        located: diagnostic.loc.is_some(),
     }
 }
 

--- a/rust/fslc/src/spec_load.rs
+++ b/rust/fslc/src/spec_load.rs
@@ -80,8 +80,20 @@ impl SemanticDiagnostic {
     /// frontend's name-resolution classification.
     #[must_use]
     pub fn from_core_error(error: &fsl_core::CoreError) -> Self {
+        // Compose's authored lowering diagnostics historically render without
+        // a file prefix. Their new origin exists to prove the span is real,
+        // not to change that public message contract. Component-load origins
+        // have a non-empty declaration path and keep their file-qualified
+        // rendering.
+        let authored_compose_error = error.origin.as_deref().is_some_and(|origin| {
+            origin.dialect == "compose" && origin.id.0.starts_with("compose:error:")
+        });
         Self {
-            message: error.to_string(),
+            message: if authored_compose_error {
+                format!("{} at {}:{}", error.message, error.line, error.column)
+            } else {
+                error.to_string()
+            },
             loc: crate::verification_output::origin_loc(error.origin.as_deref()),
             name_resolution: error.name_resolution,
         }

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -874,7 +874,12 @@ pub(super) fn run_explicit_filtered(request: ExplicitRequest<'_>) -> (Value, i32
         checked_bounds.as_ref(),
     ) {
         Ok(result) => result,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => {
+            return (
+                fslc_rust::verification_output::render_runtime_error(envelope(), &error),
+                2,
+            );
+        }
     };
     let (vacuity, reachable_diagnostics) =
         match explicit_solver_findings(&model, &result.action_coverage) {
@@ -933,7 +938,12 @@ pub(super) fn run_auto_filtered(request: ExplicitRequest<'_>) -> (Value, i32) {
         checked_bounds.as_ref(),
     ) {
         Ok(result) => result,
-        Err(error) => return (semantic_error_output(&error.to_string()), 2),
+        Err(error) => {
+            return (
+                fslc_rust::verification_output::render_runtime_error(envelope(), &error),
+                2,
+            );
+        }
     };
     let (vacuity, reachable_diagnostics) =
         match explicit_solver_findings(&model, &result.action_coverage) {
@@ -1042,6 +1052,14 @@ fn execute_bmc(
 fn prepare_bmc(request: &BmcRequest<'_>, started: Instant) -> Result<PreparedBmc, CommandResult> {
     let model = load_selected_model(request.selection)
         .map_err(|error| (spec_load_error_output(&error), 2))?;
+    if request.initial_state.is_none() {
+        fsl_runtime::check_init_write_ownership(&model).map_err(|error| {
+            (
+                fslc_rust::verification_output::render_runtime_error(envelope(), &error),
+                2,
+            )
+        })?;
+    }
     let checked_bounds = selected_implicit_bounds(
         &model,
         request.selection.property,

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -164,6 +164,20 @@ pub fn render_semantic_error(
     Value::Object(output)
 }
 
+/// Render a runtime diagnostic without discarding an authored statement span.
+#[must_use]
+pub fn render_runtime_error(
+    output: Map<String, Value>,
+    error: &fsl_runtime::RuntimeError,
+) -> Value {
+    render_semantic_error(
+        output,
+        &error.message,
+        error.span.map(fsl_syntax::Span::python_loc),
+        false,
+    )
+}
+
 /// A governance diagnostic with its source location preserved across delivery
 /// surfaces.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rust/fslc/tests/assurance/claim.rs
+++ b/rust/fslc/tests/assurance/claim.rs
@@ -117,8 +117,8 @@ impl Claim {
 }
 
 /// One semantic-surface axis of the assurance matrix: a set of rows, a set
-/// of *declared* columns (the axis's own required scope -- see
-/// `docs/DESIGN-assurance-matrix.md`'s "required" definition), and the
+/// of *declared* columns (the axis's own required scope -- see the
+/// `docs/DESIGN-assurance-matrix.md` "Cell vocabulary"), and the
 /// `Claim` for every `(row, column)` pair the axis declares as required.
 pub struct Axis {
     pub name: &'static str,

--- a/rust/fslc/tests/assurance/dialects.rs
+++ b/rust/fslc/tests/assurance/dialects.rs
@@ -42,7 +42,7 @@ const WORKER_REFINEMENT_CONTROL: Citation = Citation {
 };
 const REFINEMENT_OWNER: Citation = Citation {
     path: "rust/fslc/tests/refine_corpus_parity.rs",
-    anchor: "fn native_refine_matches_the_declared_result_and_exit_for_every_registered_mapping()",
+    anchor: "fn native_refine_matches_the_declared_projection_and_exit_for_every_registered_mapping()",
 };
 const EVIDENCE_OWNER: Citation = Citation {
     path: "rust/fslc/tests/evidence_corpus_manifest.rs",

--- a/rust/fslc/tests/corpus_check_sweep.rs
+++ b/rust/fslc/tests/corpus_check_sweep.rs
@@ -28,23 +28,27 @@
 //! fails under `check`. That assertion now belongs to
 //! `corpus_expectation_manifest.rs`, which runs every header's declared
 //! command verbatim (not just `check`) and compares `result`/`kind`/exit
-//! against the declaration (issue #645, #537 C4 residual). This file keeps
-//! exactly two properties, deliberately narrower than a per-file oracle:
-//! (i) a file that declares no error anywhere must not fail `check`
-//! unexpectedly, and (ii) the Verdict Conservation Law below. Splitting the
-//! two prevents a gap, not a hole: `corpus_expectation_manifest.rs`'s roster
-//! is derived from the same header convention this sweep reads, so a
-//! `check`-targeted declared fixture cannot lose its owner by falling
-//! between the two files.
+//! against the declaration (issue #645, #537 C4 residual). This file's
+//! per-file rule remains deliberately narrower than an oracle: a file that
+//! declares no error anywhere must not fail `check` unexpectedly. The
+//! independent `check` and `verify` Verdict Conservation Laws below bind
+//! their envelopes to process exits without declaring a per-file result; the
+//! verify owner checks the exact public 0/1/2/3 mapping, not only zero versus
+//! non-zero.
+//! Splitting these properties prevents a gap, not a hole:
+//! `corpus_expectation_manifest.rs`'s roster is derived from the same header
+//! convention this sweep reads, so a `check`-targeted declared fixture cannot
+//! lose its owner by falling between the two files.
 //!
-//! `check_result_and_exit_status_never_contradict` below is a second,
-//! independent property over the same corpus sweep (issue #537 C2, Verdict
-//! Conservation Law). It holds no per-file oracle and needs none of the
-//! exclusions above: unlike "does this file check clean", "does the exit
-//! status agree with the result class" is a closed law that every corpus
-//! file -- including deliberately-failing fixtures and the
+//! `check_result_and_exit_status_never_contradict` and
+//! `verify_result_and_exit_status_never_contradict` are independent
+//! properties over the same corpus sweep (issue #537 C2 and issue #761 F1,
+//! Verdict Conservation Law). They hold no per-file oracle and need none of
+//! the exclusions above: unlike "does this file check clean", "does the exit
+//! status agree with the result class" is a closed law that every corpus file
+//! -- including deliberately-failing fixtures and the
 //! `refinement`/`examples/gallery/injected/` categories excluded above --
-//! must satisfy. Its class definition is production code
+//! must satisfy. Their class definition is production code
 //! (`fslc_rust::outcome::outcome_class`), not a list in this file.
 
 use std::collections::BTreeSet;
@@ -113,6 +117,55 @@ fn run_check(path: &Path) -> (Value, i32) {
         )
     });
     (value, status)
+}
+
+/// Runs the bounded BMC baseline used by the corpus-wide verify/exit
+/// conservation law. These arguments also match the verify side of the
+/// ledger comparison below.
+fn run_verify(path: &Path) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "verify",
+            path.to_str().expect("utf8 path"),
+            "--depth",
+            "2",
+            "--deadlock",
+            "ignore",
+            "--engine",
+            "bmc",
+        ])
+        .current_dir(root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for `fslc verify {}`: {error}; stderr={}",
+            path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let status = output.status.code().unwrap_or_else(|| {
+        panic!(
+            "`fslc verify {}` terminated by signal, no exit code",
+            path.display()
+        )
+    });
+    (value, status)
+}
+
+/// Exact public exit contract for a top-level `fslc verify` envelope.
+/// Keep this independent from the CLI's final process-status normalization so
+/// a production mapping mutation cannot change both produced and expected.
+fn expected_verify_exit(envelope: &Value) -> i32 {
+    match envelope.get("result").and_then(Value::as_str) {
+        Some("verified" | "proved") => 0,
+        Some("violated" | "reachable_failed" | "unknown_cti" | "unknown_budget") => 1,
+        Some("error") if envelope.get("kind").and_then(Value::as_str) == Some("internal") => 3,
+        Some("error") => 2,
+        result => panic!(
+            "unregistered `fslc verify` result {result:?}; update the public exact-exit contract"
+        ),
+    }
 }
 
 #[test]
@@ -246,6 +299,100 @@ fn check_result_and_exit_status_never_contradict() {
     );
 }
 
+/// Exact Verdict Conservation Law for `fslc verify` over the complete corpus.
+/// Like the check-side owner above, this has no per-file expected verdict:
+/// it derives the exact expected exit from each envelope's public result/kind
+/// class and binds it to the process status for every accepted, deliberately
+/// failing, and structurally inapplicable corpus file without exclusions.
+#[test]
+fn verify_result_and_exit_status_never_contradict() {
+    let root = root();
+    let files = corpus_files(&root);
+    assert!(
+        files.len() > 150,
+        "corpus scan floor: found only {} .fsl files under specs/+examples/, expected 150+ \
+         (the directory walk may be broken)",
+        files.len()
+    );
+
+    let mut failures = Vec::new();
+    let mut observed_results = BTreeSet::new();
+
+    for path in &files {
+        let rel = repo_relative(&root, path);
+        let (envelope, exit) = run_verify(path);
+
+        let Some(object) = envelope.as_object() else {
+            failures.push(format!(
+                "{rel}: `fslc verify` stdout is not a JSON object: {envelope}"
+            ));
+            continue;
+        };
+        let Some(result) = object.get("result").and_then(Value::as_str) else {
+            failures.push(format!(
+                "{rel}: `fslc verify` envelope has no string `result` field: {envelope}"
+            ));
+            continue;
+        };
+
+        observed_results.insert(result.to_owned());
+        let expected_exit = expected_verify_exit(&envelope);
+        if exit != expected_exit {
+            failures.push(format!(
+                "{rel}: verify result={result:?}; produced exit={exit}, expected \
+                 exit={expected_exit} from the public exact-exit contract"
+            ));
+        }
+
+        let produced_success_class = fslc_rust::outcome::outcome_class(&envelope).is_success();
+        let expected_success_class = expected_exit == 0;
+        if produced_success_class != expected_success_class {
+            failures.push(format!(
+                "{rel}: verify result={result:?}; production outcome_class produced \
+                 success={produced_success_class}, expected success={expected_success_class} \
+                 from exact exit={expected_exit}"
+            ));
+        }
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+    for required in ["verified", "violated", "reachable_failed", "error"] {
+        assert!(
+            observed_results.contains(required),
+            "expected corpus verify to exercise result={required:?}; got {observed_results:?}"
+        );
+    }
+}
+
+#[test]
+fn verify_result_classes_map_to_exact_public_exit_codes() {
+    for result in ["verified", "proved"] {
+        assert_eq!(
+            expected_verify_exit(&serde_json::json!({"result": result})),
+            0
+        );
+    }
+    for result in [
+        "violated",
+        "reachable_failed",
+        "unknown_cti",
+        "unknown_budget",
+    ] {
+        assert_eq!(
+            expected_verify_exit(&serde_json::json!({"result": result})),
+            1
+        );
+    }
+    assert_eq!(
+        expected_verify_exit(&serde_json::json!({"result": "error", "kind": "semantics"})),
+        2
+    );
+    assert_eq!(
+        expected_verify_exit(&serde_json::json!({"result": "error", "kind": "internal"})),
+        3
+    );
+}
+
 /// Runs `fslc` with `args` and returns only its exit status -- `ledger`
 /// prints rendered Markdown (not JSON) to stdout when `-o` is omitted, so
 /// unlike `run_check` there is no envelope here to parse.
@@ -292,16 +439,7 @@ fn ledger_exit_status_agrees_with_its_verify_baseline() {
     for path in &files {
         let rel = repo_relative(&root, path);
         let path_str = path.to_str().expect("utf8 path");
-        let verify_exit = run_exit_status(&[
-            "verify",
-            path_str,
-            "--depth",
-            "2",
-            "--deadlock",
-            "ignore",
-            "--engine",
-            "bmc",
-        ]);
+        let (_verify_envelope, verify_exit) = run_verify(path);
         let ledger_exit = run_exit_status(&["ledger", path_str, "--depth", "2"]);
 
         if verify_exit != 0 {

--- a/rust/fslc/tests/dialect_induction_contract.rs
+++ b/rust/fslc/tests/dialect_induction_contract.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native CLI ownership for the business, requirements, and governance
+//! induction cases previously compared only by
+//! `tools/check_rust_dialect_parity.py` (issue #761 F2).
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+struct Case {
+    path: &'static str,
+    spec: &'static str,
+    invariants: &'static [&'static str],
+}
+
+const CASES: &[Case] = &[
+    Case {
+        path: "examples/e2e/1_business.fsl",
+        spec: "ExpenseToBe",
+        invariants: &["_bounds_claim_stage"],
+    },
+    Case {
+        path: "examples/e2e/2_requirements.fsl",
+        spec: "ExpenseRequirements",
+        invariants: &["_bounds_claim_amount", "_bounds_claim_stage"],
+    },
+    Case {
+        path: "examples/consulting/governance_controls.fsl",
+        spec: "ExpenseTransformationControls",
+        invariants: &["_governance_catalog_ok"],
+    },
+];
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_induction(path: &str) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "verify",
+            path,
+            "--depth",
+            "8",
+            "--engine",
+            "induction",
+            "--k",
+            "1",
+            "--deadlock",
+            "warn",
+        ])
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for induction case {path}: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn string_set(value: &Value) -> BTreeSet<&str> {
+    value
+        .as_array()
+        .expect("expected JSON array")
+        .iter()
+        .map(|item| item.as_str().expect("expected string array item"))
+        .collect()
+}
+
+#[test]
+fn business_requirements_and_governance_pin_native_induction_contracts() {
+    for case in CASES {
+        let (output, exit) = run_induction(case.path);
+        assert_eq!(
+            exit, 0,
+            "{}: produced exit={exit}, expected=0; {output:#}",
+            case.path
+        );
+        assert_eq!(output["result"], "proved", "{}: {output:#}", case.path);
+        assert_eq!(output["spec"], case.spec, "{}: {output:#}", case.path);
+        assert_eq!(output["engine"], "induction", "{}: {output:#}", case.path);
+        assert_eq!(
+            output["completeness"], "unbounded",
+            "{}: {output:#}",
+            case.path
+        );
+        assert_eq!(output["checked_to_depth"], 8, "{}: {output:#}", case.path);
+        assert_eq!(output["base_depth"], 8, "{}: {output:#}", case.path);
+        assert_eq!(
+            string_set(&output["invariants_checked"]),
+            case.invariants.iter().copied().collect(),
+            "{}: {output:#}",
+            case.path
+        );
+
+        let k_used = output["k_used"]
+            .as_object()
+            .unwrap_or_else(|| panic!("{}: expected k_used object; {output:#}", case.path));
+        assert_eq!(
+            k_used.len(),
+            case.invariants.len(),
+            "{}: {output:#}",
+            case.path
+        );
+        for invariant in case.invariants {
+            assert_eq!(
+                k_used.get(*invariant),
+                Some(&Value::from(1)),
+                "{}: invariant={invariant}; {output:#}",
+                case.path
+            );
+        }
+
+        match case.path {
+            "examples/e2e/1_business.fsl" => {
+                assert_eq!(
+                    output["leads_to"]["CTRL-1"]["checked_to_depth"], 8,
+                    "{output:#}"
+                );
+                assert_eq!(
+                    output["leads_to"]["CTRL-2"]["checked_to_depth"], 8,
+                    "{output:#}"
+                );
+                assert_eq!(
+                    output["reachables"]["CanPay"]["witnessed_at_step"], 3,
+                    "{output:#}"
+                );
+            }
+            "examples/e2e/2_requirements.fsl" => {
+                assert_eq!(output["implements"]["abs"], "ExpenseToBe", "{output:#}");
+                assert_eq!(output["implements"]["result"], "refines", "{output:#}");
+            }
+            "examples/consulting/governance_controls.fsl" => {
+                assert_eq!(
+                    output["action_coverage"]["_governance_noop"]["covered"], false,
+                    "{output:#}"
+                );
+                assert_eq!(
+                    output["action_coverage"]["_governance_noop"]["requirement"]["id"], "GOV",
+                    "{output:#}"
+                );
+            }
+            _ => unreachable!("unregistered dialect induction case"),
+        }
+    }
+}

--- a/rust/fslc/tests/explicit_engine.rs
+++ b/rust/fslc/tests/explicit_engine.rs
@@ -272,6 +272,42 @@ fn explicit_accepts_forall_init_writing_the_same_value_every_iteration() {
 }
 
 #[test]
+fn unresolved_init_index_collisions_share_the_ownership_diagnostic() {
+    let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let expected = "state variable 'm' assigned more than once in init forall";
+
+    for name in ["issue_826_root_concrete.fsl", "issue_826_root_root.fsl"] {
+        let path = fixtures.join(name);
+        let path = path.to_str().expect("UTF-8 fixture path");
+
+        let (checked, check_status) = run_cli(&["check".to_owned(), path.to_owned()]);
+        assert_eq!(check_status, 2, "check accepted {name}: {checked:#}");
+        assert_eq!(checked["result"], "error");
+        assert_eq!(checked["kind"], "semantics");
+        assert_eq!(checked["message"], expected);
+        assert_eq!(checked["loc"], json!({"line": 8, "column": 21}));
+
+        for engine in ["bmc", "explicit"] {
+            let (verified, verify_status) = verify(path, engine, 1, &[]);
+            assert_eq!(verify_status, 2, "{engine} accepted {name}: {verified:#}");
+            assert_eq!(verified["result"], checked["result"]);
+            assert_eq!(verified["kind"], checked["kind"]);
+            assert_eq!(verified["message"], checked["message"]);
+            assert_eq!(verified["loc"], checked["loc"]);
+        }
+    }
+
+    let lone = fixtures.join("issue_826_lone_root.fsl");
+    let lone = lone.to_str().expect("UTF-8 fixture path");
+    let (checked, check_status) = run_cli(&["check".to_owned(), lone.to_owned()]);
+    assert_eq!(check_status, 0, "check rejected a lone owner: {checked:#}");
+    assert_eq!(checked["result"], "ok");
+    let (verified, verify_status) = verify(lone, "bmc", 1, &[]);
+    assert_eq!(verify_status, 0, "BMC rejected a lone owner: {verified:#}");
+    assert_eq!(verified["result"], "verified");
+}
+
+#[test]
 fn explicit_closure_proves_true_noninductive_invariant() {
     let fixture =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/explicit_noninductive.fsl");

--- a/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
+++ b/rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json
@@ -7630,11 +7630,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -7786,11 +7786,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -7811,11 +7811,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8038,11 +8038,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8063,11 +8063,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8102,11 +8102,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8133,11 +8133,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8162,11 +8162,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8192,11 +8192,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8220,11 +8220,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8250,11 +8250,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8278,11 +8278,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8308,11 +8308,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8336,11 +8336,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8367,11 +8367,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8396,11 +8396,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8427,11 +8427,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8456,11 +8456,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8486,11 +8486,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",
@@ -8514,11 +8514,11 @@
           "versions": {
             "verifier": {
               "name": "fslc-rust",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "core": {
               "name": "fsl-core",
-              "version": "4.4.0"
+              "version": "4.4.1"
             },
             "solver": {
               "name": "z3",

--- a/rust/fslc/tests/fixtures/issue_826_lone_root.fsl
+++ b/rust/fslc/tests/fixtures/issue_826_lone_root.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec LoneRootWrite {
+  type Idx = 0..2
+  state { m: Map<Idx, Bool> }
+  init { forall i: Idx { m[i - i] = true } }
+  action noop() { }
+}

--- a/rust/fslc/tests/fixtures/issue_826_root_concrete.fsl
+++ b/rust/fslc/tests/fixtures/issue_826_root_concrete.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec RootConcreteCollision {
+  type Idx = 0..2
+  state { m: Map<Idx, Bool> }
+  init {
+    forall i: Idx { m[i - i] = true }
+    forall j: Idx { m[j] = true }
+  }
+  action noop() { }
+}

--- a/rust/fslc/tests/fixtures/issue_826_root_root.fsl
+++ b/rust/fslc/tests/fixtures/issue_826_root_root.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec RootRootCollision {
+  type Idx = 0..2
+  state { m: Map<Idx, Bool> }
+  init {
+    forall i: Idx { m[i - i] = true }
+    forall j: Idx { m[j - j] = true }
+  }
+  action noop() { }
+}

--- a/rust/fslc/tests/fixtures/issue_832/accept_alias_condition.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/accept_alias_condition.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose AcceptAliasCondition {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    if core.flag {
+      x = 0
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_832/accept_real_type.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/accept_real_type.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose AcceptRealType {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    forall u: core.RealType {
+      x = 0
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_832/core.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/core.fsl
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec Core {
+  type RealType = 0..1
+  state { flag: Bool }
+  init { flag = true }
+  action noop() {}
+}

--- a/rust/fslc/tests/fixtures/issue_832/expr_binder.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/expr_binder.fsl
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+compose Broken {
+  use Core as core from "core.fsl"
+    invariant Bad { forall u: core.NoSuchType { true } }
+}

--- a/rust/fslc/tests/fixtures/issue_832/requirements_missing_binder.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/requirements_missing_binder.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+requirements ProcessBinderLocation {
+  process Claim {
+    stages Draft, Done
+    initial Draft
+    transition finish Draft -> Done by System
+  }
+  invariant Bad { forall c: Missing { true } }
+}
+verify { instances Claim = 1 }

--- a/rust/fslc/tests/fixtures/issue_832/requirements_real_binder.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/requirements_real_binder.fsl
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+requirements ProcessBinderLocation {
+  process Claim {
+    stages Draft, Done
+    initial Draft
+    transition finish Draft -> Done by System
+  }
+  invariant Good { forall c: Claim { true } }
+}
+verify { instances Claim = 1 }

--- a/rust/fslc/tests/fixtures/issue_832/rhs_control.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/rhs_control.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose RhsControl {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    x = nonexistent.value
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_832/shape_a.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/shape_a.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose ShapeA {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    forall u: core.NoSuchType {
+      x = 0
+    }
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_832/shape_b.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/shape_b.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose ShapeB {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init {
+    if nonexistent.flag {
+      x = 0
+    }
+  }
+}

--- a/rust/fslc/tests/goldens/induction_cli_contract.json
+++ b/rust/fslc/tests/goldens/induction_cli_contract.json
@@ -1,0 +1,2363 @@
+[
+  {
+    "path": "examples/gallery/valid/tiny_turnstile.fsl",
+    "depth": 4,
+    "k": 1,
+    "exit": 0,
+    "output": {
+      "action_coverage": {
+        "coin": true,
+        "push": true
+      },
+      "base_depth": 4,
+      "checked_to_depth": 4,
+      "completeness": "unbounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "coin"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "push"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 12,
+            "elapsed_s": "<elapsed>",
+            "kind": "ensures",
+            "name": "push"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "LockedOrOpen"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "LockedOrOpen"
+          },
+          {
+            "checks": 3,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "OneEntry"
+          },
+          {
+            "checks": 4,
+            "elapsed_s": "<elapsed>",
+            "kind": "reachable",
+            "name": "OneEntry"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_entries"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_locked"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "coin"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "push"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "engine": "induction",
+      "fsl": "1.0",
+      "invariants_checked": [
+        "_bounds_entries",
+        "LockedOrOpen"
+      ],
+      "k_used": {
+        "LockedOrOpen": 1,
+        "_bounds_entries": 1
+      },
+      "reachables": {
+        "OneEntry": {
+          "witness": "<replayed-base-witness>",
+          "witnessed_at_step": 2
+        }
+      },
+      "result": "proved",
+      "spec": "GalleryTinyTurnstile",
+      "transitions_checked": [],
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "warnings": []
+    }
+  },
+  {
+    "path": "examples/gallery/valid/tiny_traffic_light.fsl",
+    "depth": 5,
+    "k": 1,
+    "exit": 0,
+    "output": {
+      "action_coverage": {
+        "tick": true
+      },
+      "base_depth": 5,
+      "checked_to_depth": 5,
+      "completeness": "unbounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "tick"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "AlwaysAColor"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "AlwaysAColor"
+          },
+          {
+            "checks": 3,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "SeenYellow"
+          },
+          {
+            "checks": 4,
+            "elapsed_s": "<elapsed>",
+            "kind": "reachable",
+            "name": "SeenYellow"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_light"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "engine": "induction",
+      "fsl": "1.0",
+      "invariants_checked": [
+        "_bounds_light",
+        "AlwaysAColor"
+      ],
+      "k_used": {
+        "AlwaysAColor": 1,
+        "_bounds_light": 1
+      },
+      "reachables": {
+        "SeenYellow": {
+          "witness": "<replayed-base-witness>",
+          "witnessed_at_step": 2
+        }
+      },
+      "result": "proved",
+      "spec": "GalleryTinyTrafficLight",
+      "transitions_checked": [],
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "warnings": []
+    }
+  },
+  {
+    "path": "examples/gallery/valid/tiny_bounded_counter.fsl",
+    "depth": 4,
+    "k": 1,
+    "exit": 0,
+    "output": {
+      "action_coverage": {
+        "dec": true,
+        "inc": true
+      },
+      "base_depth": 4,
+      "checked_to_depth": 4,
+      "completeness": "unbounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "dec"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "inc"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "NeverAboveCap"
+          },
+          {
+            "checks": 4,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "HitCap"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "NeverAboveCap"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "reachable",
+            "name": "HitCap"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_n"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "dec"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "inc"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "engine": "induction",
+      "fsl": "1.0",
+      "invariants_checked": [
+        "_bounds_n",
+        "NeverAboveCap"
+      ],
+      "k_used": {
+        "NeverAboveCap": 1,
+        "_bounds_n": 1
+      },
+      "reachables": {
+        "HitCap": {
+          "witness": "<replayed-base-witness>",
+          "witnessed_at_step": 3
+        }
+      },
+      "result": "proved",
+      "spec": "GalleryTinyBoundedCounter",
+      "transitions_checked": [],
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "warnings": []
+    }
+  },
+  {
+    "path": "examples/gallery/valid/small_elevator.fsl",
+    "depth": 7,
+    "k": 1,
+    "exit": 0,
+    "output": {
+      "action_coverage": {
+        "call": true,
+        "move_down": true,
+        "move_up": true,
+        "open": true
+      },
+      "base_depth": 7,
+      "checked_to_depth": 7,
+      "completeness": "unbounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "call"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "move_down"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "move_up"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "open"
+          },
+          {
+            "checks": 8,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 9,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "OpenAtTarget"
+          },
+          {
+            "checks": 8,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "OpenAtTarget"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "OpenAtTop"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "reachable",
+            "name": "OpenAtTop"
+          },
+          {
+            "checks": 9,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_door"
+          },
+          {
+            "checks": 9,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_floor"
+          },
+          {
+            "checks": 9,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_target"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "call"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "move_down"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "move_up"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "open"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "engine": "induction",
+      "fsl": "1.0",
+      "invariants_checked": [
+        "_bounds_floor",
+        "_bounds_target",
+        "_bounds_door",
+        "OpenAtTarget"
+      ],
+      "k_used": {
+        "OpenAtTarget": 1,
+        "_bounds_door": 1,
+        "_bounds_floor": 1,
+        "_bounds_target": 1
+      },
+      "reachables": {
+        "OpenAtTop": {
+          "witness": "<replayed-base-witness>",
+          "witnessed_at_step": 4
+        }
+      },
+      "result": "proved",
+      "spec": "GallerySmallElevator",
+      "transitions_checked": [],
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "warnings": []
+    }
+  },
+  {
+    "path": "examples/gallery/adversarial/option_struct_set_seq_combo.fsl",
+    "depth": 5,
+    "k": 1,
+    "exit": 0,
+    "output": {
+      "action_coverage": {
+        "complete": true,
+        "enqueue": true
+      },
+      "base_depth": 5,
+      "checked_to_depth": 5,
+      "completeness": "unbounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "complete"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "enqueue"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "NoDuplicateQueue"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "QueueRowsQueued"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "QueuedInActive"
+          },
+          {
+            "checks": 12,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "NoDuplicateQueue"
+          },
+          {
+            "checks": 12,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "QueueRowsQueued"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "QueuedInActive"
+          },
+          {
+            "checks": 20,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "complete"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_active"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_jobs"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_q"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "complete"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "enqueue"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "engine": "induction",
+      "fsl": "1.0",
+      "invariants_checked": [
+        "_bounds_jobs",
+        "_bounds_active",
+        "_bounds_q",
+        "QueuedInActive",
+        "QueueRowsQueued",
+        "NoDuplicateQueue"
+      ],
+      "k_used": {
+        "NoDuplicateQueue": 1,
+        "QueueRowsQueued": 1,
+        "QueuedInActive": 1,
+        "_bounds_active": 1,
+        "_bounds_jobs": 1,
+        "_bounds_q": 1
+      },
+      "reachables": {},
+      "result": "proved",
+      "spec": "GalleryAdversarialOptionStructSetSeqCombo",
+      "transitions_checked": [],
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "warnings": []
+    }
+  },
+  {
+    "path": "tests/fixtures/rust_port/induction_unknown_cti.fsl",
+    "depth": 4,
+    "k": 1,
+    "exit": 1,
+    "output": {
+      "checked_to_depth": 4,
+      "completeness": "bounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "step"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "Sync"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "XNonNegative"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "Sync"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "XNonNegative"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_x"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_y"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "step"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<null>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "cti": {
+        "states": "<nondeterministic-cti>",
+        "violated_at": 1
+      },
+      "fsl": "1.0",
+      "hint": "this state sequence satisfies all invariants but leads to a violation; the start state may be unreachable — add an auxiliary invariant that excludes it, then re-run",
+      "invariant": "Sync",
+      "k": 1,
+      "result": "unknown_cti",
+      "spec": "InductionUnknownCti",
+      "trace_type": "induction_cti",
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      }
+    }
+  },
+  {
+    "path": "tests/fixtures/rust_port/induction_unknown_cti.fsl",
+    "depth": 4,
+    "k": 3,
+    "exit": 1,
+    "output": {
+      "checked_to_depth": 4,
+      "completeness": "bounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "step"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 8,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "Sync"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "XNonNegative"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "Sync"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "XNonNegative"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_x"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_y"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "step"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<null>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "cti": {
+        "states": "<nondeterministic-cti>",
+        "violated_at": 3
+      },
+      "fsl": "1.0",
+      "hint": "this state sequence satisfies all invariants but leads to a violation; the start state may be unreachable — add an auxiliary invariant that excludes it, then re-run",
+      "invariant": "Sync",
+      "k": 3,
+      "result": "unknown_cti",
+      "spec": "InductionUnknownCti",
+      "trace_type": "induction_cti",
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      }
+    }
+  },
+  {
+    "path": "tests/fixtures/rust_port/ranked_leadsto.fsl",
+    "depth": 5,
+    "k": 1,
+    "exit": 0,
+    "output": {
+      "action_coverage": {
+        "inc": true
+      },
+      "base_depth": 5,
+      "checked_to_depth": 5,
+      "completeness": "unbounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "inc"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "XRange"
+          },
+          {
+            "checks": 76,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo",
+            "name": "ReachFive"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo_rank",
+            "name": "ReachFive"
+          },
+          {
+            "checks": 12,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "ReachFive"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "XRange"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_x"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "inc"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "engine": "induction",
+      "fsl": "1.0",
+      "invariants_checked": [
+        "XRange"
+      ],
+      "k_used": {
+        "XRange": 1
+      },
+      "leads_to": {
+        "ReachFive": {
+          "checked_to_depth": 5,
+          "completeness": "unbounded",
+          "decreases": "(5 - x)",
+          "proof": "ranking",
+          "proved": true
+        }
+      },
+      "note": "invariants and ranked leadsTo proved for all depths",
+      "reachables": {},
+      "result": "proved",
+      "spec": "RankedLeadsto",
+      "transitions_checked": [],
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "warnings": []
+    }
+  },
+  {
+    "path": "tests/fixtures/rust_port/ranked_leadsto_non_decreasing.fsl",
+    "depth": 5,
+    "k": 1,
+    "exit": 1,
+    "output": {
+      "bindings": {},
+      "checked_to_depth": 5,
+      "completeness": "bounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "inc"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "XRange"
+          },
+          {
+            "checks": 76,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo",
+            "name": "ReachFive"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo_rank",
+            "name": "ReachFive"
+          },
+          {
+            "checks": 12,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "ReachFive"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "XRange"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_x"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "inc"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "cti": {
+        "states": "<nondeterministic-cti>",
+        "violated_at": 1
+      },
+      "fsl": "1.0",
+      "hint": "from every state where P holds and Q is false, each enabled action must either make Q true, or keep P true and strictly decrease the measure",
+      "invariant": "ReachFive",
+      "last_action": {
+        "loc": {
+          "column": 3,
+          "line": 7
+        },
+        "name": "inc",
+        "params": {}
+      },
+      "loc": {
+        "column": 3,
+        "line": 13
+      },
+      "measure": "x",
+      "measure_after": 1,
+      "measure_before": 0,
+      "message": "enabled action 'inc' can leave leadsTo 'ReachFive' pending without strictly decreasing the measure",
+      "rank_failure": "non_decreasing_action",
+      "result": "unknown_cti",
+      "spec": "RankedLeadsto",
+      "trace_type": "induction_cti",
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "violation_kind": "leadsTo_rank"
+    }
+  },
+  {
+    "path": "tests/fixtures/rust_port/ranked_leadsto_unbounded_below.fsl",
+    "depth": 5,
+    "k": 1,
+    "exit": 1,
+    "output": {
+      "bindings": {},
+      "checked_to_depth": 5,
+      "completeness": "bounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "inc"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "XRange"
+          },
+          {
+            "checks": 76,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo",
+            "name": "ReachFive"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo_rank",
+            "name": "ReachFive"
+          },
+          {
+            "checks": 12,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "ReachFive"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "XRange"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_x"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "inc"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "cti": {
+        "states": "<nondeterministic-cti>",
+        "violated_at": 0
+      },
+      "fsl": "1.0",
+      "hint": "the decreases measure must be non-negative whenever the leadsTo trigger is pending (P holds and Q is false); add an invariant or use a bounded domain that proves the measure is >= 0",
+      "invariant": "ReachFive",
+      "loc": {
+        "column": 3,
+        "line": 13
+      },
+      "measure": "-x",
+      "measure_value": -1,
+      "message": "leadsTo 'ReachFive' decreases measure can be negative while P holds and Q is false",
+      "rank_failure": "unbounded_below",
+      "result": "unknown_cti",
+      "spec": "RankedLeadsto",
+      "trace_type": "induction_cti",
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "violation_kind": "leadsTo_rank"
+    }
+  },
+  {
+    "path": "tests/fixtures/rust_port/ranked_leadsto_helpful.fsl",
+    "depth": 1,
+    "k": 1,
+    "exit": 0,
+    "output": {
+      "action_coverage": {
+        "idle": true,
+        "step": true
+      },
+      "base_depth": 1,
+      "checked_to_depth": 1,
+      "completeness": "unbounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "idle"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "step"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 3,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "NonNeg"
+          },
+          {
+            "checks": 8,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo",
+            "name": "Responds"
+          },
+          {
+            "checks": 12,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo_rank",
+            "name": "Responds"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "NonNeg"
+          },
+          {
+            "checks": 8,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "Responds"
+          },
+          {
+            "checks": 3,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_level"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "step"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "engine": "induction",
+      "fsl": "1.0",
+      "invariants_checked": [
+        "_bounds_level",
+        "NonNeg"
+      ],
+      "k_used": {
+        "NonNeg": 1,
+        "_bounds_level": 1
+      },
+      "leads_to": {
+        "Responds": {
+          "checked_to_depth": 1,
+          "completeness": "unbounded",
+          "decreases": "level[c]",
+          "helpful": [
+            "step(c)"
+          ],
+          "proof": "ranking",
+          "proved": true
+        }
+      },
+      "note": "invariants and ranked leadsTo proved for all depths",
+      "reachables": {},
+      "result": "proved",
+      "spec": "HelpfulPerEntity",
+      "transitions_checked": [],
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "warnings": []
+    }
+  },
+  {
+    "path": "tests/fixtures/rust_port/ranked_leadsto_helpful_nonfair.fsl",
+    "depth": 1,
+    "k": 1,
+    "exit": 1,
+    "output": {
+      "bindings": {
+        "c": 0
+      },
+      "checked_to_depth": 1,
+      "completeness": "bounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "idle"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "step"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "NonNeg"
+          },
+          {
+            "checks": 8,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo",
+            "name": "Responds"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo_rank",
+            "name": "Responds"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "NonNeg"
+          },
+          {
+            "checks": 8,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "Responds"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_level"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "step"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "cti": {
+        "states": "<nondeterministic-cti>",
+        "violated_at": 0
+      },
+      "fsl": "1.0",
+      "helpful": [
+        "step(c)"
+      ],
+      "helpful_actions": [
+        {
+          "loc": null,
+          "name": "step",
+          "params": {
+            "c": 0
+          }
+        }
+      ],
+      "hint": "helpful only identifies the per-binding progress action. Add `fair` to the lower-layer action instance that must eventually run; helpful does not create a fairness assumption.",
+      "invariant": "Responds",
+      "loc": {
+        "column": 3,
+        "line": 20
+      },
+      "measure": "level[c]",
+      "measure_value": 1,
+      "message": "leadsTo 'Responds' uses helpful action metadata, but a matching progress action is not declared fair",
+      "rank_failure": "progress_action_not_fair",
+      "result": "unknown_cti",
+      "spec": "HelpfulNonfair",
+      "trace_type": "induction_cti",
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "violation_kind": "leadsTo_rank"
+    }
+  },
+  {
+    "path": "tests/fixtures/rust_port/ranked_leadsto_helpful_blocked.fsl",
+    "depth": 1,
+    "k": 1,
+    "exit": 1,
+    "output": {
+      "bindings": {
+        "c": 0
+      },
+      "checked_to_depth": 1,
+      "completeness": "bounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 4,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "step"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "NonNeg"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo",
+            "name": "Responds"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo_rank",
+            "name": "Responds"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "NonNeg"
+          },
+          {
+            "checks": 8,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "Responds"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_gate"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_level"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "cti": {
+        "states": "<nondeterministic-cti>",
+        "violated_at": 0
+      },
+      "fsl": "1.0",
+      "helpful": [
+        "step(c)"
+      ],
+      "helpful_actions": [
+        {
+          "loc": null,
+          "name": "step",
+          "params": {
+            "c": 0
+          }
+        }
+      ],
+      "hint": "helpful marks which action instance is responsible for progress. The matching action must be declared `fair action`, must be enabled whenever the obligation is pending, and must strictly decrease the rank when it fires; other actions must keep the pending obligation true (unless they make Q true) and must not increase the measure -- an unbounded increase between helpful firings can outpace the guaranteed decrease and prevent Q from ever being reached",
+      "invariant": "Responds",
+      "loc": {
+        "column": 3,
+        "line": 25
+      },
+      "measure": "level[c]",
+      "measure_value": 1,
+      "message": "leadsTo 'Responds' can be pending while no matching helpful action instance is enabled",
+      "rank_failure": "helpful_action_not_enabled",
+      "result": "unknown_cti",
+      "spec": "BlockedHelpful",
+      "trace_type": "induction_cti",
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "violation_kind": "leadsTo_rank"
+    }
+  },
+  {
+    "path": "tests/fixtures/rust_port/ranked_leadsto_helpful_flickering.fsl",
+    "depth": 8,
+    "k": 1,
+    "exit": 1,
+    "output": {
+      "bindings": {},
+      "checked_to_depth": 8,
+      "completeness": "bounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "helpEven"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "helpOdd"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "rotate"
+          },
+          {
+            "checks": 3,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 249,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo",
+            "name": "Finishes"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo_rank",
+            "name": "Finishes"
+          },
+          {
+            "checks": 18,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "Finishes"
+          },
+          {
+            "checks": 32,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "helpEven"
+          },
+          {
+            "checks": 32,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "helpOdd"
+          },
+          {
+            "checks": 32,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "rotate"
+          },
+          {
+            "checks": 10,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_credit"
+          },
+          {
+            "checks": 9,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_done"
+          },
+          {
+            "checks": 10,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_phase"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "helpEven"
+          },
+          {
+            "checks": 2,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "helpOdd"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "rotate"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "cti": {
+        "states": "<nondeterministic-cti>",
+        "violated_at": 1
+      },
+      "fsl": "1.0",
+      "helpful": [
+        "helpEven()",
+        "helpOdd()"
+      ],
+      "helpful_actions": [
+        {
+          "loc": null,
+          "name": "helpEven",
+          "params": {}
+        }
+      ],
+      "hint": "with more than one `helpful` action, each instance's enabledness must not flicker: once a helpful instance becomes enabled while the obligation is pending, it must stay enabled until it fires (or Q holds) -- otherwise its weak fairness is never triggered. Guard the other actions so they cannot disable a pending helpful instance, or split into a leadsTo per helpful action so each owns a stable region",
+      "invariant": "Finishes",
+      "last_action": {
+        "loc": {
+          "column": 3,
+          "line": 23
+        },
+        "name": "rotate",
+        "params": {}
+      },
+      "loc": {
+        "column": 3,
+        "line": 28
+      },
+      "measure": "credit",
+      "message": "helpful action 'helpEven' can become disabled again while leadsTo 'Finishes' is still pending, without itself having fired",
+      "rank_failure": "helpful_action_enabledness_not_sticky",
+      "result": "unknown_cti",
+      "spec": "HelpfulFlickering",
+      "trace_type": "induction_cti",
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "violation_kind": "leadsTo_rank"
+    }
+  },
+  {
+    "path": "tests/fixtures/rust_port/ranked_leadsto_helpful_pumped.fsl",
+    "depth": 8,
+    "k": 1,
+    "exit": 1,
+    "output": {
+      "bindings": {},
+      "checked_to_depth": 8,
+      "completeness": "bounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "pump"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "work"
+          },
+          {
+            "checks": 7,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 9,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "NonNeg"
+          },
+          {
+            "checks": 50,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo",
+            "name": "Finishes"
+          },
+          {
+            "checks": 4,
+            "elapsed_s": "<elapsed>",
+            "kind": "leadsTo_rank",
+            "name": "Finishes"
+          },
+          {
+            "checks": 18,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "Finishes"
+          },
+          {
+            "checks": 9,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "NonNeg"
+          },
+          {
+            "checks": 9,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_x"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "pump"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "session"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "vacuity",
+            "name": "work"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "cti": {
+        "states": "<nondeterministic-cti>",
+        "violated_at": 1
+      },
+      "fsl": "1.0",
+      "helpful": [
+        "work()"
+      ],
+      "helpful_actions": [
+        {
+          "loc": null,
+          "name": "work",
+          "params": {}
+        }
+      ],
+      "hint": "helpful marks which action instance is responsible for progress. The matching action must be declared `fair action`, must be enabled whenever the obligation is pending, and must strictly decrease the rank when it fires; other actions must keep the pending obligation true (unless they make Q true) and must not increase the measure -- an unbounded increase between helpful firings can outpace the guaranteed decrease and prevent Q from ever being reached",
+      "invariant": "Finishes",
+      "last_action": {
+        "loc": {
+          "column": 3,
+          "line": 12
+        },
+        "name": "pump",
+        "params": {}
+      },
+      "loc": {
+        "column": 3,
+        "line": 19
+      },
+      "measure": "x",
+      "measure_after": 3,
+      "measure_before": 1,
+      "message": "non-helpful action 'pump' can increase the measure while leadsTo 'Finishes' is still pending, which could outpace the helpful action's guaranteed decrease",
+      "rank_failure": "non_helpful_action_increases_measure",
+      "result": "unknown_cti",
+      "spec": "HelpfulPumpedMeasure",
+      "trace_type": "induction_cti",
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "violation_kind": "leadsTo_rank"
+    }
+  },
+  {
+    "path": "specs/cart_buggy.fsl",
+    "depth": 5,
+    "k": 1,
+    "exit": 1,
+    "output": {
+      "blame": {
+        "conjuncts": [
+          {
+            "holds": false,
+            "index": 0,
+            "text": "forall i: ItemId { stock[i] >= 0 }",
+            "violating_bindings": [
+              {
+                "i": "<number>"
+              }
+            ]
+          }
+        ]
+      },
+      "checked_to_depth": 4,
+      "completeness": "bounded",
+      "cost": {
+        "elapsed_s": "<elapsed>",
+        "properties": [
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "add_to_cart"
+          },
+          {
+            "checks": 3,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "checkout"
+          },
+          {
+            "checks": 3,
+            "elapsed_s": "<elapsed>",
+            "kind": "action_coverage",
+            "name": "remove_from_cart"
+          },
+          {
+            "checks": 4,
+            "elapsed_s": "<elapsed>",
+            "kind": "deadlock",
+            "name": "deadlock"
+          },
+          {
+            "checks": 1,
+            "elapsed_s": "<elapsed>",
+            "kind": "init",
+            "name": "initial_state"
+          },
+          {
+            "checks": 6,
+            "elapsed_s": "<elapsed>",
+            "kind": "invariant",
+            "name": "NoNegativeStock"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "partial_op",
+            "name": "NoNegativeStock"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_cart"
+          },
+          {
+            "checks": 5,
+            "elapsed_s": "<elapsed>",
+            "kind": "type_bound",
+            "name": "_bounds_stock"
+          }
+        ],
+        "solver": {
+          "check_elapsed_s": "<number>",
+          "checks": "<number>",
+          "conflicts": "<number>",
+          "decisions": "<number>",
+          "memory_mb": "<number>",
+          "propagations": "<number>"
+        }
+      },
+      "fsl": "1.0",
+      "invariant": "NoNegativeStock",
+      "last_action": {
+        "loc": {
+          "column": 3,
+          "line": 30
+        },
+        "name": "checkout",
+        "params": {
+          "u": "<number>"
+        }
+      },
+      "loc": {
+        "column": 3,
+        "line": 37
+      },
+      "result": "violated",
+      "spec": "ShoppingCart",
+      "trace": [
+        {
+          "keys": [
+            "state",
+            "step"
+          ]
+        },
+        {
+          "keys": [
+            "action",
+            "blame",
+            "changes",
+            "state",
+            "step"
+          ],
+          "action_keys": [
+            "loc",
+            "name",
+            "params"
+          ],
+          "changes_shape": [
+            [
+              "from",
+              "to"
+            ]
+          ],
+          "blame_keys": [
+            "effects",
+            "guards"
+          ]
+        },
+        {
+          "keys": [
+            "action",
+            "blame",
+            "changes",
+            "state",
+            "step"
+          ],
+          "action_keys": [
+            "loc",
+            "name",
+            "params"
+          ],
+          "changes_shape": [
+            [
+              "from",
+              "to"
+            ]
+          ],
+          "blame_keys": [
+            "effects",
+            "guards"
+          ]
+        },
+        {
+          "keys": [
+            "action",
+            "blame",
+            "changes",
+            "state",
+            "step"
+          ],
+          "action_keys": [
+            "loc",
+            "name",
+            "params"
+          ],
+          "changes_shape": [
+            [
+              "from",
+              "to"
+            ]
+          ],
+          "blame_keys": [
+            "effects",
+            "guards"
+          ]
+        },
+        {
+          "keys": [
+            "action",
+            "blame",
+            "changes",
+            "state",
+            "step"
+          ],
+          "action_keys": [
+            "loc",
+            "name",
+            "params"
+          ],
+          "changes_shape": [
+            [
+              "from",
+              "to"
+            ]
+          ],
+          "blame_keys": [
+            "effects",
+            "guards"
+          ]
+        }
+      ],
+      "trace_type": "invariant",
+      "versions": {
+        "core": {
+          "name": "fsl-core",
+          "version": "4.4.0"
+        },
+        "solver": {
+          "backend": "native-z3",
+          "name": "z3",
+          "version": "Z3 4.16.0.0"
+        },
+        "verifier": {
+          "name": "fslc-rust",
+          "version": "4.4.0"
+        }
+      },
+      "violated_at_step": 4,
+      "violating_bindings": [
+        {
+          "i": "<number>"
+        }
+      ],
+      "violation_kind": "invariant"
+    }
+  }
+]

--- a/rust/fslc/tests/goldens/induction_cli_contract.json
+++ b/rust/fslc/tests/goldens/induction_cli_contract.json
@@ -131,7 +131,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -140,7 +140,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -247,7 +247,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -256,7 +256,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -382,7 +382,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -391,7 +391,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -559,7 +559,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -568,7 +568,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -727,7 +727,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -736,7 +736,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -843,7 +843,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -852,7 +852,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       }
     }
@@ -958,7 +958,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -967,7 +967,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       }
     }
@@ -1088,7 +1088,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1097,7 +1097,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -1221,7 +1221,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1230,7 +1230,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -1345,7 +1345,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1354,7 +1354,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -1488,7 +1488,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1497,7 +1497,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "warnings": []
@@ -1632,7 +1632,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1641,7 +1641,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -1770,7 +1770,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1779,7 +1779,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -1954,7 +1954,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -1963,7 +1963,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -2109,7 +2109,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -2118,7 +2118,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violation_kind": "leadsTo_rank"
@@ -2339,7 +2339,7 @@
       "versions": {
         "core": {
           "name": "fsl-core",
-          "version": "4.4.0"
+          "version": "4.4.1"
         },
         "solver": {
           "backend": "native-z3",
@@ -2348,7 +2348,7 @@
         },
         "verifier": {
           "name": "fslc-rust",
-          "version": "4.4.0"
+          "version": "4.4.1"
         }
       },
       "violated_at_step": 4,

--- a/rust/fslc/tests/goldens/refine_corpus_projection.v1.json
+++ b/rust/fslc/tests/goldens/refine_corpus_projection.v1.json
@@ -1,0 +1,864 @@
+{
+  "specs/cart_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "CartImpl",
+    "abs": "ShoppingCart",
+    "result": "refines",
+    "checked_to_depth": 8,
+    "action_map": {
+      "add_to_cart": "add_to_cart",
+      "impl_checkout": "checkout",
+      "remove_from_cart": "remove_from_cart",
+      "reserve": "stutter"
+    },
+    "note": "abs ensures are not checked during refinement; verify/prove the abstract spec separately"
+  },
+  "specs/seat_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "SeatBookingImpl",
+    "abs": "SeatBooking",
+    "result": "refines",
+    "checked_to_depth": 6,
+    "action_map": {
+      "cancel_sold": "cancel",
+      "confirm": "book",
+      "hold": "stutter",
+      "release": "stutter"
+    }
+  },
+  "specs/bank_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "BankAccountImpl",
+    "abs": "BankAccount",
+    "result": "refines",
+    "checked_to_depth": 6,
+    "action_map": {
+      "settle": "stutter",
+      "submit_deposit": "deposit",
+      "withdraw_cleared": "withdraw"
+    },
+    "note": "abs ensures are not checked during refinement; verify/prove the abstract spec separately"
+  },
+  "examples/gallery/errors/refinement_failed_map.fsl": {
+    "fsl": "1.0",
+    "impl": "GalleryRefinementImpl",
+    "abs": "GalleryRefinementAbs",
+    "result": "refinement_failed",
+    "kind": "abs_requires_failed",
+    "at": "step",
+    "violated_at_step": 1,
+    "impl_action": {
+      "name": "quick_pay_i",
+      "params": {
+        "k": 0
+      },
+      "loc": {
+        "line": 10,
+        "column": 3
+      }
+    },
+    "abs_before": {
+      "approved": false,
+      "paid": false
+    },
+    "abs_after_expected": {
+      "approved": false,
+      "paid": true
+    },
+    "abs_after_actual": {
+      "approved": false,
+      "paid": true
+    },
+    "mismatch": [],
+    "trace_type": "refinement",
+    "hint": "the impl step does not correspond to the mapped abs action; fix the map expressions, the action correspondence, or guard the impl action"
+  },
+  "examples/gallery/adversarial/refine_mapping_boundary_map.fsl": {
+    "fsl": "1.0",
+    "impl": "GalleryAdversarialRefineImpl",
+    "abs": "GalleryAdversarialRefineAbs",
+    "result": "refinement_failed",
+    "kind": "abs_state_mismatch",
+    "at": "step",
+    "violated_at_step": 1,
+    "impl_action": {
+      "name": "jump",
+      "params": {
+        "i": 0
+      },
+      "loc": {
+        "line": 7,
+        "column": 3
+      }
+    },
+    "abs_before": {
+      "n": 0
+    },
+    "abs_after_expected": {
+      "n": 1
+    },
+    "abs_after_actual": {
+      "n": 2
+    },
+    "mismatch": [
+      "n"
+    ],
+    "trace_type": "refinement",
+    "hint": "the impl step does not correspond to the mapped abs action; fix the map expressions, the action correspondence, or guard the impl action"
+  },
+  "examples/gallery/adversarial/governance_semantic_mapping.fsl": {
+    "fsl": "1.0",
+    "result": "error",
+    "kind": "type",
+    "message": "unknown type 'Missing'",
+    "loc": {
+      "line": 4,
+      "column": 11
+    }
+  },
+  "examples/refinement_liveness/design_drops_liveness_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "DesignDropsLiveness",
+    "abs": "ClaimPolicy",
+    "result": "refines",
+    "checked_to_depth": 8,
+    "action_map": {
+      "approve": "approve",
+      "heartbeat": "stutter",
+      "pay": "pay",
+      "reject": "reject",
+      "route": "stutter"
+    }
+  },
+  "examples/refinement_liveness/design_keeps_liveness_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "DesignKeepsLiveness",
+    "abs": "ClaimPolicy",
+    "result": "refines",
+    "checked_to_depth": 8,
+    "action_map": {
+      "approve": "approve",
+      "heartbeat": "stutter",
+      "pay": "pay",
+      "reject": "reject",
+      "route": "stutter"
+    }
+  },
+  "examples/refinement_liveness/design_drops_liveness_progress_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "DesignDropsLiveness",
+    "abs": "ClaimPolicy",
+    "result": "refinement_failed",
+    "kind": "progress_lost",
+    "progress_failure": "lasso_blocks_progress",
+    "violation_kind": "leadsTo",
+    "invariant": "EveryClaimDecided",
+    "bindings": {},
+    "pending_since": 0,
+    "stutter": false,
+    "trace_type": "refinement",
+    "progress": {
+      "leadsTo": "EveryClaimDecided",
+      "actions": [
+        "approve",
+        "reject"
+      ]
+    },
+    "hint": "the impl refines the abstract safety contract, but admits an execution where the pulled-back abstract leadsTo remains pending. Fairness must come from lower-layer `fair action` declarations for the implementation actions named by preserve progress; action mappings do not create fairness or prove implementation conformance by themselves",
+    "loc": {
+      "line": 25,
+      "column": 3
+    },
+    "loop_start": 1,
+    "faithfulness_class": "liveness_not_refined",
+    "recommended_action": "re-prove liveness at each layer or add preserve progress to the refinement mapping"
+  },
+  "examples/refinement_liveness/design_keeps_liveness_progress_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "DesignKeepsLiveness",
+    "abs": "ClaimPolicy",
+    "result": "refines",
+    "checked_to_depth": 8,
+    "action_map": {
+      "approve": "approve",
+      "heartbeat": "stutter",
+      "pay": "pay",
+      "reject": "reject",
+      "route": "stutter"
+    },
+    "progress": {
+      "EveryClaimDecided": {
+        "checked_to_depth": 8,
+        "actions": [
+          "approve",
+          "reject"
+        ]
+      }
+    }
+  },
+  "examples/refinement_liveness/design_bypasses_control_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "DesignBypassesControl",
+    "abs": "ClaimPolicy",
+    "result": "refinement_failed",
+    "kind": "abs_requires_failed",
+    "at": "step",
+    "violated_at_step": 1,
+    "impl_action": {
+      "name": "fast_pay",
+      "params": {},
+      "loc": {
+        "line": 23,
+        "column": 3
+      }
+    },
+    "abs_before": {
+      "s": "Submitted"
+    },
+    "abs_after_expected": {
+      "s": "Paid"
+    },
+    "abs_after_actual": {
+      "s": "Paid"
+    },
+    "mismatch": [],
+    "trace_type": "refinement",
+    "hint": "the impl step does not correspond to the mapped abs action; fix the map expressions, the action correspondence, or guard the impl action"
+  },
+  "examples/ui_spike/ui_refines_req.fsl": {
+    "fsl": "1.0",
+    "impl": "ReturnUI",
+    "abs": "ReturnReqMin",
+    "result": "refines",
+    "checked_to_depth": 8,
+    "action_map": {
+      "enter_amount": "stutter",
+      "mgr_approved": "approve",
+      "pay": "pay",
+      "resp_auto": "approve",
+      "resp_error": "stutter",
+      "resp_mgr": "stutter",
+      "retry": "stutter",
+      "submit": "stutter"
+    }
+  },
+  "examples/layers/return_impl_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "ReturnImpl",
+    "abs": "ReturnSystemReq",
+    "result": "refines",
+    "checked_to_depth": 5,
+    "action_map": {
+      "mgr_approve": "mgr_approve",
+      "mgr_reject": "mgr_reject",
+      "outbox_send": "stutter",
+      "pay_confirm": "stutter",
+      "pay_submit": "pay",
+      "submit_large": "submit.b2",
+      "submit_small": "submit.b1"
+    }
+  },
+  "examples/consulting/tobe_refines_asis.fsl": {
+    "fsl": "1.0",
+    "impl": "ToBeExpense",
+    "abs": "AsIsExpense",
+    "result": "refines",
+    "checked_to_depth": 6,
+    "action_map": {
+      "auto_approve": "mgr_approve",
+      "mgr_approve": "mgr_approve",
+      "pay": "pay",
+      "reject": "reject",
+      "submit": "submit"
+    }
+  },
+  "examples/e2e/3_refines_2.fsl": {
+    "fsl": "1.0",
+    "impl": "ExpenseDesign",
+    "abs": "ExpenseRequirements",
+    "result": "refines",
+    "checked_to_depth": 8,
+    "action_map": {
+      "auto_approve": "auto_approve",
+      "mgr_approve": "mgr_approve",
+      "mgr_reject": "reject",
+      "outbox_send": "stutter",
+      "pay_confirm": "stutter",
+      "pay_submit": "pay",
+      "submit_large": "submit",
+      "submit_small": "submit"
+    }
+  },
+  "examples/refinement_chain/bot_refines_mid.fsl": {
+    "fsl": "1.0",
+    "impl": "ChainBot",
+    "abs": "ChainMid",
+    "result": "refines",
+    "checked_to_depth": 6,
+    "action_map": {
+      "audit": "stutter",
+      "finish": "finish",
+      "start_review": "start_review"
+    }
+  },
+  "examples/refinement_chain/mid_refines_top.fsl": {
+    "fsl": "1.0",
+    "impl": "ChainMid",
+    "abs": "ChainTop",
+    "result": "refines",
+    "checked_to_depth": 6,
+    "action_map": {
+      "finish": "finish",
+      "start_review": "stutter"
+    }
+  },
+  "examples/nfr/sla_worker_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "SlaWorkerDesign",
+    "abs": "SlaWorker",
+    "result": "refines",
+    "checked_to_depth": 6,
+    "action_map": {
+      "audit": "stutter",
+      "finish": "finish",
+      "start": "start",
+      "submit": "submit",
+      "tick": "tick"
+    }
+  },
+  "examples/validation/order_refund_windowed_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "OrderRefundWindowed",
+    "abs": "OrderRefund",
+    "result": "refines",
+    "checked_to_depth": 8,
+    "action_map": {
+      "cancel": "cancel",
+      "pay": "pay",
+      "refund": "refund",
+      "ship": "ship",
+      "tick": "stutter"
+    }
+  },
+  "examples/validation/order_refund_instant_refines.fsl": {
+    "fsl": "1.0",
+    "impl": "OrderRefundInstant",
+    "abs": "OrderRefund",
+    "result": "refinement_failed",
+    "kind": "abs_requires_failed",
+    "at": "step",
+    "violated_at_step": 2,
+    "impl_action": {
+      "name": "instant_refund",
+      "params": {
+        "o": 0
+      },
+      "loc": {
+        "line": 38,
+        "column": 3
+      }
+    },
+    "abs_before": {
+      "order": {
+        "0": "Paid",
+        "1": "Cart",
+        "2": "Cart"
+      },
+      "refunded_total": 0,
+      "stock": 1
+    },
+    "abs_after_expected": {
+      "order": {
+        "0": "Refunded",
+        "1": "Cart",
+        "2": "Cart"
+      },
+      "refunded_total": 1,
+      "stock": 2
+    },
+    "abs_after_actual": {
+      "order": {
+        "0": "Refunded",
+        "1": "Cart",
+        "2": "Cart"
+      },
+      "refunded_total": 1,
+      "stock": 2
+    },
+    "mismatch": [],
+    "trace_type": "refinement",
+    "hint": "the impl step does not correspond to the mapped abs action; fix the map expressions, the action correspondence, or guard the impl action"
+  },
+  "examples/agentic_rag/agentic_rag_requirements_refines_business.fsl": {
+    "fsl": "1.0",
+    "impl": "AgenticRagRequirements",
+    "abs": "AgenticRagBusiness",
+    "result": "refines",
+    "checked_to_depth": 7,
+    "action_map": {
+      "answer": "answer",
+      "approve_tool": "approve_tool",
+      "classify_answer": "stutter",
+      "classify_tool": "stutter",
+      "deny_tool": "deny_tool",
+      "draft_answer": "stutter",
+      "execute_tool": "execute_tool",
+      "grant_operator": "stutter",
+      "output_guard_fail": "stutter",
+      "output_guard_pass": "clear_response",
+      "receive": "receive",
+      "refuse_guard_failure": "cannot_answer",
+      "refuse_low_evidence": "cannot_answer",
+      "request_tool_approval": "request_approval",
+      "retrieve_empty": "stutter",
+      "retrieve_success": "stutter",
+      "retry_retrieve": "stutter",
+      "review_guard_failure": "escalate",
+      "review_low_evidence": "escalate"
+    },
+    "progress": {
+      "BP1": {
+        "checked_to_depth": 7,
+        "actions": [
+          "output_guard_pass",
+          "refuse_low_evidence",
+          "review_low_evidence",
+          "refuse_guard_failure",
+          "review_guard_failure",
+          "request_tool_approval"
+        ]
+      },
+      "BP2": {
+        "checked_to_depth": 7,
+        "actions": [
+          "answer"
+        ]
+      },
+      "BP3": {
+        "checked_to_depth": 7,
+        "actions": [
+          "approve_tool",
+          "deny_tool"
+        ]
+      },
+      "BP4": {
+        "checked_to_depth": 7,
+        "actions": [
+          "execute_tool"
+        ]
+      }
+    }
+  },
+  "examples/agentic_rag/agentic_rag_design_refines_requirements.fsl": {
+    "fsl": "1.0",
+    "impl": "AgenticRagDesign",
+    "abs": "AgenticRagRequirements",
+    "result": "refines",
+    "checked_to_depth": 6,
+    "action_map": {
+      "accept_request": "stutter",
+      "approve_tool": "approve_tool",
+      "deny_tool": "deny_tool",
+      "draft_answer": "draft_answer",
+      "enqueue_draft": "stutter",
+      "enqueue_router": "stutter",
+      "evaluate_adequate": "retrieve_success",
+      "evaluate_inadequate": "retrieve_empty",
+      "execute_tool": "execute_tool",
+      "output_guard_fail": "output_guard_fail",
+      "output_guard_pass": "output_guard_pass",
+      "plan_tool": "stutter",
+      "publish_answer": "answer",
+      "refuse_guard_failure": "refuse_guard_failure",
+      "refuse_low_evidence": "refuse_low_evidence",
+      "request_tool_approval": "request_tool_approval",
+      "rerank": "stutter",
+      "rerank_retry": "stutter",
+      "review_guard_failure": "review_guard_failure",
+      "review_low_evidence": "review_low_evidence",
+      "route_answer": "classify_answer",
+      "route_tool": "classify_tool",
+      "schedule_retry": "retry_retrieve",
+      "set_operator": "grant_operator",
+      "start_output_guard": "stutter",
+      "vector_search": "stutter",
+      "vector_search_retry": "stutter",
+      "write_audit": "receive"
+    },
+    "progress": {
+      "RequestEventuallyHandled": {
+        "checked_to_depth": 6,
+        "actions": [
+          "publish_answer",
+          "refuse_low_evidence",
+          "review_low_evidence",
+          "refuse_guard_failure",
+          "review_guard_failure",
+          "deny_tool",
+          "execute_tool"
+        ]
+      }
+    }
+  },
+  "examples/agentic_rag/negative/guard_bypass_refines_requirements.fsl": {
+    "fsl": "1.0",
+    "impl": "AgenticRagGuardBypassDesign",
+    "abs": "AgenticRagRequirements",
+    "result": "refinement_failed",
+    "kind": "abs_requires_failed",
+    "at": "step",
+    "violated_at_step": 5,
+    "impl_action": {
+      "name": "publish_without_guard",
+      "params": {
+        "r": 0
+      },
+      "loc": {
+        "line": 87,
+        "column": 3
+      }
+    },
+    "abs_before": {
+      "req": {
+        "0": {
+          "approval": "NoApproval",
+          "audit": true,
+          "citation_ok": true,
+          "evidence": "Adequate",
+          "guard": "Unchecked",
+          "needs_tool": false,
+          "retry": 2,
+          "role": "Public",
+          "st": "Drafted"
+        },
+        "1": {
+          "approval": "NoApproval",
+          "audit": false,
+          "citation_ok": false,
+          "evidence": "Missing",
+          "guard": "Unchecked",
+          "needs_tool": false,
+          "retry": 2,
+          "role": "Public",
+          "st": "New"
+        }
+      }
+    },
+    "abs_after_expected": {
+      "req": {
+        "0": {
+          "approval": "NoApproval",
+          "audit": true,
+          "citation_ok": true,
+          "evidence": "Adequate",
+          "guard": "Unchecked",
+          "needs_tool": false,
+          "retry": 2,
+          "role": "Public",
+          "st": "Answered"
+        },
+        "1": {
+          "approval": "NoApproval",
+          "audit": false,
+          "citation_ok": false,
+          "evidence": "Missing",
+          "guard": "Unchecked",
+          "needs_tool": false,
+          "retry": 2,
+          "role": "Public",
+          "st": "New"
+        }
+      }
+    },
+    "abs_after_actual": {
+      "req": {
+        "0": {
+          "approval": "NoApproval",
+          "audit": true,
+          "citation_ok": true,
+          "evidence": "Adequate",
+          "guard": "Unchecked",
+          "needs_tool": false,
+          "retry": 2,
+          "role": "Public",
+          "st": "Answered"
+        },
+        "1": {
+          "approval": "NoApproval",
+          "audit": false,
+          "citation_ok": false,
+          "evidence": "Missing",
+          "guard": "Unchecked",
+          "needs_tool": false,
+          "retry": 2,
+          "role": "Public",
+          "st": "New"
+        }
+      }
+    },
+    "mismatch": [],
+    "trace_type": "refinement",
+    "hint": "the impl step does not correspond to the mapped abs action; fix the map expressions, the action correspondence, or guard the impl action"
+  },
+  "examples/agentic_rag/negative/tool_approval_bypass_refines_requirements.fsl": {
+    "fsl": "1.0",
+    "impl": "AgenticRagToolApprovalBypassDesign",
+    "abs": "AgenticRagRequirements",
+    "result": "refinement_failed",
+    "kind": "abs_requires_failed",
+    "at": "step",
+    "violated_at_step": 6,
+    "impl_action": {
+      "name": "execute_without_approval",
+      "params": {
+        "r": 0
+      },
+      "loc": {
+        "line": 91,
+        "column": 3
+      }
+    },
+    "abs_before": {
+      "req": {
+        "0": {
+          "approval": "Requested",
+          "audit": true,
+          "citation_ok": true,
+          "evidence": "Adequate",
+          "guard": "Unchecked",
+          "needs_tool": true,
+          "retry": 2,
+          "role": "Operator",
+          "st": "ToolApproval"
+        },
+        "1": {
+          "approval": "NoApproval",
+          "audit": false,
+          "citation_ok": false,
+          "evidence": "Missing",
+          "guard": "Unchecked",
+          "needs_tool": false,
+          "retry": 2,
+          "role": "Public",
+          "st": "New"
+        }
+      }
+    },
+    "abs_after_expected": {
+      "req": {
+        "0": {
+          "approval": "Requested",
+          "audit": true,
+          "citation_ok": true,
+          "evidence": "Adequate",
+          "guard": "Unchecked",
+          "needs_tool": true,
+          "retry": 2,
+          "role": "Operator",
+          "st": "ActionExecuted"
+        },
+        "1": {
+          "approval": "NoApproval",
+          "audit": false,
+          "citation_ok": false,
+          "evidence": "Missing",
+          "guard": "Unchecked",
+          "needs_tool": false,
+          "retry": 2,
+          "role": "Public",
+          "st": "New"
+        }
+      }
+    },
+    "abs_after_actual": {
+      "req": {
+        "0": {
+          "approval": "Requested",
+          "audit": true,
+          "citation_ok": true,
+          "evidence": "Adequate",
+          "guard": "Unchecked",
+          "needs_tool": true,
+          "retry": 2,
+          "role": "Operator",
+          "st": "ActionExecuted"
+        },
+        "1": {
+          "approval": "NoApproval",
+          "audit": false,
+          "citation_ok": false,
+          "evidence": "Missing",
+          "guard": "Unchecked",
+          "needs_tool": false,
+          "retry": 2,
+          "role": "Public",
+          "st": "New"
+        }
+      }
+    },
+    "mismatch": [],
+    "trace_type": "refinement",
+    "hint": "the impl step does not correspond to the mapped abs action; fix the map expressions, the action correspondence, or guard the impl action"
+  },
+  "examples/agentic_rag/negative/liveness_drop_refines_requirements.fsl": {
+    "fsl": "1.0",
+    "impl": "AgenticRagLivenessDropDesign",
+    "abs": "AgenticRagLivenessRequirements",
+    "result": "refinement_failed",
+    "kind": "progress_lost",
+    "progress_failure": "lasso_blocks_progress",
+    "violation_kind": "leadsTo",
+    "invariant": "RequestEventuallyHandled",
+    "bindings": {},
+    "pending_since": 0,
+    "stutter": false,
+    "trace_type": "refinement",
+    "progress": {
+      "leadsTo": "RequestEventuallyHandled",
+      "actions": [
+        "publish_answer"
+      ]
+    },
+    "hint": "the impl refines the abstract safety contract, but admits an execution where the pulled-back abstract leadsTo remains pending. Fairness must come from lower-layer `fair action` declarations for the implementation actions named by preserve progress; action mappings do not create fairness or prove implementation conformance by themselves",
+    "loc": {
+      "line": 65,
+      "column": 5
+    },
+    "loop_start": 0,
+    "faithfulness_class": "liveness_not_refined",
+    "recommended_action": "re-prove liveness at each layer or add preserve progress to the refinement mapping"
+  },
+  "examples/multi_agent_system/multi_agent_requirements_refines_business.fsl": {
+    "fsl": "1.0",
+    "impl": "MultiAgentRequirements",
+    "abs": "MultiAgentBusiness",
+    "result": "refines",
+    "checked_to_depth": 8,
+    "action_map": {
+      "aggregate_results": "collect",
+      "aggregate_revision_results": "stutter",
+      "approve_tool": "approve_effect",
+      "assign_revision_workers": "stutter",
+      "assign_workers": "delegate",
+      "critic_pass": "approve_result",
+      "critic_requests_revision": "stutter",
+      "deliver_answer": "deliver",
+      "deny_tool": "deny_effect",
+      "escalate_after_revision": "escalate_review",
+      "execute_tool": "run_effect",
+      "plan_work": "stutter",
+      "receive": "submit",
+      "reject_after_revision": "reject_result",
+      "request_tool_approval": "request_effect_approval",
+      "revise_plan": "stutter",
+      "scope_high": "stutter",
+      "scope_low": "stutter",
+      "start_critic": "stutter",
+      "worker_a_finish": "stutter",
+      "worker_b_finish": "stutter"
+    },
+    "progress": {
+      "BP1": {
+        "checked_to_depth": 8,
+        "actions": [
+          "assign_workers",
+          "reject_after_revision",
+          "escalate_after_revision"
+        ]
+      },
+      "BP2": {
+        "checked_to_depth": 8,
+        "actions": [
+          "aggregate_results",
+          "escalate_after_revision"
+        ]
+      },
+      "BP3": {
+        "checked_to_depth": 8,
+        "actions": [
+          "critic_pass",
+          "reject_after_revision",
+          "escalate_after_revision"
+        ]
+      },
+      "BP4": {
+        "checked_to_depth": 8,
+        "actions": [
+          "deliver_answer",
+          "request_tool_approval"
+        ]
+      },
+      "BP5": {
+        "checked_to_depth": 8,
+        "actions": [
+          "approve_tool",
+          "deny_tool"
+        ]
+      },
+      "BP6": {
+        "checked_to_depth": 8,
+        "actions": [
+          "execute_tool"
+        ]
+      }
+    }
+  },
+  "examples/multi_agent_system/multi_agent_design_refines_requirements.fsl": {
+    "fsl": "1.0",
+    "impl": "MultiAgentDesign",
+    "abs": "MultiAgentRequirements",
+    "result": "refines",
+    "checked_to_depth": 8,
+    "action_map": {
+      "accept_work": "stutter",
+      "aggregate_results": "aggregate_results",
+      "aggregate_revision_results": "aggregate_revision_results",
+      "approve_tool": "approve_tool",
+      "assign_revision_workers": "assign_revision_workers",
+      "assign_workers": "assign_workers",
+      "classify_high": "scope_high",
+      "classify_low": "scope_low",
+      "critic_pass": "critic_pass",
+      "critic_requests_revision": "critic_requests_revision",
+      "deny_tool": "deny_tool",
+      "enqueue_critic": "stutter",
+      "enqueue_plan": "plan_work",
+      "enqueue_tool": "stutter",
+      "enqueue_workers": "stutter",
+      "escalate_after_revision": "escalate_after_revision",
+      "execute_tool": "execute_tool",
+      "finish_plan": "stutter",
+      "publish_answer": "deliver_answer",
+      "reject_after_revision": "reject_after_revision",
+      "request_tool_approval": "request_tool_approval",
+      "requeue_plan": "revise_plan",
+      "start_critic": "start_critic",
+      "start_planner": "stutter",
+      "worker_a_finish": "worker_a_finish",
+      "worker_b_finish": "worker_b_finish",
+      "write_audit": "receive"
+    },
+    "progress": {
+      "WorkEventuallyHandled": {
+        "checked_to_depth": 8,
+        "actions": [
+          "publish_answer",
+          "reject_after_revision",
+          "escalate_after_revision",
+          "deny_tool",
+          "execute_tool"
+        ]
+      },
+      "WorkOpenUntilHandled": {
+        "checked_to_depth": 8,
+        "actions": [
+          "publish_answer",
+          "reject_after_revision",
+          "escalate_after_revision",
+          "deny_tool",
+          "execute_tool"
+        ]
+      }
+    }
+  }
+}

--- a/rust/fslc/tests/induction_cli_contract.rs
+++ b/rust/fslc/tests/induction_cli_contract.rs
@@ -1,0 +1,513 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native CLI ownership for the sixteen induction envelope/exit cases in
+//! `tools/check_rust_induction_parity.py` (issue #761 F3).
+//!
+//! Regenerate the observed contract from the repository root only after a
+//! reviewed CLI contract change:
+//!
+//! `UPDATE_INDUCTION_CLI_CONTRACT=1 cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test induction_cli_contract --locked`
+//!
+//! The update path executes the same roster, cache handling, normalization,
+//! and exit capture as the ordinary comparison. Ordinary test/CI runs never
+//! write the golden. Review the complete golden diff after regeneration.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::{Map, Value, json};
+
+const UPDATE_ENV: &str = "UPDATE_INDUCTION_CLI_CONTRACT";
+
+struct Case {
+    path: &'static str,
+    depth: u8,
+    k: u8,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        path: "examples/gallery/valid/tiny_turnstile.fsl",
+        depth: 4,
+        k: 1,
+    },
+    Case {
+        path: "examples/gallery/valid/tiny_traffic_light.fsl",
+        depth: 5,
+        k: 1,
+    },
+    Case {
+        path: "examples/gallery/valid/tiny_bounded_counter.fsl",
+        depth: 4,
+        k: 1,
+    },
+    Case {
+        path: "examples/gallery/valid/small_elevator.fsl",
+        depth: 7,
+        k: 1,
+    },
+    Case {
+        path: "examples/gallery/adversarial/option_struct_set_seq_combo.fsl",
+        depth: 5,
+        k: 1,
+    },
+    Case {
+        path: "tests/fixtures/rust_port/induction_unknown_cti.fsl",
+        depth: 4,
+        k: 1,
+    },
+    Case {
+        path: "tests/fixtures/rust_port/induction_unknown_cti.fsl",
+        depth: 4,
+        k: 3,
+    },
+    Case {
+        path: "tests/fixtures/rust_port/ranked_leadsto.fsl",
+        depth: 5,
+        k: 1,
+    },
+    Case {
+        path: "tests/fixtures/rust_port/ranked_leadsto_non_decreasing.fsl",
+        depth: 5,
+        k: 1,
+    },
+    Case {
+        path: "tests/fixtures/rust_port/ranked_leadsto_unbounded_below.fsl",
+        depth: 5,
+        k: 1,
+    },
+    Case {
+        path: "tests/fixtures/rust_port/ranked_leadsto_helpful.fsl",
+        depth: 1,
+        k: 1,
+    },
+    Case {
+        path: "tests/fixtures/rust_port/ranked_leadsto_helpful_nonfair.fsl",
+        depth: 1,
+        k: 1,
+    },
+    Case {
+        path: "tests/fixtures/rust_port/ranked_leadsto_helpful_blocked.fsl",
+        depth: 1,
+        k: 1,
+    },
+    Case {
+        path: "tests/fixtures/rust_port/ranked_leadsto_helpful_flickering.fsl",
+        depth: 8,
+        k: 1,
+    },
+    Case {
+        path: "tests/fixtures/rust_port/ranked_leadsto_helpful_pumped.fsl",
+        depth: 8,
+        k: 1,
+    },
+    Case {
+        path: "specs/cart_buggy.fsl",
+        depth: 5,
+        k: 1,
+    },
+];
+
+#[derive(Clone, Copy)]
+enum Treatment {
+    Mask(&'static str),
+    ValueShape,
+    TraceShape,
+}
+
+struct Exclusion {
+    path: &'static str,
+    reason: &'static str,
+    treatment: Treatment,
+}
+
+// Read from the parity harness's normalization and then tightened from two
+// consecutive native observations. Timing is one path family because all
+// elapsed_s values are wall-clock measurements; the original harness named
+// only the root member even though the nested members vary for the same reason.
+const EXCLUSIONS: &[Exclusion] = &[
+    Exclusion {
+        path: "$.cost.**.*elapsed_s",
+        reason: "wall-clock timing varies between repeated invocations; cost kinds, names, check counts, solver statistics, and memory remain compared",
+        treatment: Treatment::Mask("<elapsed>"),
+    },
+    Exclusion {
+        path: "$.cti.states",
+        reason: "the solver may choose a different induction counterexample; its existence and surrounding diagnostic remain compared",
+        treatment: Treatment::Mask("<nondeterministic-cti>"),
+    },
+    Exclusion {
+        path: "$.reachables.*.witness",
+        reason: "a replayed BMC base witness is non-unique; witnessed depth and the rest of the reachable envelope remain compared",
+        treatment: Treatment::Mask("<replayed-base-witness>"),
+    },
+    Exclusion {
+        path: "$.trace",
+        reason: "a BMC violation witness is non-unique and separately replay-owned; its complete structural shape remains compared",
+        treatment: Treatment::TraceShape,
+    },
+    Exclusion {
+        path: "$.violating_bindings",
+        reason: "binding values derive from the non-unique BMC witness; their complete structural shape remains compared",
+        treatment: Treatment::ValueShape,
+    },
+    Exclusion {
+        path: "$.last_action.params",
+        reason: "parameter values derive from the non-unique BMC witness; their complete structural shape remains compared",
+        treatment: Treatment::ValueShape,
+    },
+    Exclusion {
+        path: "$.blame.conjuncts.*.violating_bindings",
+        reason: "blame binding values derive from the non-unique BMC witness; their complete structural shape remains compared",
+        treatment: Treatment::ValueShape,
+    },
+    Exclusion {
+        path: "$.cost.solver",
+        reason: "Z3 internal search statistics vary across hosts and runs (observed memory_mb 17.24 vs 17.27 and conflicts 1097 vs 1173 for the same case across environments); the key set and value types remain compared",
+        treatment: Treatment::ValueShape,
+    },
+];
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn run_induction(case: &Case) -> (Value, i32) {
+    let depth = case.depth.to_string();
+    let k = case.k.to_string();
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args([
+            "verify",
+            case.path,
+            "--depth",
+            &depth,
+            "--engine",
+            "induction",
+            "--k",
+            &k,
+            "--deadlock",
+            "ignore",
+        ])
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc induction");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON for induction case {} depth={} k={}: {error}; stderr={}",
+            case.path,
+            case.depth,
+            case.k,
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn exclusion_index(path: &str) -> Option<usize> {
+    if path.starts_with("$.cost.") && path.ends_with("elapsed_s") {
+        Some(0)
+    } else if path == "$.cti.states" {
+        Some(1)
+    } else if path.starts_with("$.reachables.") && path.ends_with(".witness") {
+        Some(2)
+    } else if path == "$.trace" {
+        Some(3)
+    } else if path == "$.violating_bindings" {
+        Some(4)
+    } else if path == "$.last_action.params" {
+        Some(5)
+    } else if path.starts_with("$.blame.conjuncts.") && path.ends_with(".violating_bindings") {
+        Some(6)
+    } else if path == "$.cost.solver" {
+        Some(7)
+    } else {
+        None
+    }
+}
+
+fn value_shape(value: &Value) -> Value {
+    match value {
+        Value::Null => json!("<null>"),
+        Value::Bool(_) => json!("<boolean>"),
+        Value::Number(_) => json!("<number>"),
+        Value::String(_) => json!("<string>"),
+        Value::Array(items) => Value::Array(items.iter().map(value_shape).collect()),
+        Value::Object(items) => {
+            let mut keys: Vec<_> = items.keys().collect();
+            keys.sort();
+            Value::Object(
+                keys.into_iter()
+                    .map(|key| (key.clone(), value_shape(&items[key])))
+                    .collect(),
+            )
+        }
+    }
+}
+
+fn sorted_keys(value: &Value) -> Value {
+    match value.as_object() {
+        Some(object) => {
+            let mut keys: Vec<_> = object.keys().cloned().collect();
+            keys.sort();
+            Value::Array(keys.into_iter().map(Value::String).collect())
+        }
+        None => value_shape(value),
+    }
+}
+
+fn trace_shape(value: &Value) -> Value {
+    let Some(trace) = value.as_array() else {
+        return value_shape(value);
+    };
+    Value::Array(
+        trace
+            .iter()
+            .map(|entry| {
+                let Some(object) = entry.as_object() else {
+                    return value_shape(entry);
+                };
+                let mut shaped = Map::new();
+                shaped.insert("keys".to_owned(), sorted_keys(entry));
+                if let Some(action) = object.get("action") {
+                    shaped.insert("action_keys".to_owned(), sorted_keys(action));
+                }
+                if let Some(changes) = object.get("changes") {
+                    let changes_shape = match changes.as_object() {
+                        Some(changes) => {
+                            let change_key_shapes: BTreeSet<Vec<String>> = changes
+                                .values()
+                                .map(|change| match change.as_object() {
+                                    Some(change) => {
+                                        let mut keys: Vec<_> = change.keys().cloned().collect();
+                                        keys.sort();
+                                        keys
+                                    }
+                                    None => vec!["<non-object>".to_owned()],
+                                })
+                                .collect();
+                            Value::Array(
+                                change_key_shapes
+                                    .into_iter()
+                                    .map(|shape| {
+                                        Value::Array(shape.into_iter().map(Value::String).collect())
+                                    })
+                                    .collect(),
+                            )
+                        }
+                        None => value_shape(changes),
+                    };
+                    shaped.insert("changes_shape".to_owned(), changes_shape);
+                }
+                if let Some(blame) = object.get("blame") {
+                    shaped.insert("blame_keys".to_owned(), sorted_keys(blame));
+                }
+                Value::Object(shaped)
+            })
+            .collect(),
+    )
+}
+
+fn normalize(value: &Value, path: &str, hits: &mut [usize]) -> Value {
+    if let Some(index) = exclusion_index(path) {
+        hits[index] += 1;
+        return match EXCLUSIONS[index].treatment {
+            Treatment::Mask(marker) => Value::String(marker.to_owned()),
+            Treatment::ValueShape => value_shape(value),
+            Treatment::TraceShape => trace_shape(value),
+        };
+    }
+
+    match value {
+        Value::Object(object) => {
+            let mut keys: Vec<_> = object.keys().collect();
+            keys.sort();
+            Value::Object(
+                keys.into_iter()
+                    .map(|key| {
+                        (
+                            key.clone(),
+                            normalize(&object[key], &format!("{path}.{key}"), hits),
+                        )
+                    })
+                    .collect(),
+            )
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .enumerate()
+                .map(|(index, value)| normalize(value, &format!("{path}.{index}"), hits))
+                .collect(),
+        ),
+        _ => value.clone(),
+    }
+}
+
+/// Cache presence depends on ambient execution order. Compare the stable
+/// envelope without it, but fail closed on any present cache block that is not
+/// the exact public shape of a successful cache hit (`exact` or `cross_depth`). This is deliberately
+/// separate from `EXCLUSIONS`: requiring a live hit would make a clean cache
+/// fail, while requiring absence would make a warm cache fail.
+fn remove_and_validate_optional_cache(output: &mut Value) {
+    let Some(cache) = output
+        .as_object_mut()
+        .expect("CLI envelope object")
+        .remove("cache")
+    else {
+        return;
+    };
+    let cache = cache.as_object().expect("cache object");
+    let actual_keys: BTreeSet<&str> = cache.keys().map(String::as_str).collect();
+    let expected_keys: BTreeSet<&str> = ["hit", "key", "source"].into_iter().collect();
+    assert_eq!(
+        actual_keys, expected_keys,
+        "unexpected cache envelope: {cache:#?}"
+    );
+    assert_eq!(cache["hit"], true, "{cache:#?}");
+    assert!(
+        matches!(cache["source"].as_str(), Some("exact" | "cross_depth")),
+        "cache source is not a public successful-hit source: {cache:#?}"
+    );
+    let key = cache["key"].as_str().expect("cache key string");
+    assert!(
+        valid_cache_key(key),
+        "cache key is not 64 lowercase hexadecimal characters: {key}"
+    );
+}
+
+fn valid_cache_key(key: &str) -> bool {
+    key.len() == 64
+        && key
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn observe_contract() -> Value {
+    assert_eq!(
+        CASES.len(),
+        16,
+        "the retired harness owned exactly 16 cases"
+    );
+    let mut hits = vec![0; EXCLUSIONS.len()];
+    let mut observed = Vec::with_capacity(CASES.len());
+    for case in CASES {
+        let (mut output, exit) = run_induction(case);
+        remove_and_validate_optional_cache(&mut output);
+        let normalized = normalize(&output, "$", &mut hits);
+        observed.push(json!({
+            "path": case.path,
+            "depth": case.depth,
+            "k": case.k,
+            "exit": exit,
+            "output": normalized,
+        }));
+    }
+
+    for (exclusion, hits) in EXCLUSIONS.iter().zip(hits) {
+        assert!(
+            hits > 0,
+            "dead exclusion {} matched no field in either observed/native side; reason was: {}",
+            exclusion.path,
+            exclusion.reason
+        );
+    }
+    Value::Array(observed)
+}
+
+#[test]
+fn sixteen_induction_cases_pin_the_complete_stable_cli_envelope_and_exit() {
+    let actual = observe_contract();
+    if std::env::var_os(UPDATE_ENV).is_some() {
+        let golden =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/goldens/induction_cli_contract.json");
+        std::fs::write(
+            &golden,
+            format!(
+                "{}\n",
+                serde_json::to_string_pretty(&actual).expect("serialize induction CLI golden")
+            ),
+        )
+        .unwrap_or_else(|error| panic!("write {}: {error}", golden.display()));
+        return;
+    }
+
+    let expected: Value = serde_json::from_str(include_str!("goldens/induction_cli_contract.json"))
+        .expect("parse induction CLI golden");
+    let actual = actual.as_array().expect("observed induction array");
+    let expected = expected.as_array().expect("induction golden array");
+    assert_eq!(expected.len(), CASES.len(), "golden/case roster drift");
+
+    for (index, case) in CASES.iter().enumerate() {
+        let actual_case = &actual[index];
+        let expected_case = &expected[index];
+        assert_eq!(expected_case["path"], case.path, "case {index} path drift");
+        assert_eq!(
+            expected_case["depth"], case.depth,
+            "{} depth drift",
+            case.path
+        );
+        assert_eq!(expected_case["k"], case.k, "{} k drift", case.path);
+        assert_eq!(
+            actual_case["exit"],
+            expected_case["exit"],
+            "{} depth={} k={}: produced exit={}, expected={}; output={:#}",
+            case.path,
+            case.depth,
+            case.k,
+            actual_case["exit"],
+            expected_case["exit"],
+            actual_case["output"]
+        );
+        assert_eq!(
+            actual_case["output"], expected_case["output"],
+            "{} depth={} k={}: complete stable envelope drift",
+            case.path, case.depth, case.k
+        );
+    }
+}
+
+#[test]
+fn cache_key_contract_rejects_uppercase_hex_fixture() {
+    let lowercase = "a".repeat(64);
+    assert!(valid_cache_key(&lowercase), "lowercase control must pass");
+
+    let uppercase = "A".repeat(64);
+    let mut uppercase_fixture = json!({
+        "cache": {
+            "hit": true,
+            "key": uppercase,
+            "source": "exact",
+        }
+    });
+    let produced = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        remove_and_validate_optional_cache(&mut uppercase_fixture);
+    }));
+    assert!(
+        produced.is_err(),
+        "uppercase cache-key fixture: produced=accepted, expected=rejected"
+    );
+}
+
+#[test]
+fn nonexistent_induction_case_is_an_io_error_with_exit_two() {
+    let case = Case {
+        path: "tests/fixtures/rust_port/induction_case_does_not_exist.fsl",
+        depth: 1,
+        k: 1,
+    };
+    let (output, exit) = run_induction(&case);
+    assert_eq!(exit, 2, "produced exit={exit}, expected=2; {output:#}");
+    assert_eq!(output["result"], "error", "{output:#}");
+    assert_eq!(output["kind"], "io", "{output:#}");
+    assert!(
+        output["message"]
+            .as_str()
+            .is_some_and(|message| message.contains(case.path)),
+        "{output:#}"
+    );
+}

--- a/rust/fslc/tests/issue_681_precedence_policy.rs
+++ b/rust/fslc/tests/issue_681_precedence_policy.rs
@@ -318,7 +318,7 @@ verify { instances Item = 1 }
 
 #[test]
 fn unknown_and_ambiguous_references_fail_with_policy_identity_and_location() {
-    for (name, process, policy, expected) in [
+    for (name, process, policy, expected, expected_line) in [
         (
             "unknown-stage",
             r"process Return {
@@ -327,7 +327,8 @@ fn unknown_and_ambiguous_references_fail_with_policy_identity_and_location() {
     transition refund Requested -> Refunded by Manager
   }",
             "every Return reaching Refunded must have passed through Missing",
-            "stage 'Missing' is not declared",
+            "stage 'Missing' is not declared for process 'Return'",
+            9,
         ),
         (
             "unknown-entity",
@@ -338,6 +339,7 @@ fn unknown_and_ambiguous_references_fail_with_policy_identity_and_location() {
   }",
             "every Invoice reaching Refunded must have passed through Requested",
             "entity 'Invoice' has no process",
+            9,
         ),
         (
             "ambiguous-entity",
@@ -352,7 +354,8 @@ fn unknown_and_ambiguous_references_fail_with_policy_identity_and_location() {
     transition legacyRefund Requested -> Refunded by Manager
   }",
             "every Return reaching Refunded must have passed through Requested",
-            "multiple processes; precedence policy is ambiguous",
+            "entity 'Return' has multiple processes; precedence policy is ambiguous",
+            14,
         ),
     ] {
         let source = format!(
@@ -371,9 +374,19 @@ verify {{ instances Return = 1 }}
         assert_eq!(status, 2, "{output:#}");
         assert_eq!(output["kind"], "semantics", "{output:#}");
         let message = output["message"].as_str().expect("diagnostic message");
-        assert!(message.contains("policy 'CTRL-BAD'"), "{output:#}");
-        assert!(message.contains(expected), "{output:#}");
-        assert!(output["loc"]["line"].as_u64().is_some(), "{output:#}");
-        assert!(output["loc"]["column"].as_u64().is_some(), "{output:#}");
+        assert_eq!(
+            message,
+            format!("policy 'CTRL-BAD': {expected} at {expected_line}:3"),
+            "{output:#}"
+        );
+        let policy_line = source
+            .lines()
+            .nth(expected_line - 1)
+            .expect("diagnostic line exists in authored source");
+        assert_eq!(policy_line.find("policy").map(|offset| offset + 1), Some(3));
+        assert!(
+            output.get("loc").is_none(),
+            "unproven CoreError coordinates must not become public loc: {output:#}"
+        );
     }
 }

--- a/rust/fslc/tests/issue_832_compose_check.rs
+++ b/rust/fslc/tests/issue_832_compose_check.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+use std::process::Command;
+
+use serde_json::{Value, json};
+
+const FIXTURES: &str = "rust/fslc/tests/fixtures/issue_832";
+
+fn run_cli(args: &[&str]) -> (Value, i32) {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root");
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn fixture(name: &str) -> String {
+    format!("{FIXTURES}/{name}.fsl")
+}
+
+#[test]
+fn compose_core_error_origin_preserves_the_existing_message_shape() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root");
+    let path = root.join(fixture("shape_a"));
+    let source = std::fs::read_to_string(&path).expect("shape A source");
+    let resolver = fsl_core::FsResolver::new(path.parent().expect("fixture directory"));
+    let error = fsl_core::parse_kernel_source_with_file(
+        &source,
+        &resolver,
+        path.strip_prefix(root)
+            .expect("relative fixture path")
+            .display()
+            .to_string(),
+    )
+    .expect_err("shape A must fail");
+    let diagnostic = fslc_rust::spec_load::SemanticDiagnostic::from_core_error(&error);
+
+    assert_eq!(diagnostic.message, "unknown type 'core.NoSuchType' at 7:5");
+    assert_eq!(diagnostic.loc, Some(json!({"line": 7, "column": 5})));
+}
+
+fn assert_rejected_by_check_and_verify(name: &str, kind: &str, message: &str, loc: &Value) {
+    let path = fixture(name);
+    for args in [
+        vec!["check", path.as_str()],
+        vec!["verify", path.as_str(), "--depth", "1", "--no-cache"],
+    ] {
+        let command = args[0];
+        let (value, status) = run_cli(&args);
+        assert_eq!(status, 2, "{command}: {value}");
+        assert_eq!(value["result"], "error", "{command}: {value}");
+        assert_eq!(value["kind"], kind, "{command}: {value}");
+        assert_eq!(value["message"], message, "{command}: {value}");
+        assert_eq!(&value["loc"], loc, "{command}: {value}");
+    }
+}
+
+/// Rejecting detector A: a declared alias must not authorize an absent type.
+#[test]
+fn check_rejects_unknown_member_of_declared_alias() {
+    assert_rejected_by_check_and_verify(
+        "shape_a",
+        "type",
+        "unknown type 'core.NoSuchType' at 7:5",
+        &json!({"line": 7, "column": 5}),
+    );
+}
+
+/// Rejecting detector for the expression-binder path: an invariant's typed
+/// `forall` reports its authored location instead of the `(1, 1)` placeholder.
+#[test]
+fn check_rejects_unknown_member_in_invariant_binder_at_authored_location() {
+    assert_rejected_by_check_and_verify(
+        "expr_binder",
+        "type",
+        "unknown type 'core.NoSuchType' at 4:5",
+        &json!({"line": 4, "column": 5}),
+    );
+}
+
+/// Rejecting detector for the shared typed-binder gate: requirements process
+/// lowering must not let an unknown invariant binder pass `check` and fail only
+/// when `verify` tries to enumerate its finite domain. The binder is authored
+/// on line 8, where the invariant declaration owns the property diagnostic.
+#[test]
+fn check_rejects_unknown_requirements_binder_at_authored_property_location() {
+    assert_rejected_by_check_and_verify(
+        "requirements_missing_binder",
+        "semantics",
+        "invalid model expression: unknown type 'Missing' at 8:3",
+        &json!({"line": 8, "column": 3}),
+    );
+}
+
+/// Rejecting detector B: `init if` conditions receive the same name/type gate
+/// as assignment right-hand sides.
+#[test]
+fn check_rejects_undeclared_alias_shaped_init_condition() {
+    assert_rejected_by_check_and_verify(
+        "shape_b",
+        "semantics",
+        "invalid init statement: public Kernel cannot type identifier 'nonexistent' at 7:5",
+        &json!({"line": 7, "column": 5}),
+    );
+}
+
+/// Accepting controls for both corrected positions.
+#[test]
+fn check_accepts_real_alias_type_and_declared_alias_condition() {
+    for name in ["accept_real_type", "accept_alias_condition"] {
+        let path = fixture(name);
+        let (value, status) = run_cli(&["check", &path]);
+        assert_eq!(status, 0, "{name}: {value}");
+        assert_eq!(value["result"], "ok", "{name}: {value}");
+    }
+}
+
+/// Accepting control for the shared gate: a process entity is a real lowered
+/// type and remains valid as an invariant binder.
+#[test]
+fn check_accepts_real_requirements_process_binder() {
+    let path = fixture("requirements_real_binder");
+    let (value, status) = run_cli(&["check", &path]);
+    assert_eq!(status, 0, "{value}");
+    assert_eq!(value["result"], "ok", "{value}");
+}
+
+/// Preservation control: the pre-existing assignment-RHS rejection remains
+/// active; this is not a detector for either new fix.
+#[test]
+fn assignment_rhs_rejection_is_preserved() {
+    assert_rejected_by_check_and_verify(
+        "rhs_control",
+        "semantics",
+        "invalid init statement: public Kernel cannot type identifier 'nonexistent' at 7:5",
+        &json!({"line": 7, "column": 5}),
+    );
+}
+
+/// Negative location control: CLI scope overrides own no source construct, so
+/// their placeholder `(1, 1)` must never be promoted into a public `loc`.
+#[test]
+fn sweep_scope_error_does_not_fabricate_source_location() {
+    let (value, status) = run_cli(&[
+        "sweep",
+        "examples/e2e/3_design.fsl",
+        "--instances",
+        "Typo=1..1",
+        "--depth",
+        "1..1",
+    ]);
+
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error", "{value}");
+    assert_eq!(value["kind"], "semantics", "{value}");
+    assert_eq!(
+        value["message"], "verify instances references undeclared entity 'Typo' at 1:1",
+        "{value}"
+    );
+    assert!(value.get("loc").is_none(), "fabricated loc: {value}");
+}

--- a/rust/fslc/tests/ledger_evidence_findings_cli.rs
+++ b/rust/fslc/tests/ledger_evidence_findings_cli.rs
@@ -7,10 +7,11 @@
 //! list, or a nested `findings[]`/`checks[]` item's `requirement.id`) still
 //! rendered green with no 🔴 row, and evidence with no requirement
 //! attribution at all was silently dropped rather than becoming a
-//! spec-level finding. `docs/DESIGN-assurance-classes.md`: "a failing
-//! source never lowers the class of an independently proven requirement —
-//! it adds a 要確認 finding." Every `*_is_a_red_finding`/`*_finding` test
-//! here fails if the fix is reverted; the `*_stays_green` tests guard that
+//! spec-level finding. `docs/DESIGN-assurance-classes.md` requires that "a
+//! failing source never lowers the class of an independently proven
+//! requirement — it adds a 要確認 finding." Every
+//! `*_is_a_red_finding`/`*_finding` test here fails if the fix is reverted;
+//! the `*_stays_green` tests guard that
 //! a passing or verdict-less (gate-failure) source is not turned into a
 //! false positive.
 

--- a/rust/fslc/tests/liveness_witness_replay.rs
+++ b/rust/fslc/tests/liveness_witness_replay.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+
+use fsl_core::{FsResolver, FslValue, KernelModel, TraceAction, TraceChange, TraceStep};
+use fsl_verifier::BmcResult;
+
+const DEPTH: usize = 5;
+
+#[derive(Debug)]
+struct LassoCase {
+    name: &'static str,
+    model: KernelModel,
+    trace: Vec<TraceStep>,
+    loop_start: usize,
+    corrupted_loop_start: usize,
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn load_model(relative: &str) -> KernelModel {
+    let path = repository_root().join(relative);
+    let source = std::fs::read_to_string(&path).expect("read leadsTo case");
+    let resolver = FsResolver::new(path.parent().expect("case parent"));
+    let kernel = fsl_core::parse_kernel_source(&source, &resolver).expect("parse leadsTo case");
+    fsl_core::build_model(kernel).expect("build leadsTo model")
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => panic!("native solver unexpectedly yielded Pending"),
+    }
+}
+
+fn verify(model: &KernelModel) -> BmcResult {
+    let mut solver = fsl_solver_z3::Z3Solver::new().expect("create native solver");
+    block_on(fsl_verifier::verify_bounded(model, &mut solver, DEPTH)).expect("verify leadsTo case")
+}
+
+fn state_changes(
+    before: &BTreeMap<String, FslValue>,
+    after: &BTreeMap<String, FslValue>,
+) -> BTreeMap<String, TraceChange> {
+    after
+        .iter()
+        .filter_map(|(name, value)| {
+            let old = &before[name];
+            (old != value).then(|| {
+                (
+                    name.clone(),
+                    TraceChange {
+                        from: old.clone(),
+                        to: value.clone(),
+                    },
+                )
+            })
+        })
+        .collect()
+}
+
+fn native_cycle(
+    name: &'static str,
+    relative: &str,
+    actions: &[&str],
+    loop_start: usize,
+    corrupted_loop_start: usize,
+) -> LassoCase {
+    let model = load_model(relative);
+    let mut monitor = fsl_runtime::Monitor::new(model.clone()).expect("initialize native cycle");
+    let mut trace = vec![TraceStep {
+        step: 0,
+        state: monitor.state.clone(),
+        action: None,
+        changes: BTreeMap::new(),
+    }];
+    for (index, action_name) in actions.iter().enumerate() {
+        let enabled = monitor
+            .enabled()
+            .expect("enumerate enabled actions")
+            .into_iter()
+            .find(|action| action.action == *action_name)
+            .unwrap_or_else(|| panic!("{name}: action {action_name} must be enabled"));
+        let before = monitor.state.clone();
+        let stepped = monitor.step(&enabled).expect("execute native cycle action");
+        assert_eq!(stepped.violation, None, "{name}: clean cycle action");
+        trace.push(TraceStep {
+            step: index + 1,
+            changes: state_changes(&before, &stepped.state),
+            state: stepped.state,
+            action: Some(TraceAction {
+                name: enabled.action,
+                params: enabled.params,
+            }),
+        });
+    }
+    assert_eq!(
+        trace[loop_start].state,
+        trace.last().expect("cycle tail").state,
+        "{name}: declared loop must close"
+    );
+    LassoCase {
+        name,
+        model,
+        trace,
+        loop_start,
+        corrupted_loop_start,
+    }
+}
+
+fn cases() -> [LassoCase; 3] {
+    [
+        native_cycle(
+            "starvation",
+            "examples/gallery/errors/violated_leads_to_starvation.fsl",
+            &["request", "idle"],
+            1,
+            0,
+        ),
+        native_cycle(
+            "simultaneous",
+            "examples/gallery/adversarial/simultaneous_leads_to_satisfaction.fsl",
+            &["reset", "start_and_finish"],
+            0,
+            1,
+        ),
+        native_cycle(
+            "tcp",
+            "examples/gallery/valid/small_tcp_handshake.fsl",
+            &["send_syn", "recv_syn_ack", "close"],
+            0,
+            1,
+        ),
+    ]
+}
+
+fn replay_lasso(model: &KernelModel, trace: &[TraceStep], loop_start: usize) -> Result<(), String> {
+    fsl_runtime::replay_trace(model.clone(), trace).map_err(|error| error.to_string())?;
+    let loop_head = trace
+        .get(loop_start)
+        .ok_or_else(|| format!("loop_start {loop_start} is outside the witness trace"))?;
+    let loop_tail = trace
+        .last()
+        .ok_or_else(|| "empty leadsTo witness trace".to_owned())?;
+    if loop_head.state != loop_tail.state {
+        return Err(format!(
+            "lasso loop state mismatch: trace[{loop_start}] != trace[{}]",
+            loop_tail.step
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn deleted_leadsto_matrix_keeps_native_verdicts_and_replays_each_cycle() {
+    for (relative, expected_lasso) in [
+        (
+            "examples/gallery/errors/violated_leads_to_starvation.fsl",
+            true,
+        ),
+        (
+            "examples/gallery/adversarial/simultaneous_leads_to_satisfaction.fsl",
+            false,
+        ),
+        ("examples/gallery/valid/small_tcp_handshake.fsl", false),
+    ] {
+        let result = verify(&load_model(relative));
+        assert!(
+            result.violation.is_none(),
+            "unexpected safety violation for {relative}: {:?}",
+            result.violation
+        );
+        assert_eq!(
+            result.leadsto_violation.is_some(),
+            expected_lasso,
+            "unexpected leadsTo verdict for {relative}"
+        );
+    }
+    for case in cases() {
+        replay_lasso(&case.model, &case.trace, case.loop_start)
+            .unwrap_or_else(|error| panic!("{} baseline cycle rejected: {error}", case.name));
+    }
+}
+
+#[test]
+fn all_nine_case_by_corruption_cells_are_rejected_exactly() {
+    for case in cases() {
+        let mut state = case.trace.clone();
+        state[1]
+            .state
+            .insert("corrupted".to_owned(), FslValue::Bool(true));
+
+        let mut action = case.trace.clone();
+        action[1].action.as_mut().expect("first cycle action").name = "corrupted_action".to_owned();
+
+        let loop_expected = format!(
+            "lasso loop state mismatch: trace[{}] != trace[{}]",
+            case.corrupted_loop_start,
+            case.trace.last().expect("cycle tail").step
+        );
+        for (corruption, trace, loop_start, expected) in [
+            (
+                "state",
+                state,
+                case.loop_start,
+                "trace state mismatch at step 1".to_owned(),
+            ),
+            (
+                "action",
+                action,
+                case.loop_start,
+                "trace action 'corrupted_action' is not enabled at step 1".to_owned(),
+            ),
+            (
+                "loop",
+                case.trace.clone(),
+                case.corrupted_loop_start,
+                loop_expected,
+            ),
+        ] {
+            let produced = replay_lasso(&case.model, &trace, loop_start)
+                .expect_err("corrupted lasso must be rejected");
+            assert_eq!(
+                produced, expected,
+                "{} × {corruption} produced an unexpected diagnostic",
+                case.name
+            );
+        }
+    }
+}

--- a/rust/fslc/tests/refine_corpus_parity.rs
+++ b/rust/fslc/tests/refine_corpus_parity.rs
@@ -23,10 +23,11 @@
 //!    corpus, never hard-coded, so adding a mapping fails this test until it
 //!    is registered. A hard-coded list is precisely the shape #577 retired
 //!    28 stale instances of.
-//! 2. `native_refine_matches_the_declared_result_and_exit_for_every_registered_mapping`
-//!    runs each live row and compares `result`, `kind`, **and** the process
-//!    exit code (#537 C4 requires both; a JSON envelope that disagrees with
-//!    the exit status is how #554 and #600 escaped).
+//! 2. `native_refine_matches_the_declared_projection_and_exit_for_every_registered_mapping`
+//!    runs each live row and compares the complete observed stable JSON
+//!    projection plus the process exit code (#537 C4 requires both; a JSON
+//!    envelope that disagrees with the exit status is how #554 and #600
+//!    escaped).
 //! 3. `every_exclusion_premise_still_holds` re-measures each exclusion's
 //!    recorded premise and fails when it no longer holds — the self-retiring
 //!    shape #568 introduced for the Worker parity corpus. An exclusion here
@@ -50,7 +51,7 @@ use std::process::Command;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 #[path = "support/mod.rs"]
 mod support;
@@ -101,6 +102,76 @@ struct Case {
 struct Declaration {
     path: &'static str,
     anchor: &'static str,
+}
+
+/// A public envelope field that cannot be compared with its checked-in
+/// observation. This registry is deliberately read from emitted JSON rather
+/// than from a Rust output type: changing an internal type does not establish
+/// that a public key is present, and a dead exclusion must fail.
+struct ProjectionExclusion {
+    key: &'static str,
+    reason: &'static str,
+}
+
+/// The only observed field outside the stable projection.
+///
+/// `impl_trace` is a bounded solver witness: several traces can establish the
+/// same refinement failure, and solver enumeration may select a different one
+/// between executions. Its verdict-bearing summary remains fully compared:
+/// `kind`, `at`, `violated_at_step`, `impl_action`, abstract before/after
+/// states, `mismatch`, `progress_failure`, `hint`, and `trace_type` wherever
+/// emitted. `fsl`, `impl`, `abs`, `result`, `checked_to_depth`, `action_map`,
+/// and `note` are stable and are therefore compared rather than classified as
+/// metadata.
+const PROJECTION_EXCLUSIONS: &[ProjectionExclusion] = &[ProjectionExclusion {
+    key: "impl_trace",
+    reason: "a refinement failure may have several valid bounded implementation witnesses, so \
+             solver enumeration can select a different trace while every stable summary field \
+             remains identical",
+}];
+
+fn expected_projections() -> Map<String, Value> {
+    serde_json::from_str::<Value>(include_str!("goldens/refine_corpus_projection.v1.json"))
+        .expect("valid refinement corpus projection golden")
+        .as_object()
+        .expect("refinement corpus projection golden must be an object")
+        .clone()
+}
+
+fn stable_projection(mut envelope: Value) -> Value {
+    let object = envelope
+        .as_object_mut()
+        .expect("`fslc refine` envelope must be a JSON object");
+    for exclusion in PROJECTION_EXCLUSIONS {
+        object.remove(exclusion.key);
+    }
+    envelope
+}
+
+/// Fail if an exclusion names a key neither the emitted nor expected
+/// envelopes carry. A dead exclusion weakens nothing while looking like a
+/// considered exception, so it is itself a test failure.
+fn assert_projection_exclusions_are_live(actual: &[Value], expected: &Map<String, Value>) {
+    for exclusion in PROJECTION_EXCLUSIONS {
+        let actual_has_key = actual.iter().any(|value| {
+            value
+                .as_object()
+                .is_some_and(|object| object.contains_key(exclusion.key))
+        });
+        let expected_has_key = expected.values().any(|value| {
+            value
+                .as_object()
+                .is_some_and(|object| object.contains_key(exclusion.key))
+        });
+        assert!(
+            actual_has_key || expected_has_key,
+            "projection exclusion {:?} is dead: neither emitted nor expected envelopes carry \
+             that key, so it excludes nothing. Delete it instead of retaining a decorative \
+             exception. Recorded reason: {}",
+            exclusion.key,
+            exclusion.reason
+        );
+    }
 }
 
 const CASES: &[Case] = &[
@@ -813,14 +884,16 @@ fn every_corpus_refinement_mapping_is_registered() {
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
-/// Each live row must reproduce the `result`, the `kind`, **and** the exit
-/// code its `declared_by` citation states (#537 C4: stdout JSON and process
-/// status, both). A mapping or a semantics change that breaks the declared
-/// correspondence fails here by name, the way #466, #483, #493, #494, and
-/// #512 did not.
+/// Each live row must reproduce its complete observed stable envelope and the
+/// exit code its `declared_by` citation states (#537 C4: stdout JSON and
+/// process status, both). The checked-in projection is deliberately broader
+/// than the declaration-backed `result`/`kind`: it binds every observed
+/// stable public field, while the assertions below keep the declared verdict
+/// authoritative over the observation.
 #[test]
-fn native_refine_matches_the_declared_result_and_exit_for_every_registered_mapping() {
-    let failures = for_each_parallel(CASES.len(), |index| {
+fn native_refine_matches_the_declared_projection_and_exit_for_every_registered_mapping() {
+    let observations = Mutex::new(Vec::with_capacity(CASES.len()));
+    let run_failures = for_each_parallel(CASES.len(), |index| {
         let case = &CASES[index];
         let (output, status) = run_refine(
             case.implementation,
@@ -828,37 +901,92 @@ fn native_refine_matches_the_declared_result_and_exit_for_every_registered_mappi
             case.mapping,
             case.depth,
         );
-        let result = output["result"].as_str().unwrap_or_else(|| {
-            panic!(
-                "{}: `fslc refine` envelope has no string `result` field: {output}",
-                case.mapping
-            )
-        });
-
-        if result != case.expected_result {
-            return Some(format!(
-                "{}: declared result={:?} ({}), got result={result:?} ({output})",
-                case.mapping, case.expected_result, case.declared_by
-            ));
-        }
-        if let Some(expected_kind) = case.expected_kind {
-            let kind = output["kind"].as_str();
-            if kind != Some(expected_kind) {
-                return Some(format!(
-                    "{}: declared kind={expected_kind:?} ({}), got kind={kind:?} ({output})",
-                    case.mapping, case.declared_by
-                ));
-            }
-        }
-        let expected_exit = expected_status(case.expected_result);
-        if status != expected_exit {
-            return Some(format!(
-                "{}: result={result:?} binds exit={expected_exit}, got exit={status}",
-                case.mapping
-            ));
-        }
+        observations
+            .lock()
+            .expect("observation list")
+            .push((index, output, status));
         None
     });
+    assert!(run_failures.is_empty(), "{}", run_failures.join("\n"));
+
+    let mut observations = observations.into_inner().expect("observation list");
+    observations.sort_by_key(|(index, _, _)| *index);
+    let raw_outputs = observations
+        .iter()
+        .map(|(_, output, _)| output.clone())
+        .collect::<Vec<_>>();
+
+    if std::env::var_os("UPDATE_FSL_REFINEMENT_GOLDEN").is_some() {
+        let projection = observations
+            .iter()
+            .map(|(index, output, _)| {
+                (
+                    CASES[*index].mapping.to_owned(),
+                    stable_projection(output.clone()),
+                )
+            })
+            .collect::<Map<_, _>>();
+        let path = root().join("rust/fslc/tests/goldens/refine_corpus_projection.v1.json");
+        let rendered = serde_json::to_string_pretty(&projection)
+            .expect("serialize refinement corpus projection golden");
+        std::fs::write(&path, format!("{rendered}\n")).expect("update refinement golden");
+        return;
+    }
+
+    let expected = expected_projections();
+    let expected_rows = expected.keys().map(String::as_str).collect::<BTreeSet<_>>();
+    let manifest_rows = CASES
+        .iter()
+        .map(|case| case.mapping)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        expected_rows, manifest_rows,
+        "the projection golden and live CASES must have exactly the same rows; regenerate only \
+         after reviewing the observed envelope diff"
+    );
+
+    // Run this before equality so a dead exclusion reports its own failure
+    // instead of being obscured by whatever newly unexcluded field differs.
+    assert_projection_exclusions_are_live(&raw_outputs, &expected);
+
+    let mut failures = Vec::new();
+    for (index, output, status) in observations {
+        let case = &CASES[index];
+        let expected_output = &expected[case.mapping];
+
+        if expected_output["result"] != case.expected_result {
+            failures.push(format!(
+                "{}: golden result={} contradicts declared result={:?} ({})",
+                case.mapping, expected_output["result"], case.expected_result, case.declared_by
+            ));
+            continue;
+        }
+        if let Some(expected_kind) = case.expected_kind
+            && expected_output["kind"] != expected_kind
+        {
+            failures.push(format!(
+                "{}: golden kind={} contradicts declared kind={expected_kind:?} ({})",
+                case.mapping, expected_output["kind"], case.declared_by
+            ));
+            continue;
+        }
+
+        let actual_projection = stable_projection(output);
+        if actual_projection != *expected_output {
+            failures.push(format!(
+                "{}: complete stable projection differs\nexpected={expected_output:#}\nproduced={actual_projection:#}",
+                case.mapping
+            ));
+        }
+
+        let expected_exit = expected_status(case.expected_result);
+        if status != expected_exit {
+            failures.push(format!(
+                "{}: result={:?} binds exit={expected_exit}, got exit={status}",
+                case.mapping, case.expected_result
+            ));
+        }
+    }
 
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }

--- a/rust/fslc/tests/replay_trace_contract.rs
+++ b/rust/fslc/tests/replay_trace_contract.rs
@@ -343,6 +343,82 @@ fn legacy_action_only_arrays_keep_the_pre_v1_result_shape() {
 }
 
 #[test]
+fn legacy_object_wrapper_keeps_the_pre_v1_public_projection() {
+    let output = replay_value(&json!({"events":[
+        {"action":"select","params":{"i":0}},
+        {"action":"finish","params":{}}
+    ]}));
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(
+        json(&output),
+        json!({
+            "fsl":"1.0",
+            "result":"conformant",
+            "spec":"ReplayTrace",
+            "steps_checked":2,
+            "final_state":{
+                "count":{"0":1,"1":0},
+                "phase":"Done",
+                "selected":0
+            },
+            "note":"leadsTo properties are not checked by replay (finite logs only)"
+        })
+    );
+}
+
+#[test]
+fn legacy_object_wrapper_rejects_a_forbidden_call_with_public_diagnostics() {
+    let output = replay_value(&json!({"events":[
+        {"action":"select","params":{"i":0}},
+        {"action":"finish","params":{}},
+        {"action":"select","params":{"i":1}}
+    ]}));
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        json(&output),
+        json!({
+            "fsl":"1.0",
+            "result":"nonconformant",
+            "spec":"ReplayTrace",
+            "failed_at_event":2,
+            "violation":{
+                "kind":"requires_failed",
+                "check":"safety",
+                "name":"_requires_failed_select",
+                "action":"select",
+                "params":{"i":1}
+            },
+            "state_before":{
+                "count":{"0":1,"1":0},
+                "phase":"Done",
+                "selected":0
+            },
+            "hint":"the implementation performed an action the spec forbids at this state (or reached a state violating an invariant)",
+            "note":"leadsTo properties are not checked by replay (finite logs only)"
+        })
+    );
+}
+
+#[test]
+fn legacy_object_wrapper_rejects_wrong_key_type_and_extra_keys_exactly() {
+    let expected = json!({
+        "fsl":"1.0",
+        "result":"error",
+        "kind":"io",
+        "message":"trace JSON must be a public replay trace, an array, or {\"events\": [...]}"
+    });
+    for (shape, input) in [
+        ("key", json!({"eventz":[]})),
+        ("type", json!({"events":{}})),
+        ("extra", json!({"events":[],"extra":true})),
+    ] {
+        let output = replay_value(&input);
+        assert_eq!(output.status.code(), Some(2), "{shape}");
+        assert_eq!(json(&output), expected, "{shape}");
+    }
+}
+
+#[test]
 fn release_bundles_include_the_schema_spec_and_positive_and_negative_goldens() {
     let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/rust/fslc/tests/typed_agreement/engines.rs
+++ b/rust/fslc/tests/typed_agreement/engines.rs
@@ -18,7 +18,10 @@ use std::future::Future;
 use std::pin::pin;
 use std::task::{Context, Poll, Waker};
 
-use fsl_core::{FsResolver, KernelModel, build_model, build_surface_model, parse_kernel_source};
+use fsl_core::{
+    FsResolver, FslValue as Value, KernelModel, build_model, build_surface_model,
+    parse_kernel_source,
+};
 use fsl_runtime::{Monitor, State, Violation};
 use fsl_syntax::{Expr, SpecItem};
 
@@ -129,6 +132,7 @@ impl fmt::Display for AgreementFailure {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AgreementObservation {
     pub verdict: Verdict,
+    pub deadlock_step: Option<usize>,
     pub required_edges: Vec<&'static str>,
     pub property_location: Option<String>,
     pub completeness: AgreementCompleteness,
@@ -146,8 +150,40 @@ pub struct AgreementCompleteness {
 
 struct MonitorObservation {
     verdict: Verdict,
+    deadlock_step: Option<usize>,
     depth_reached: usize,
     closure: bool,
+}
+
+fn monitor_terminal_holds(id: &str, monitor: &Monitor) -> Result<bool, AgreementFailure> {
+    let Some(terminal) = &monitor.model.terminal else {
+        return Ok(false);
+    };
+    match fsl_runtime::eval(
+        terminal,
+        &monitor.state,
+        &mut BTreeMap::new(),
+        &monitor.model,
+        None,
+    )
+    .map_err(|error| {
+        disagreement(
+            id,
+            "earliest_deadlock",
+            "terminal",
+            "Boolean",
+            error.message,
+        )
+    })? {
+        Value::Bool(value) => Ok(value),
+        value => Err(disagreement(
+            id,
+            "earliest_deadlock",
+            "terminal",
+            "Boolean",
+            value,
+        )),
+    }
 }
 
 fn disagreement(
@@ -178,6 +214,36 @@ fn require_equal<T: Eq + fmt::Debug>(
     } else {
         Err(disagreement(id, edge, field, left, right))
     }
+}
+
+pub fn require_deadlock_agreement(
+    id: &str,
+    monitor: Option<usize>,
+    legacy_bfs: Option<usize>,
+    explicit: Option<usize>,
+    symbolic: Option<usize>,
+) -> Result<(), AgreementFailure> {
+    require_equal(
+        id,
+        "earliest_deadlock",
+        "monitor_bfs",
+        &monitor,
+        &legacy_bfs,
+    )?;
+    require_equal(
+        id,
+        "earliest_deadlock",
+        "bfs_explicit",
+        &legacy_bfs,
+        &explicit,
+    )?;
+    require_equal(
+        id,
+        "earliest_deadlock",
+        "explicit_bmc",
+        &explicit,
+        &symbolic,
+    )
 }
 
 fn property_location(
@@ -236,6 +302,7 @@ fn observe_monitor(
         .map_err(|error| disagreement(id, "monitor_bfs", "engine", "ok", error.message))?;
     let mut frontier = BTreeMap::from([(initial.state.clone(), initial)]);
     let mut seen: BTreeSet<_> = frontier.keys().cloned().collect();
+    let mut deadlock_step = None;
 
     for level in 0..=depth {
         for monitor in frontier.values() {
@@ -245,17 +312,11 @@ fn observe_monitor(
             if violation.is_some() {
                 return Ok(MonitorObservation {
                     verdict: Verdict::from(violation),
+                    deadlock_step,
                     depth_reached: level,
                     closure: false,
                 });
             }
-        }
-        if level == depth {
-            return Ok(MonitorObservation {
-                verdict: Verdict::Clean,
-                depth_reached: level,
-                closure: false,
-            });
         }
 
         let mut next = BTreeMap::new();
@@ -263,6 +324,15 @@ fn observe_monitor(
             let enabled = monitor
                 .enabled()
                 .map_err(|error| disagreement(id, "monitor_bfs", "enabled", "ok", error.message))?;
+            if enabled.is_empty()
+                && deadlock_step.is_none()
+                && !monitor_terminal_holds(id, monitor)?
+            {
+                deadlock_step = Some(level);
+            }
+            if level == depth {
+                continue;
+            }
             for action in enabled {
                 let mut child = monitor.clone();
                 let stepped = child.step(&action).map_err(|error| {
@@ -271,6 +341,7 @@ fn observe_monitor(
                 if stepped.violation.is_some() {
                     return Ok(MonitorObservation {
                         verdict: Verdict::from(stepped.violation),
+                        deadlock_step,
                         depth_reached: level + 1,
                         closure: false,
                     });
@@ -280,9 +351,18 @@ fn observe_monitor(
                 }
             }
         }
+        if level == depth {
+            return Ok(MonitorObservation {
+                verdict: Verdict::Clean,
+                deadlock_step,
+                depth_reached: level,
+                closure: false,
+            });
+        }
         if next.is_empty() {
             return Ok(MonitorObservation {
                 verdict: Verdict::Clean,
+                deadlock_step,
                 depth_reached: level,
                 closure: true,
             });
@@ -440,6 +520,13 @@ pub fn compare_agreement(
             // different points after a violation. Reachable steps and action
             // coverage therefore have a common contract only for clean runs.
             if matches!(bmc_verdict, Verdict::Clean) {
+                require_deadlock_agreement(
+                    id,
+                    monitor.deadlock_step,
+                    bfs_result.deadlock_step,
+                    explicit_result.deadlock_step,
+                    bmc_result.deadlock_step,
+                )?;
                 let bfs_reachables = bfs_result
                     .reachables
                     .iter()
@@ -532,6 +619,7 @@ pub fn compare_agreement(
 
     Ok(AgreementObservation {
         verdict: bmc_verdict,
+        deadlock_step: bmc_result.deadlock_step,
         required_edges: if has_leadsto {
             vec!["depth_completeness", "replay", "successor_admission"]
         } else {
@@ -545,6 +633,9 @@ pub fn compare_agreement(
             ];
             if trace_compared {
                 edges.push("trace_explicit_bmc");
+            }
+            if !has_violation {
+                edges.push("earliest_deadlock");
             }
             if has_violation {
                 edges.push("property_location");

--- a/rust/fslc/tests/typed_agreement/inventory.rs
+++ b/rust/fslc/tests/typed_agreement/inventory.rs
@@ -77,4 +77,21 @@ fn generation_inventory_is_coupled_to_registries_and_test_anchors() {
         BTreeSet::from(["head", "pop", "at", "index", "divide", "remainder"]),
         "head/pop/at/index/divide/remainder inventory must stay complete"
     );
+
+    let excluded = inventory["excluded_observation_fields"]
+        .as_object()
+        .expect("excluded observation fields");
+    let required_edges = inventory["required_edges"]
+        .as_array()
+        .expect("required agreement edges");
+    assert!(
+        !excluded.contains_key("deadlock_step"),
+        "terminal-aware legacy BFS must not retain the deadlock_step exclusion"
+    );
+    assert!(
+        required_edges
+            .iter()
+            .any(|edge| edge == "earliest_deadlock"),
+        "removing the deadlock_step exclusion must promote earliest_deadlock to a required edge"
+    );
 }

--- a/rust/fslc/tests/typed_agreement/inventory.v1.json
+++ b/rust/fslc/tests/typed_agreement/inventory.v1.json
@@ -44,6 +44,7 @@
     "monitor_bfs",
     "bfs_explicit",
     "explicit_bmc",
+    "earliest_deadlock",
     "generated_expectation",
     "depth_completeness",
     "trace_explicit_bmc",
@@ -52,7 +53,6 @@
     "successor_admission"
   ],
   "excluded_observation_fields": {
-    "deadlock_step": "Terminal-state handling makes BFS deadlock_step and explicit deadlock_step intentionally non-identical; terminal verdict and action coverage remain required.",
     "auxiliary_observations_after_violation": "Engines intentionally stop at different points after the first violation; reachable steps and action coverage are equated only for clean bounded runs.",
     "states_explored": "Symbolic BMC has no concrete state-count analogue.",
     "symbolic_frontier_vs_concrete_closure": "Monitor and explicit concrete closure are equated. BMC frontier progress uses a different bounded symbolic proof domain, so both values are reported without pretending they are identical."

--- a/rust/fslc/tests/typed_agreement/logic_test.rs
+++ b/rust/fslc/tests/typed_agreement/logic_test.rs
@@ -69,6 +69,52 @@ fn validate_report(report: &Value) {
         .expect("FSL Logic report matches schema");
 }
 
+#[test]
+fn terminal_siblings_agree_on_the_earliest_reportable_deadlock() {
+    for (id, source, expected) in [
+        (
+            "terminal_positive",
+            include_str!("../fixtures/assurance_terminal_once.fsl"),
+            None,
+        ),
+        (
+            "missing_terminal_sibling",
+            include_str!("../fixtures/assurance_terminal_once_missing.fsl"),
+            Some(1),
+        ),
+    ] {
+        let model = engines::build(id, source);
+        let observation = engines::compare_agreement(id, &model, 1)
+            .unwrap_or_else(|failure| panic!("{id}: {failure}"));
+        assert_eq!(
+            observation.deadlock_step, expected,
+            "{id}: produced {:?}, expected {expected:?}",
+            observation.deadlock_step
+        );
+        assert!(
+            observation.required_edges.contains(&"earliest_deadlock"),
+            "{id}: earliest_deadlock edge did not execute"
+        );
+    }
+}
+
+#[test]
+fn earliest_deadlock_edge_rejects_an_isolated_legacy_misclassification() {
+    let failure = engines::require_deadlock_agreement(
+        "terminal_deadlock_mutation",
+        None,
+        Some(1),
+        None,
+        None,
+    )
+    .expect_err("a legacy terminal-as-deadlock mutation must be detected");
+
+    assert_eq!(failure.edge, "earliest_deadlock");
+    assert_eq!(failure.field, "monitor_bfs");
+    assert_eq!(failure.left, "None", "expected monitor value");
+    assert_eq!(failure.right, "Some(1)", "produced mutated legacy value");
+}
+
 fn parse_replay_case(value: &str) -> (u64, usize, usize) {
     let coordinates = value
         .strip_prefix("fsl-logic-v1-s")

--- a/src/fslc/dialects.py
+++ b/src/fslc/dialects.py
@@ -758,13 +758,15 @@ def _business_action_actor_map(abs_ast):
     return actors
 
 
-def _check_auto_mapped_process_actors(processes, abs_ast):
+def _check_auto_mapped_process_actors(processes, abs_ast, explicit_action_names):
     business_actors = _business_action_actor_map(abs_ast)
     if not business_actors:
         return
     for proc in processes:
         for tr in proc["transitions"]:
             name = tr["name"]
+            if name in explicit_action_names:
+                continue
             biz_actor = business_actors.get(name)
             if biz_actor is None:
                 continue
@@ -924,6 +926,7 @@ def _expand_requirements_with_display(ast, base_dir, bounds_overrides=None):
     out = []
     display_names = {}
     action_maps = []
+    process_action_maps = []
     auto_state_maps = []
     action_aliases = {}
     implements = None
@@ -1006,7 +1009,7 @@ def _expand_requirements_with_display(ast, base_dir, bounds_overrides=None):
             )
             out.extend(expanded)
             auto_state_maps.extend(state_maps)
-            action_maps.extend(maps)
+            process_action_maps.extend(maps)
             for action in maps:
                 action_aliases.setdefault(action[1], []).append(action[1])
         elif tag == "acceptance":
@@ -1038,11 +1041,25 @@ def _expand_requirements_with_display(ast, base_dir, bounds_overrides=None):
     )
 
     if implements is not None:
-        _check_auto_mapped_process_actors(processes, implements["abs_ast"])
+        explicit_action_names = {
+            item[1] for item in implements["maps"] if item[0] == "action_map"
+        }
+        _check_auto_mapped_process_actors(
+            processes,
+            implements["abs_ast"],
+            explicit_action_names,
+        )
         mapping_items = [("impl", name), ("abs", implements["abs"])]
         mapping_items.extend(implements["maps"])
         mapping_items.extend(auto_state_maps)
         mapping_items.extend(action_maps)
+        # Process transitions synthesize same-name correspondences. An explicit
+        # inline entry is the override for cases such as an arity-changing lower
+        # action; retaining both would turn a valid override into a duplicate.
+        mapping_items.extend(
+            action for action in process_action_maps
+            if action[1] not in explicit_action_names
+        )
         implements["mapping_ast"] = ("refinement", f"{name}Implements{implements['abs']}", mapping_items)
         out.append(("__implements", implements))
     if display_names:

--- a/tests/fixtures/bash-version-guards/accepting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/accepting/fixture.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "fixture requires Bash 4 or newer" >&2; exit 1; }
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+declare -A labels=()
+mapfile -t values </dev/null
+printf '%s\n' "${values[@]}"

--- a/tests/fixtures/bash-version-guards/double-quoted-decoy/fixture.sh
+++ b/tests/fixtures/bash-version-guards/double-quoted-decoy/fixture.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+printf '%s\n' "mapfile -t values" "local -A labels=()"

--- a/tests/fixtures/bash-version-guards/heredoc-data/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-data/fixture.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<'QUOTED_DATA'
+mapfile -t values </dev/null
+QUOTED_DATA
+cat <<PLAIN_DATA
+local -A labels=()
+PLAIN_DATA
+cat <<-TAB_DATA
+	readarray -t values </dev/null
+	TAB_DATA

--- a/tests/fixtures/bash-version-guards/heredoc-followed-by-code/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-followed-by-code/fixture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<'DATA'
+mapfile is data here
+DATA
+mapfile -t values </dev/null

--- a/tests/fixtures/bash-version-guards/heredoc-quoted-command-accepting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-quoted-command-accepting/fixture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<D'AT'A
+mapfile -t values </dev/null
+declare -A labels=()
+DATA

--- a/tests/fixtures/bash-version-guards/heredoc-quoted-command-rejecting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-quoted-command-rejecting/fixture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<'DATA'
+mapfile is literal data
+DATA
+mapfile -t values </dev/null

--- a/tests/fixtures/bash-version-guards/heredoc-quoted-expansion-accepting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-quoted-expansion-accepting/fixture.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+cat <<-'DATA'
+	${values[@]}
+	$(mapfile -t nested_values </dev/null)
+	DATA

--- a/tests/fixtures/bash-version-guards/heredoc-quoted-expansion-rejecting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-quoted-expansion-rejecting/fixture.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+cat <<-'DATA'
+	${values[@]}
+	$(mapfile -t nested_values </dev/null)
+	DATA
+printf '%s\n' "${values[@]}"

--- a/tests/fixtures/bash-version-guards/heredoc-unquoted-command-accepting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-unquoted-command-accepting/fixture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<DATA
+readarray -t values </dev/null
+local -A labels=()
+DATA

--- a/tests/fixtures/bash-version-guards/heredoc-unquoted-command-rejecting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-unquoted-command-rejecting/fixture.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+cat <<DATA
+declare -A is literal data
+DATA
+declare -A labels=()

--- a/tests/fixtures/bash-version-guards/heredoc-unquoted-expansion-accepting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-unquoted-expansion-accepting/fixture.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "Bash 4+ required" >&2; exit 1; }
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+cat <<-DATA
+	${values[@]}
+	$(mapfile -t nested_values </dev/null)
+	DATA

--- a/tests/fixtures/bash-version-guards/heredoc-unquoted-expansion-rejecting/fixture.sh
+++ b/tests/fixtures/bash-version-guards/heredoc-unquoted-expansion-rejecting/fixture.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+cat <<-DATA
+	${values[@]}
+	$(mapfile -t nested_values </dev/null)
+	DATA

--- a/tests/fixtures/bash-version-guards/indented-declare/fixture.sh
+++ b/tests/fixtures/bash-version-guards/indented-declare/fixture.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+fixture() {
+  declare -A labels=()
+}

--- a/tests/fixtures/bash-version-guards/late-guard/fixture.sh
+++ b/tests/fixtures/bash-version-guards/late-guard/fixture.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# A guard after another line is too late.
+(( BASH_VERSINFO[0] >= 4 )) || { echo "fixture requires Bash 4 or newer" >&2; exit 1; }
+mapfile -t values </dev/null

--- a/tests/fixtures/bash-version-guards/local-associative/fixture.sh
+++ b/tests/fixtures/bash-version-guards/local-associative/fixture.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+fixture() {
+  local -A labels=()
+}

--- a/tests/fixtures/bash-version-guards/missing-guard/fixture.sh
+++ b/tests/fixtures/bash-version-guards/missing-guard/fixture.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -u
+values=()
+declare -A labels=()
+mapfile -t values </dev/null
+printf '%s\n' "${values[@]}"

--- a/tests/fixtures/bash-version-guards/quoted-decoy/fixture.sh
+++ b/tests/fixtures/bash-version-guards/quoted-decoy/fixture.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+printf '%s\n' 'mapfile -t values' 'declare -A labels=()' '${values[@]}'

--- a/tests/fixtures/design-citation-headings/accepting/.github/workflows/ci.yml
+++ b/tests/fixtures/design-citation-headings/accepting/.github/workflows/ci.yml
@@ -1,0 +1,2 @@
+# See `docs/DESIGN-ci.md`, "Sharded pre-merge Linux
+# evidence", "Ruleset drift audit".

--- a/tests/fixtures/design-citation-headings/accepting/.github/workflows/ruleset-drift-audit.yml
+++ b/tests/fixtures/design-citation-headings/accepting/.github/workflows/ruleset-drift-audit.yml
@@ -1,0 +1,1 @@
+# See docs/DESIGN-ci.md, "Ruleset drift audit".

--- a/tests/fixtures/design-citation-headings/accepting/.github/workflows/site-reference-freshness.yml
+++ b/tests/fixtures/design-citation-headings/accepting/.github/workflows/site-reference-freshness.yml
@@ -1,0 +1,2 @@
+# See docs/DESIGN-ci.md's "Product gate
+# contract" and "Ruleset drift audit".

--- a/tests/fixtures/design-citation-headings/accepting/CHANGELOG.md
+++ b/tests/fixtures/design-citation-headings/accepting/CHANGELOG.md
@@ -1,0 +1,1 @@
+Historical docs/DESIGN-ci.md, "Merge queue (planned, not yet enabled)".

--- a/tests/fixtures/design-citation-headings/accepting/docs/DESIGN-ci.md
+++ b/tests/fixtures/design-citation-headings/accepting/docs/DESIGN-ci.md
@@ -1,0 +1,9 @@
+# CI fixture
+
+## Ruleset drift audit
+
+## 3. Product gate contract (#537 C5)
+
+## Sharded pre-merge `Linux` evidence
+
+## Merge readiness contract

--- a/tests/fixtures/design-citation-headings/accepting/rust/scoped-reference.rs
+++ b/tests/fixtures/design-citation-headings/accepting/rust/scoped-reference.rs
@@ -1,0 +1,1 @@
+// This scoped file deliberately contains no citation.

--- a/tests/fixtures/design-citation-headings/accepting/skills/scoped-reference.md
+++ b/tests/fixtures/design-citation-headings/accepting/skills/scoped-reference.md
@@ -1,0 +1,1 @@
+This scoped file deliberately contains no citation.

--- a/tests/fixtures/design-citation-headings/accepting/tools/colon-reference.txt
+++ b/tests/fixtures/design-citation-headings/accepting/tools/colon-reference.txt
@@ -1,0 +1,1 @@
+See docs/DESIGN-ci.md: "Merge readiness contract".

--- a/tests/fixtures/design-citation-headings/accepting/tools/scoped-reference.py
+++ b/tests/fixtures/design-citation-headings/accepting/tools/scoped-reference.py
@@ -1,0 +1,1 @@
+# This scoped file deliberately contains no citation.

--- a/tests/fixtures/design-citation-headings/accepting/tools/section-word-reference.txt
+++ b/tests/fixtures/design-citation-headings/accepting/tools/section-word-reference.txt
@@ -1,0 +1,1 @@
+See docs/DESIGN-ci.md section "Merge readiness contract".

--- a/tests/fixtures/design-citation-headings/stale-435b0f6/.github/workflows/ci.yml
+++ b/tests/fixtures/design-citation-headings/stale-435b0f6/.github/workflows/ci.yml
@@ -1,0 +1,8 @@
+# First issue citation.
+# See docs/DESIGN-ci.md, "Merge queue (planned, not yet enabled)".
+
+# Second issue citation in a coordinated list.
+# See docs/DESIGN-ci.md, "Required pre-merge contexts, and why the merge queue was rejected" and "Merge queue (planned, not yet enabled)".
+
+# Enabling FSL_MERGE_QUEUE_CI is the only remaining step. This deliberately
+# uncited premise is outside the syntax lint's contract.

--- a/tests/fixtures/design-citation-headings/stale-435b0f6/docs/DESIGN-ci.md
+++ b/tests/fixtures/design-citation-headings/stale-435b0f6/docs/DESIGN-ci.md
@@ -1,0 +1,3 @@
+# CI fixture after the heading rename
+
+## Required pre-merge contexts, and why the merge queue was rejected

--- a/tests/fixtures/design-citation-headings/stale-435b0f6/tools/check-product-gate-scope.sh
+++ b/tests/fixtures/design-citation-headings/stale-435b0f6/tools/check-product-gate-scope.sh
@@ -1,0 +1,3 @@
+# Third issue citation, folded exactly as the historical shape was folded.
+# See docs/DESIGN-ci.md's "Merge queue (planned, not yet
+# enabled)".

--- a/tests/fixtures/design-citation-headings/stale-new-separators/docs/DESIGN-ci.md
+++ b/tests/fixtures/design-citation-headings/stale-new-separators/docs/DESIGN-ci.md
@@ -1,0 +1,3 @@
+# CI fixture after two headings were removed
+
+## A surviving heading

--- a/tests/fixtures/design-citation-headings/stale-new-separators/tools/broken-separators.txt
+++ b/tests/fixtures/design-citation-headings/stale-new-separators/tools/broken-separators.txt
@@ -1,0 +1,2 @@
+See docs/DESIGN-ci.md: "Colon heading removed".
+See docs/DESIGN-ci.md section "Section-word heading removed".

--- a/tests/fixtures/design-citation-headings/untracked-design/docs/DESIGN-ambient.md
+++ b/tests/fixtures/design-citation-headings/untracked-design/docs/DESIGN-ambient.md
@@ -1,0 +1,3 @@
+# Ambient document fixture
+
+## Ambient-only heading

--- a/tests/fixtures/design-citation-headings/untracked-design/tools/untracked-target-reference.txt
+++ b/tests/fixtures/design-citation-headings/untracked-design/tools/untracked-target-reference.txt
@@ -1,0 +1,1 @@
+See docs/DESIGN-ambient.md: "Ambient-only heading".

--- a/tests/fixtures/shell-script-inventory/accepting/.github/scripts/report-one.sh
+++ b/tests/fixtures/shell-script-inventory/accepting/.github/scripts/report-one.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+exit 0

--- a/tests/fixtures/shell-script-inventory/accepting/tools/check-one.sh
+++ b/tests/fixtures/shell-script-inventory/accepting/tools/check-one.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+exit 0

--- a/tests/fixtures/shell-script-inventory/accepting/tools/run-one.sh
+++ b/tests/fixtures/shell-script-inventory/accepting/tools/run-one.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+exit 0

--- a/tests/test_inline_implements_action.py
+++ b/tests/test_inline_implements_action.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Inline `implements { }` action correspondence (#73).
+"""Inline `implements { }` action correspondence (#73, #786).
 
 Confirms `refinement_action` can appear inside the requirements-dialect
 inline `implements { }` block (grammar.py `?implements_item`), including
@@ -11,7 +11,10 @@ refinement file + `fslc refine`. The inline desugar (dialects.py
 same `("refinement", ..., mapping_items)` AST that the separate-file path
 parses, so `refine.py` needs no changes.
 """
+from pathlib import Path
+
 from fslc.cli import run_check, run_refine, run_verify
+from fslc.dialects import _parse_file
 
 
 def _write(tmp_path, files):
@@ -178,6 +181,81 @@ def test_inline_action_map_conflicts_with_requirement_maps_clause_is_an_error(tm
     assert checked["result"] == "error"
     assert checked["kind"] == "type"
     assert "duplicate action map for 'pay'" in checked["message"]
+
+
+def test_inline_action_map_overrides_process_auto_map_only():
+    root = Path(__file__).resolve().parents[1]
+    requirements = root / "examples/e2e/2_requirements.fsl"
+
+    checked = run_check(str(requirements))
+    assert checked["result"] == "ok", checked
+    assert checked["implements"] == {"abs": "ExpenseToBe", "result": "refines"}
+
+    ast, _display_names = _parse_file(requirements)
+    implements = next(item[1] for item in ast[2] if item[0] == "__implements")
+    action_maps = [
+        item for item in implements["mapping_ast"][2] if item[0] == "action_map"
+    ]
+
+    assert [(item[1], item[2], item[3]) for item in action_maps] == [
+        (
+            "submit",
+            [("refinement_param", "c", None), ("refinement_param", "a", None)],
+            ("action", "submit", [("var", "c")]),
+        ),
+        ("auto_approve", ["c"], ("action", "auto_approve", [("var", "c")])),
+        ("mgr_approve", ["c"], ("action", "mgr_approve", [("var", "c")])),
+        ("reject", ["c"], ("action", "reject", [("var", "c")])),
+        ("pay", ["c"], ("action", "pay", [("var", "c")])),
+    ]
+
+
+BUSINESS_PROCESS_ACTOR_OVERRIDE = '''business ActorOverrideBiz {
+  actor Employee, Manager
+  entity Claim
+
+  process Claim {
+    stages Draft, Submitted
+    initial Draft
+    transition submit Draft -> Submitted by Employee
+    transition review Draft -> Submitted by Manager
+  }
+}
+verify {
+  instances Claim = 1
+}
+'''
+
+REQUIREMENTS_PROCESS_ACTOR_OVERRIDE = '''requirements ActorOverrideReq {
+  implements ActorOverrideBiz from "biz.fsl" {
+    action submit(c) -> review(c)
+  }
+
+  process Claim {
+    stages Draft, Submitted
+    initial Draft
+    transition submit Draft -> Submitted by Manager
+  }
+}
+verify {
+  instances Claim = 1
+}
+'''
+
+
+def test_inline_action_map_override_skips_auto_map_actor_validation(tmp_path):
+    _write(tmp_path, {
+        "biz.fsl": BUSINESS_PROCESS_ACTOR_OVERRIDE,
+        "req.fsl": REQUIREMENTS_PROCESS_ACTOR_OVERRIDE,
+    })
+
+    checked = run_check(str(tmp_path / "req.fsl"))
+
+    assert checked["result"] == "ok", checked
+    assert checked["implements"] == {
+        "abs": "ActorOverrideBiz",
+        "result": "refines",
+    }
 
 
 ABS_BRANCH = '''spec AbsBranch73 {

--- a/tools/aggregate_changelog.sh
+++ b/tools/aggregate_changelog.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "aggregate_changelog.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 #
 # Aggregates checked-in changelog fragments under `changelog.d/` into
@@ -115,7 +116,10 @@ export LC_ALL=C
 # end-to-end control-1/control-4 fixtures `cd` into a throwaway git repo and
 # re-invoke this tool, and `$0` alone would break there if the script was
 # invoked with a relative path.
-SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+self_directory="$(dirname "$0")"
+self_directory="$(cd "$self_directory" && pwd)"
+self_basename="$(basename "$0")"
+SELF="$self_directory/$self_basename"
 
 # This repository's bullet-lead-word vocabulary. See the header comment.
 DECLARED_CATEGORY_ORDER=(
@@ -239,15 +243,18 @@ reject_unenumerable_fragments() {
   local dir="$1" f rel
   [ -d "$dir" ] || return 0
   # A newline-joined string, not an array: `"${arr[@]}"` on a zero-element
-  # array is an unbound-variable error under `set -u` on bash < 4.4 (macOS's
-  # default bash is 3.2), and this dir legitimately has zero enumerable
+  # array is an unbound-variable error under `set -u` on bash 4.0-4.3, and
+  # this dir legitimately has zero enumerable
   # fragments whenever every file under it is unenumerable (the exact case
   # this function exists to catch) or the dir holds only README.md (which
   # list_fragment_files itself always skips). `grep -qxF` below does exact
   # whole-line membership testing against this string instead of iterating
   # an array, so the empty case needs no special-casing at all.
-  local enumerated
+  local enumerated found_paths
   enumerated="$(list_fragment_files "$dir")"
+  found_paths="$(mktemp)" || fail "could not create fragment path inventory"
+  find "$dir" -type f -print0 >"$found_paths" 2>/dev/null \
+    || { rm -f "$found_paths"; fail "could not enumerate fragment paths under $dir"; }
   while IFS= read -r -d '' f; do
     # rel, not basename: a nested README.md ("sub/README.md") must not be
     # mistaken for the top-level exemption -- only $dir/README.md itself is
@@ -257,22 +264,26 @@ reject_unenumerable_fragments() {
     # the full relative path, not the last path component.
     rel="${f#"$dir"/}"
     [ "$rel" = "README.md" ] && continue
-    is_known_non_fragment_artifact "$(basename "$rel")" && continue
+    local basename_rel
+    basename_rel="$(basename "$rel")"
+    is_known_non_fragment_artifact "$basename_rel" && continue
     if ! printf '%s\n' "$enumerated" | grep -qxF "$rel"; then
       fail "changelog-fragment-path-invalid: $dir/$rel (not enumerable by list_fragment_files -- fragments must be direct, non-hidden children of $dir/ with a .md extension; only $dir/README.md is exempt)"
     fi
-  done < <(find "$dir" -type f -print0 2>/dev/null)
+  done <"$found_paths"
+  rm -f "$found_paths"
 }
 
 validate_fragment_names() {
   local dir="$1"
   reject_unenumerable_fragments "$dir"
   local -a files=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$(list_fragment_files "$dir" | sort)"
+  local f listed
+  listed="$(list_fragment_files "$dir" | sort)" \
+    || fail "could not list and sort fragments under $dir"
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$listed"
   # `"${files[@]}"` on a zero-element array is an unbound-variable error
-  # under `set -u` on bash < 4.4 (macOS's default bash is 3.2, unlike
-  # ubuntu-latest's bash 5 that merge-readiness actually runs on), so guard
+  # under `set -u` on bash 4.0-4.3, so guard
   # the empty case -- an empty `changelog.d/` is trivially valid, not an
   # error, here.
   [ "${#files[@]}" -eq 0 ] && return 0
@@ -283,15 +294,15 @@ validate_fragment_names() {
 
 check_duplicates() {
   # Deliberately a plain indexed-array linear scan, not an associative
-  # array: this keeps the script running on bash 3.2 (macOS's default,
-  # unlike ubuntu-latest's bash 5, which is what merge-readiness actually
-  # runs on) so a contributor can execute it locally without a newer bash.
+  # array: the simpler data structure is sufficient for the bounded input.
   # Fragment counts are small (dozens at most between releases), so the
   # O(n^2) scan is not a performance concern.
   local dir="$1"
   local -a files=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$(list_fragment_files "$dir" | sort)"
+  local f listed
+  listed="$(list_fragment_files "$dir" | sort)" \
+    || fail "could not list and sort fragments under $dir"
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$listed"
   [ "${#files[@]}" -eq 0 ] && return 0
   local -a seen_keys=() seen_files=()
   for f in "${files[@]}"; do
@@ -315,8 +326,9 @@ check_duplicates() {
 sort_fragments() {
   local dir="$1"
   local -a files=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$(list_fragment_files "$dir")"
+  local f listed
+  listed="$(list_fragment_files "$dir")"
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$listed"
   [ "${#files[@]}" -eq 0 ] && return 0
   local keyed=""
   for f in "${files[@]}"; do
@@ -399,8 +411,9 @@ validate_fragment_hygiene() {
 validate_fragment_hygiene_all() {
   local dir="$1"
   local -a files=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$(list_fragment_files "$dir")"
+  local f listed
+  listed="$(list_fragment_files "$dir")"
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$listed"
   [ "${#files[@]}" -eq 0 ] && return 0
   for f in "${files[@]}"; do
     validate_fragment_hygiene "$dir/$f"
@@ -422,8 +435,9 @@ render_fragment() {
 aggregate_section_body() {
   local dir="$1"
   local -a sorted=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$(sort_fragments "$dir")"
+  local f listed
+  listed="$(sort_fragments "$dir")"
+  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$listed"
   [ "${#sorted[@]}" -eq 0 ] && return 0
   local out="" f_out
   for f in "${sorted[@]}"; do
@@ -463,11 +477,16 @@ split_bullets() {
 verify_conservation() {
   local dir="$1" produced="$2"
   local -a sorted=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$(sort_fragments "$dir")"
+  local f listed
+  listed="$(sort_fragments "$dir")"
+  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$listed"
   local -a actual=()
-  local seg
-  while IFS= read -r -d '' seg; do actual+=("$seg"); done < <(split_bullets "$produced")
+  local seg bullet_file
+  bullet_file="$(mktemp)" || fail "could not create rendered-bullet inventory"
+  split_bullets "$produced" >"$bullet_file" \
+    || { rm -f "$bullet_file"; fail "could not split rendered bullets"; }
+  while IFS= read -r -d '' seg; do actual+=("$seg"); done <"$bullet_file"
+  rm -f "$bullet_file"
   if [ "${#actual[@]}" -ne "${#sorted[@]}" ]; then
     fail "fragment-dropped: bullet count mismatch (expected ${#sorted[@]} fragment(s), produced ${#actual[@]} top-level bullet(s))"
   fi
@@ -751,7 +770,7 @@ classify_product_diff() {
     fail "changelog-fragment-missing: ${non_exempt[*]}"
   fi
   # `"${arr[@]}"` on an empty array is an unbound-variable error under
-  # `set -u` on bash < 4.4 (macOS's default bash is 3.2), so guard the
+  # `set -u` on bash 4.0-4.3, so guard the
   # common empty case explicitly instead of relying on a modern bash.
   if [ "${#check_fragments[@]}" -gt 0 ]; then
     printf '%s\n' "${check_fragments[@]}"
@@ -868,9 +887,10 @@ check_direct_edit_files() {
 # own fail-closed behavior (a bad edit fails here, before control 1 ever
 # runs) and control 1's release exclusion -- one computation, consumed
 # twice, so the two controls cannot disagree (review finding S2-1, #737,
-# comment 2026-08-07, second round).
+# comment 2026-08-07, second round). $1 is the repository-relative changelog
+# path and must be supplied explicitly by the caller.
 compute_direct_edit_classification() {
-  local changelog="${1:-CHANGELOG.md}"
+  local changelog="$1"
   : "${BASE_SHA:?BASE_SHA is required}"
   : "${HEAD_SHA:?HEAD_SHA is required}"
   # Diff against the merge base, not BASE_SHA's tip: this repository's own
@@ -965,7 +985,7 @@ check_pr() {
   # cannot disagree about whether this diff is a genuine release move (S2-1).
   local classification status
   set +e
-  classification="$(compute_direct_edit_classification)"
+  classification="$(compute_direct_edit_classification "CHANGELOG.md")"
   status=$?
   set -e
   [ "$status" -eq 0 ] || exit 1
@@ -980,8 +1000,9 @@ check_stale() {
   # dotfile) must not be able to reach tag time invisibly either (S3-1).
   reject_unenumerable_fragments "$dir"
   local -a files=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$(list_fragment_files "$dir")"
+  local f listed
+  listed="$(list_fragment_files "$dir")"
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done <<<"$listed"
   if [ "${#files[@]}" -gt 0 ]; then
     fail "stale-fragments-present: ${files[*]}"
   fi
@@ -1008,8 +1029,9 @@ release() {
   validate_fragment_hygiene_all "$fragdir"
 
   local -a sorted=()
-  local f
-  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$(sort_fragments "$fragdir")"
+  local f listed
+  listed="$(sort_fragments "$fragdir")"
+  while IFS= read -r f; do [ -n "$f" ] && sorted+=("$f"); done <<<"$listed"
   # An empty `changelog.d/` is a legitimate release, not an error (review
   # finding S3-2, #737, comment 2026-08-07, second round): a version bump
   # with no product-facing content since the previous release is a real
@@ -1020,7 +1042,7 @@ release() {
   # made step 7 impossible to run for that release shape at all. Guarded
   # with `-gt 0` before the loop below (rather than only inside it) because
   # `"${sorted[@]}"` on a zero-element array is an unbound-variable error
-  # under `set -u` on bash < 4.4 (macOS's default bash is 3.2).
+  # under `set -u` on bash 4.0-4.3.
   if [ "${#sorted[@]}" -gt 0 ]; then
     for f in "${sorted[@]}"; do
       fragment_is_empty "$fragdir/$f" && fail "changelog-fragment-empty: $fragdir/$f"
@@ -1255,7 +1277,10 @@ selftest_control3() {
   fi
   local lexicographic_numeric
   lexicographic_numeric="$(list_fragment_files "$tmp" | LC_ALL=C sort)"
-  echo "selftest: rejecting fixture 'control3 rejecting: lexicographic sham vs numeric golden' produced: $(printf '%s' "$lexicographic_numeric" | tr '\n' ' ')"
+  local lexicographic_numeric_display
+  lexicographic_numeric_display="$(printf '%s' "$lexicographic_numeric" | tr '\n' ' ')" \
+    || fail "could not format numeric-order selftest output"
+  echo "selftest: rejecting fixture 'control3 rejecting: lexicographic sham vs numeric golden' produced: $lexicographic_numeric_display"
   if [ "$lexicographic_numeric" = "$golden_numeric" ]; then
     st_report "control3 rejecting: lexicographic sham vs numeric golden (aggregation-order-wrong)" fail 0
   else
@@ -1278,7 +1303,10 @@ selftest_control3() {
   fi
   local lexicographic_category
   lexicographic_category="$(list_fragment_files "$tmp" | LC_ALL=C sort)"
-  echo "selftest: rejecting fixture 'control3 rejecting: lexicographic-category sham vs category golden' produced: $(printf '%s' "$lexicographic_category" | tr '\n' ' ')"
+  local lexicographic_category_display
+  lexicographic_category_display="$(printf '%s' "$lexicographic_category" | tr '\n' ' ')" \
+    || fail "could not format category-order selftest output"
+  echo "selftest: rejecting fixture 'control3 rejecting: lexicographic-category sham vs category golden' produced: $lexicographic_category_display"
   if [ "$lexicographic_category" = "$golden_category" ]; then
     st_report "control3 rejecting: lexicographic-category sham vs category golden (aggregation-order-wrong)" fail 0
   else
@@ -1353,8 +1381,10 @@ selftest_control5() {
   st_expect_pass "control5 accepting: faithful aggregation of 3 fragments (one multi-line)" verify_conservation "$tmp" "$faithful"
 
   # Rejecting (a): a sham that drops one of three fragments.
-  local dropped
-  dropped="$(render_fragment "$tmp/1-a.added.md")"$'\n'"$(render_fragment "$tmp/3-c.added.md")"
+  local dropped first_render third_render
+  first_render="$(render_fragment "$tmp/1-a.added.md")"
+  third_render="$(render_fragment "$tmp/3-c.added.md")"
+  dropped="${first_render}"$'\n'"${third_render}"
   st_expect_fail "control5 rejecting: sham drops one of three fragments (fragment-dropped)" verify_conservation "$tmp" "$dropped"
 
   # Rejecting (b): a sham that copies only each fragment's first line,
@@ -1376,8 +1406,9 @@ selftest_control5() {
   # must reject it.
   st_setup_frag "$tmp" "1-a.added.md" "Fixed (#1): a."
   st_setup_frag "$tmp" "2-b.added.md" "Fixed (#1): a." "more detail."
-  local duplicated
-  duplicated="$(render_fragment "$tmp/2-b.added.md")"$'\n'"$(render_fragment "$tmp/2-b.added.md")"
+  local duplicated duplicated_render
+  duplicated_render="$(render_fragment "$tmp/2-b.added.md")"
+  duplicated="${duplicated_render}"$'\n'"${duplicated_render}"
   st_expect_fail "control5 rejecting: sham drops fragment A and emits fragment B (whose block starts with A's) twice" \
     verify_conservation "$tmp" "$duplicated"
 

--- a/tools/aggregate_changelog.sh
+++ b/tools/aggregate_changelog.sh
@@ -621,6 +621,12 @@ is_release_bump_path() {
     rust/Cargo.lock) return 0 ;;
     rust/Cargo.toml) return 0 ;;
     rust/fslc/tests/fixtures/domain_characterization/baseline.v1.json) return 0 ;;
+    # #906's induction contract golden records each envelope's `versions`
+    # block, so a release bump regenerates it for the same reason as the
+    # characterization baseline above. Observed on the v4.4.1 candidate: the
+    # complete product gate failed comparing 4.4.0 against 4.4.1 before this
+    # path was named here.
+    rust/fslc/tests/goldens/induction_cli_contract.json) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/tools/check-bash-version-guards.py
+++ b/tools/check-bash-version-guards.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Require an immediate Bash 4+ guard for direct syntactic feature use.
+
+This lint detects direct shell syntax. Dynamic execution through ``eval`` or a
+variable-expanded command word is outside its static-detection boundary and is
+not part of its detection claim. Literal heredoc command text is ignored;
+parameter, command, backtick, and arithmetic expansions are scanned only when
+the heredoc delimiter is unquoted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+GUARD = re.compile(
+    r'^\(\( BASH_VERSINFO\[0\] >= 4 \)\) \|\| \{ echo "[^"]+" >&2; exit 1; \}$'
+)
+ARRAY_EXPANSION = re.compile(r"\$\{[^}\n]*\[@\][^}\n]*\}")
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+COMMAND_BOUNDARIES = {"\n", ";", ";;", ";&", ";;&", "&", "&&", "|", "||", "(", ")", "{", "}"}
+COMMAND_KEYWORDS = {
+    "!",
+    "case",
+    "do",
+    "done",
+    "elif",
+    "else",
+    "esac",
+    "fi",
+    "for",
+    "function",
+    "if",
+    "in",
+    "select",
+    "then",
+    "time",
+    "until",
+    "while",
+}
+
+
+class Token(NamedTuple):
+    kind: str
+    text: str
+
+
+class Heredoc(NamedTuple):
+    delimiter: str
+    strip_tabs: bool
+    quoted: bool
+
+
+class LexedShell:
+    def __init__(self) -> None:
+        self.tokens: list[Token] = []
+        self.nested_commands: list[str] = []
+        self.has_array_expansion = False
+
+
+def consume_parenthesized(source: str, start: int) -> tuple[str, int]:
+    """Return one parser-validated $(...) or $((...)) body and its end offset."""
+    arithmetic = source.startswith("$((", start)
+    first_parenthesis = start + 1
+    depth = 0
+    quote = ""
+    escaped = False
+    index = first_parenthesis
+    while index < len(source):
+        char = source[index]
+        if escaped:
+            escaped = False
+        elif char == "\\" and quote != "'":
+            escaped = True
+        elif quote:
+            if char == quote:
+                quote = ""
+        elif char in "'\"":
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                body_start = start + (3 if arithmetic else 2)
+                body_end = index - (1 if arithmetic else 0)
+                return source[body_start:body_end], index + 1
+        index += 1
+    return source[start:], len(source)
+
+
+def consume_braced(source: str, start: int) -> tuple[str, int]:
+    depth = 0
+    index = start + 1
+    while index < len(source):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1], index + 1
+        index += 1
+    return source[start:], len(source)
+
+
+def consume_backticks(source: str, start: int) -> tuple[str, int]:
+    index = start + 1
+    escaped = False
+    while index < len(source):
+        char = source[index]
+        if escaped:
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif char == "`":
+            return source[start + 1 : index], index + 1
+        index += 1
+    return source[start + 1 :], len(source)
+
+
+def consume_heredoc_delimiter(source: str, start: int) -> tuple[str, int, bool]:
+    """Apply quote removal and report whether a heredoc delimiter was quoted."""
+    delimiter: list[str] = []
+    quoted = False
+    index = start
+    while index < len(source) and source[index] not in " \t\r\n;&|(){}<>":
+        char = source[index]
+        if char == "\\":
+            quoted = True
+            if index + 1 < len(source):
+                delimiter.append(source[index + 1])
+                index += 2
+            else:
+                index += 1
+            continue
+        if char == "'":
+            quoted = True
+            end = source.find("'", index + 1)
+            if end < 0:
+                delimiter.append(source[index + 1 :])
+                return "".join(delimiter), len(source), quoted
+            delimiter.append(source[index + 1 : end])
+            index = end + 1
+            continue
+        if char == '"':
+            quoted = True
+            index += 1
+            while index < len(source) and source[index] != '"':
+                if source[index] == "\\" and index + 1 < len(source):
+                    escaped = source[index + 1]
+                    if escaped in {'$', '`', '"', "\\"}:
+                        delimiter.append(escaped)
+                    elif escaped != "\n":
+                        delimiter.extend(("\\", escaped))
+                    index += 2
+                else:
+                    delimiter.append(source[index])
+                    index += 1
+            index += index < len(source)
+            continue
+        delimiter.append(char)
+        index += 1
+    return "".join(delimiter), index, quoted
+
+
+def consume_heredoc_bodies(
+    source: str, start: int, heredocs: list[Heredoc]
+) -> tuple[int, list[str]]:
+    """Return the end offset and expansion-capable unquoted heredoc bodies."""
+    index = start
+    expandable_bodies: list[str] = []
+    for heredoc in heredocs:
+        body_start = index
+        while index < len(source):
+            line_start = index
+            newline = source.find("\n", index)
+            line_end = len(source) if newline < 0 else newline
+            line = source[index:line_end]
+            comparison = line.lstrip("\t") if heredoc.strip_tabs else line
+            index = len(source) if newline < 0 else newline + 1
+            if comparison == heredoc.delimiter:
+                if not heredoc.quoted:
+                    expandable_bodies.append(source[body_start:line_start])
+                break
+    return index, expandable_bodies
+
+
+def record_heredoc_expansions(source: str, result: LexedShell) -> None:
+    """Record only expansions Bash executes in an unquoted heredoc body."""
+    index = 0
+    while index < len(source):
+        if source[index] == "\\":
+            index += 2
+            continue
+        if source.startswith("$((", index):
+            arithmetic, index = consume_parenthesized(source, index)
+            record_heredoc_expansions(arithmetic, result)
+            continue
+        if source.startswith("$(", index):
+            nested, index = consume_parenthesized(source, index)
+            result.nested_commands.append(nested)
+            continue
+        if source.startswith("${", index):
+            expansion, index = consume_braced(source, index)
+            if ARRAY_EXPANSION.search(expansion):
+                result.has_array_expansion = True
+            continue
+        if source[index] == "`":
+            nested, index = consume_backticks(source, index)
+            result.nested_commands.append(nested)
+            continue
+        index += 1
+
+
+def lex_shell(source: str) -> LexedShell:
+    """Tokenize enough parsed Bash structure to classify executed simple commands."""
+    result = LexedShell()
+    word: list[str] = []
+    word_active = False
+    heredocs: list[Heredoc] = []
+    expect_heredoc_delimiter: bool | None = None
+    index = 0
+
+    def flush_word() -> None:
+        nonlocal word_active
+        if word_active:
+            result.tokens.append(Token("word", "".join(word)))
+            word.clear()
+            word_active = False
+
+    def append_parameter(expansion: str) -> None:
+        nonlocal word_active
+        word.append(expansion)
+        word_active = True
+        if ARRAY_EXPANSION.search(expansion):
+            result.has_array_expansion = True
+
+    while index < len(source):
+        char = source[index]
+        if expect_heredoc_delimiter is not None:
+            if char in " \t\r":
+                index += 1
+                continue
+            delimiter, index, quoted = consume_heredoc_delimiter(source, index)
+            heredocs.append(Heredoc(delimiter, expect_heredoc_delimiter, quoted))
+            expect_heredoc_delimiter = None
+            continue
+        if char in " \t\r":
+            flush_word()
+            index += 1
+            continue
+        if char == "\n":
+            flush_word()
+            result.tokens.append(Token("operator", "\n"))
+            index += 1
+            if heredocs:
+                index, expandable_bodies = consume_heredoc_bodies(
+                    source, index, heredocs
+                )
+                for body in expandable_bodies:
+                    record_heredoc_expansions(body, result)
+                heredocs.clear()
+            continue
+        if char == "#" and not word_active:
+            newline = source.find("\n", index)
+            index = len(source) if newline < 0 else newline
+            continue
+        if char == "\\":
+            word_active = True
+            if index + 1 < len(source):
+                word.append(source[index + 1])
+                index += 2
+            else:
+                index += 1
+            continue
+        if char == "'":
+            word_active = True
+            end = source.find("'", index + 1)
+            if end < 0:
+                word.append(source[index + 1 :])
+                break
+            word.append(source[index + 1 : end])
+            index = end + 1
+            continue
+        if char == '"':
+            word_active = True
+            index += 1
+            while index < len(source) and source[index] != '"':
+                if source[index] == "\\" and index + 1 < len(source):
+                    word.append(source[index + 1])
+                    index += 2
+                elif source.startswith("$((", index):
+                    arithmetic, index = consume_parenthesized(source, index)
+                    append_parameter(arithmetic)
+                    word.append("$((...))")
+                elif source.startswith("$(", index):
+                    nested, index = consume_parenthesized(source, index)
+                    result.nested_commands.append(nested)
+                    word.append("$(...)")
+                elif source.startswith("${", index):
+                    expansion, index = consume_braced(source, index)
+                    append_parameter(expansion)
+                elif source[index] == "`":
+                    nested, index = consume_backticks(source, index)
+                    result.nested_commands.append(nested)
+                    word.append("`...`")
+                else:
+                    word.append(source[index])
+                    index += 1
+            index += index < len(source)
+            continue
+        if source.startswith("$((", index):
+            arithmetic, index = consume_parenthesized(source, index)
+            append_parameter(arithmetic)
+            word.append("$((...))")
+            continue
+        if source.startswith("$(", index):
+            nested, index = consume_parenthesized(source, index)
+            result.nested_commands.append(nested)
+            word.append("$(...)")
+            word_active = True
+            continue
+        if source.startswith("${", index):
+            expansion, index = consume_braced(source, index)
+            append_parameter(expansion)
+            continue
+        if char == "`":
+            nested, index = consume_backticks(source, index)
+            result.nested_commands.append(nested)
+            word.append("`...`")
+            word_active = True
+            continue
+        if char in ";&|(){}<>":
+            flush_word()
+            if source.startswith("<<<", index):
+                operator = "<<<"
+                index += 3
+            elif source.startswith("<<-", index):
+                operator = "<<-"
+                index += 3
+                expect_heredoc_delimiter = True
+            elif index + 1 < len(source) and source[index : index + 2] in {
+                "&&",
+                "||",
+                ";;",
+                ";&",
+                "|&",
+                "<<",
+                ">>",
+                "<&",
+                ">&",
+            }:
+                operator = source[index : index + 2]
+                index += 2
+                if operator == "<<":
+                    expect_heredoc_delimiter = False
+                if operator == ";;" and index < len(source) and source[index] == "&":
+                    operator = ";;&"
+                    index += 1
+            else:
+                operator = char
+                index += 1
+            result.tokens.append(Token("operator", operator))
+            continue
+        word.append(char)
+        word_active = True
+        index += 1
+    flush_word()
+    return result
+
+
+def simple_commands(tokens: list[Token]) -> list[list[str]]:
+    commands: list[list[str]] = []
+    current: list[str] = []
+    expect_function_name = False
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.kind == "operator" and token.text in COMMAND_BOUNDARIES:
+            if (
+                token.text == "("
+                and len(current) == 1
+                and index + 1 < len(tokens)
+                and tokens[index + 1] == Token("operator", ")")
+            ):
+                current = []
+                index += 2
+                continue
+            if current:
+                commands.append(current)
+                current = []
+            index += 1
+            continue
+        if token.kind != "word":
+            index += 1
+            continue
+        if expect_function_name:
+            expect_function_name = False
+            index += 1
+            continue
+        if not current and token.text in COMMAND_KEYWORDS:
+            expect_function_name = token.text == "function"
+            index += 1
+            continue
+        current.append(token.text)
+        index += 1
+    if current:
+        commands.append(current)
+    return commands
+
+
+def command_word(words: list[str]) -> tuple[str, list[str]]:
+    index = 0
+    while index < len(words) and ASSIGNMENT.match(words[index]):
+        index += 1
+    if index >= len(words):
+        return "", []
+    command = words[index]
+    arguments = words[index + 1 :]
+    if command == "command" and arguments:
+        if any(argument in {"-v", "-V"} for argument in arguments):
+            return "", []
+        while arguments and arguments[0].startswith("-"):
+            arguments = arguments[1:]
+        if arguments:
+            command = arguments[0]
+            arguments = arguments[1:]
+    elif command == "builtin" and arguments:
+        command = arguments[0]
+        arguments = arguments[1:]
+    return command, arguments
+
+
+def enables_nounset(arguments: list[str]) -> bool:
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == "--":
+            return False
+        if argument == "-o":
+            return index + 1 < len(arguments) and arguments[index + 1] == "nounset"
+        if argument.startswith("-") and "u" in argument[1:]:
+            return True
+        index += 1
+    return False
+
+
+def scan_facts(source: str) -> tuple[set[str], bool, bool]:
+    features: set[str] = set()
+    has_set_u = False
+    has_array_expansion = False
+    pending = [source]
+    while pending:
+        lexed = lex_shell(pending.pop())
+        pending.extend(lexed.nested_commands)
+        has_array_expansion = has_array_expansion or lexed.has_array_expansion
+        for words in simple_commands(lexed.tokens):
+            command, arguments = command_word(words)
+            if command in {"mapfile", "readarray"}:
+                features.add("mapfile/readarray")
+            if command in {"declare", "local", "typeset"}:
+                for argument in arguments:
+                    if argument == "--":
+                        break
+                    if argument.startswith("-") and "A" in argument[1:]:
+                        features.add("associative array")
+                        break
+            if command == "set":
+                has_set_u = has_set_u or enables_nounset(arguments)
+    return features, has_set_u, has_array_expansion
+
+
+def required_features(source: str) -> list[str]:
+    found, has_set_u, has_array_expansion = scan_facts(source)
+    if has_set_u and has_array_expansion:
+        found.add("array expansion under set -u")
+    return [
+        feature
+        for feature in (
+            "mapfile/readarray",
+            "associative array",
+            "array expansion under set -u",
+        )
+        if feature in found
+    ]
+
+
+FEATURE_CASES = (
+    ("mapfile column zero", "mapfile -t values </dev/null\n", ["mapfile/readarray"]),
+    ("mapfile indented", "f() {\n  mapfile -t values </dev/null\n}\n", ["mapfile/readarray"]),
+    ("readarray command", "readarray -t values </dev/null\n", ["mapfile/readarray"]),
+    ("quoted mapfile command", "\"mapfile\" -t values </dev/null\n", ["mapfile/readarray"]),
+    ("builtin mapfile command", "builtin mapfile -t values </dev/null\n", ["mapfile/readarray"]),
+    (
+        "mapfile in command substitution",
+        "printf '%s' \"$(mapfile -t values </dev/null)\"\n",
+        ["mapfile/readarray"],
+    ),
+    (
+        "mapfile in backticks",
+        "printf '%s' \"`mapfile -t values </dev/null`\"\n",
+        ["mapfile/readarray"],
+    ),
+    ("mapfile unquoted argument", "printf '%s' mapfile\n", []),
+    ("mapfile single-quoted argument", "printf '%s' 'mapfile -t values'\n", []),
+    ("mapfile double-quoted argument", "printf '%s' \"mapfile -t values\"\n", []),
+    ("mapfile comment", "# mapfile -t values\nprintf ok\n", []),
+    ("mapfile near miss", "mapfile_helper -t values\n", []),
+    ("mapfile keyword argument", "printf '%s' if mapfile\n", []),
+    ("mapfile function declaration", "mapfile() { printf ok; }\n", []),
+    ("declare associative", "declare -A values=()\n", ["associative array"]),
+    ("declare associative indented", "f() {\n  declare -A values=()\n}\n", ["associative array"]),
+    ("local associative", "f() {\n  local -A values=()\n}\n", ["associative array"]),
+    ("typeset associative", "f() {\n  typeset -A values=()\n}\n", ["associative array"]),
+    ("combined associative flags", "declare -gA values=()\n", ["associative array"]),
+    ("builtin associative declaration", "builtin declare -A values\n", ["associative array"]),
+    ("declare single-quoted argument", "printf '%s' 'declare -A values=()'\n", []),
+    ("local double-quoted argument", "printf '%s' \"local -A values=()\"\n", []),
+    ("associative comment", "# local -A values=()\nprintf ok\n", []),
+    ("indexed declaration", "declare -a values=()\n", []),
+    ("associative function declaration", "declare() { printf ok; }\n", []),
+    (
+        "set short nounset",
+        "set -u\nvalues=()\nprintf '%s' ${values[@]}\n",
+        ["array expansion under set -u"],
+    ),
+    (
+        "set combined nounset",
+        "set -euo pipefail\nvalues=()\nprintf '%s' \"${values[@]}\"\n",
+        ["array expansion under set -u"],
+    ),
+    (
+        "set named nounset",
+        "set -o nounset\nvalues=()\nprintf '%s' \"${values[@]}\"\n",
+        ["array expansion under set -u"],
+    ),
+    ("array expansion without nounset", "values=()\nprintf '%s' \"${values[@]}\"\n", []),
+    ("single-quoted array literal", "set -u\nprintf '%s' '${values[@]}'\n", []),
+    ("array expansion comment", "set -u\n# printf '%s' \"${values[@]}\"\nprintf ok\n", []),
+    (
+        "nounset double-quoted argument",
+        "printf '%s' \"set -u\"\nvalues=()\nprintf '%s' \"${values[@]}\"\n",
+        [],
+    ),
+    ("nounset disabled", "set +u\nvalues=()\nprintf '%s' \"${values[@]}\"\n", []),
+    ("nounset positional argument", "set -- -u\nvalues=()\nprintf '%s' \"${values[@]}\"\n", []),
+    (
+        "quoted heredoc data",
+        "cat <<'EOF'\nmapfile -t values </dev/null\nEOF\n",
+        [],
+    ),
+    (
+        "tab-stripped heredoc data",
+        "cat <<-EOF\n\tlocal -A values=()\n\tEOF\n",
+        [],
+    ),
+    (
+        "code after heredoc",
+        "cat <<EOF\nmapfile data only\nEOF\nmapfile -t values </dev/null\n",
+        ["mapfile/readarray"],
+    ),
+    (
+        "unquoted heredoc command text",
+        "cat <<EOF\nmapfile -t values </dev/null\nEOF\n",
+        [],
+    ),
+    (
+        "quoted heredoc parameter and command text",
+        "set -u\nvalues=()\ncat <<'EOF'\n${values[@]}\n$(mapfile -t nested)\nEOF\n",
+        [],
+    ),
+    (
+        "unquoted heredoc array expansion",
+        "set -u\nvalues=()\ncat <<EOF\n${values[@]}\nEOF\n",
+        ["array expansion under set -u"],
+    ),
+    (
+        "unquoted heredoc command substitution",
+        "cat <<EOF\n$(mapfile -t values </dev/null)\nEOF\n",
+        ["mapfile/readarray"],
+    ),
+    (
+        "tab-stripped unquoted heredoc expansions",
+        "set -u\nvalues=()\ncat <<-EOF\n\t${values[@]}\n\t$(readarray -t nested)\n\tEOF\n",
+        ["mapfile/readarray", "array expansion under set -u"],
+    ),
+    (
+        "unquoted heredoc backtick substitution",
+        "cat <<EOF\n`mapfile -t values </dev/null`\nEOF\n",
+        ["mapfile/readarray"],
+    ),
+    (
+        "unquoted heredoc arithmetic expansion",
+        "set -u\nvalues=()\ncat <<EOF\n$(( ${values[@]} ))\nEOF\n",
+        ["array expansion under set -u"],
+    ),
+    ("literal eval is outside boundary", "eval 'mapfile -t values </dev/null'\n", []),
+    (
+        "variable command is outside boundary",
+        "command_name=mapfile\n\"$command_name\" -t values </dev/null\n",
+        [],
+    ),
+)
+
+
+def audit(root: Path, files: list[Path]) -> list[str]:
+    findings: list[str] = []
+    for relative in files:
+        path = root / relative
+        parsed = subprocess.run(
+            ["bash", "-n", str(path)], capture_output=True, text=True, check=False
+        )
+        if parsed.returncode != 0:
+            findings.append(
+                f"{relative}: bash parser rejected file: {parsed.stderr.strip()}"
+            )
+            continue
+        source = path.read_text(encoding="utf-8")
+        features = required_features(source)
+        if not features:
+            continue
+        lines = source.splitlines()
+        if len(lines) < 2 or not GUARD.fullmatch(lines[1]):
+            findings.append(
+                f"{relative}: Bash 4+ feature(s) {', '.join(features)} require "
+                "the fail-closed guard immediately after the shebang"
+            )
+    return findings
+
+
+def repository_files(root: Path) -> list[Path]:
+    return sorted(
+        path.relative_to(root)
+        for directory in (root / "tools", root / ".github/scripts")
+        if directory.is_dir()
+        for path in directory.glob("*.sh")
+    )
+
+
+def selftest(root: Path) -> int:
+    fixtures = root / "tests/fixtures/bash-version-guards"
+    cases = {
+        "accepting": [],
+        "missing-guard": ["require the fail-closed guard"],
+        "late-guard": ["require the fail-closed guard"],
+        "quoted-decoy": [],
+        "double-quoted-decoy": [],
+        "heredoc-data": [],
+        "heredoc-followed-by-code": ["mapfile/readarray"],
+        "heredoc-quoted-command-accepting": [],
+        "heredoc-quoted-command-rejecting": ["mapfile/readarray"],
+        "heredoc-unquoted-command-accepting": [],
+        "heredoc-unquoted-command-rejecting": ["associative array"],
+        "heredoc-quoted-expansion-accepting": [],
+        "heredoc-quoted-expansion-rejecting": ["array expansion under set -u"],
+        "heredoc-unquoted-expansion-accepting": [],
+        "heredoc-unquoted-expansion-rejecting": [
+            "mapfile/readarray",
+            "array expansion under set -u",
+        ],
+        "indented-declare": ["associative array"],
+        "local-associative": ["associative array"],
+    }
+    ok = True
+    for label, source, expected in FEATURE_CASES:
+        parsed = subprocess.run(
+            ["bash", "-n"], input=source, capture_output=True, text=True, check=False
+        )
+        if parsed.returncode != 0:
+            print(
+                f"selftest: FAIL: feature table {label}: bash parser rejected "
+                f"source: {parsed.stderr.strip()}",
+                file=sys.stderr,
+            )
+            ok = False
+            continue
+        produced = required_features(source)
+        if produced != expected:
+            print(
+                f"selftest: FAIL: feature table {label}: produced={produced!r} "
+                f"expected={expected!r}",
+                file=sys.stderr,
+            )
+            ok = False
+    for name, expected_fragments in cases.items():
+        case_root = fixtures / name
+        produced = audit(case_root, [Path("fixture.sh")])
+        fragments_match = all(
+            any(fragment in item for item in produced)
+            for fragment in expected_fragments
+        )
+        if fragments_match and bool(produced) == bool(expected_fragments):
+            continue
+        print(
+            f"selftest: FAIL: {name}: produced={produced!r} "
+            f"expected_fragments={expected_fragments!r}",
+            file=sys.stderr,
+        )
+        ok = False
+    if ok:
+        print(
+            f"selftest: PASS: feature_cases={len(FEATURE_CASES)} "
+            "guard_accepting=8 guard_rejecting=9"
+        )
+        return 0
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("check", "selftest"))
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parent.parent
+    if args.command == "selftest":
+        return selftest(root)
+    findings = audit(root, repository_files(root))
+    if findings:
+        print("\n".join(findings), file=sys.stderr)
+        return 1
+    print("check-bash-version-guards: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check-design-citation-headings.py
+++ b/tools/check-design-citation-headings.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Check quoted DESIGN document section citations against ATX headings."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+SCOPES = (".github", "tools", "rust", "docs", "skills")
+EXCLUDED_PATHS = {Path("CHANGELOG.md")}
+DESIGN_PATH = r"`?(docs/DESIGN-[A-Za-z0-9._-]+\.md)`?"
+QUOTED_TITLE = r'["“]([^"”\n]+)["”]'
+CITATION_PATTERNS = (
+    re.compile(
+        DESIGN_PATH
+        + r"(?:'s|’s)?"
+        + r"(?:\s*,\s*|\s*:\s*|\s*\(\s*|\s+section\s+|\s+)"
+        + QUOTED_TITLE
+    ),
+    re.compile(QUOTED_TITLE + r"\s+(?:section\s+)?(?:in|of)\s+" + DESIGN_PATH),
+)
+FOLLOWING_TITLE = re.compile(
+    r"\s*(?:(?:,\s*)?(?:and|or)\s+|,\s*)" + QUOTED_TITLE
+)
+COMMENT_PREFIX = re.compile(r"^\s*(?://!|///|//|#{1,2}|\*)\s?")
+MARKDOWN_HEADING = re.compile(r"^#{2,6}\s+(.+?)\s*#*\s*$")
+
+
+class AuditError(Exception):
+    """An invocation or input error that makes the audit indeterminate."""
+
+
+@dataclass(frozen=True, order=True)
+class Citation:
+    source: Path
+    line: int
+    design_path: str
+    title: str
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    citation: Citation
+    reason: str
+
+
+def normalize_title(value: str) -> str:
+    """Normalize presentation-only heading syntax symmetrically."""
+    value = html.unescape(value)
+    value = value.replace("`", "")
+    value = " ".join(value.split())
+    value = re.sub(r"^\d+(?:\.\d+)*\.?\s+", "", value)
+    value = re.sub(r"\s+\(#[0-9]+(?:\s+[A-Z][0-9]+)?\)$", "", value)
+    return value
+
+
+def prose_groups(text: str) -> list[tuple[str, list[int]]]:
+    """Join blank-line-delimited prose while retaining a character line map."""
+    groups: list[tuple[str, list[int]]] = []
+    chunks: list[str] = []
+    line_map: list[int] = []
+
+    def flush() -> None:
+        if not chunks:
+            return
+        groups.append(("".join(chunks), list(line_map)))
+        chunks.clear()
+        line_map.clear()
+
+    for line_number, raw in enumerate(text.splitlines(), 1):
+        if not raw.strip():
+            flush()
+            continue
+        content = COMMENT_PREFIX.sub("", raw).strip().replace(r'\"', '"')
+        if chunks:
+            chunks.append(" ")
+            line_map.append(line_number)
+        chunks.append(content)
+        line_map.extend([line_number] * len(content))
+    flush()
+    return groups
+
+
+def citations_in(source: Path, text: str) -> list[Citation]:
+    citations: list[Citation] = []
+    for joined, line_map in prose_groups(text):
+        for pattern_number, pattern in enumerate(CITATION_PATTERNS):
+            for match in pattern.finditer(joined):
+                if pattern_number == 0:
+                    design_path, title = match.group(1), match.group(2)
+                else:
+                    title, design_path = match.group(1), match.group(2)
+                line = line_map[match.start()] if line_map else 1
+                citations.append(
+                    Citation(source, line, design_path, normalize_title(title))
+                )
+                if pattern_number != 0:
+                    continue
+                cursor = match.end()
+                while following := FOLLOWING_TITLE.match(joined, cursor):
+                    title_start = following.start(1)
+                    citations.append(
+                        Citation(
+                            source,
+                            line_map[title_start] if line_map else 1,
+                            design_path,
+                            normalize_title(following.group(1)),
+                        )
+                    )
+                    cursor = following.end()
+    return citations
+
+
+def read_utf8(root: Path, relative: Path) -> str:
+    try:
+        return (root / relative).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise AuditError(f"cannot read UTF-8 file {relative}: {error}") from error
+
+
+def tracked_files(root: Path) -> list[Path]:
+    command = ["git", "ls-files", "-z", "--", *SCOPES]
+    try:
+        result = subprocess.run(
+            command, cwd=root, check=False, capture_output=True, timeout=30
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise AuditError(f"cannot enumerate tracked files: {error}") from error
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise AuditError(
+            f"git ls-files failed with exit {result.returncode}: {detail or '(no stderr)'}"
+        )
+    try:
+        names = result.stdout.decode("utf-8").split("\0")
+    except UnicodeDecodeError as error:
+        raise AuditError(f"git returned a non-UTF-8 path: {error}") from error
+    return sorted(
+        Path(name)
+        for name in names
+        if name and Path(name) not in EXCLUDED_PATHS
+    )
+
+
+def fixture_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for scope in SCOPES:
+        directory = root / scope
+        if directory.is_dir():
+            files.extend(
+                path.relative_to(root)
+                for path in directory.rglob("*")
+                if path.is_file()
+            )
+    return sorted(path for path in files if path not in EXCLUDED_PATHS)
+
+
+def headings_in(root: Path, relative: Path) -> set[str]:
+    headings: set[str] = set()
+    for line in read_utf8(root, relative).splitlines():
+        if match := MARKDOWN_HEADING.match(line):
+            headings.add(normalize_title(match.group(1)))
+    return headings
+
+
+def audit(root: Path, files: Iterable[Path]) -> tuple[list[Citation], list[Finding]]:
+    audited_files = sorted(set(files))
+    audited_file_set = set(audited_files)
+    citations: list[Citation] = []
+    for relative in audited_files:
+        citations.extend(citations_in(relative, read_utf8(root, relative)))
+    citations.sort()
+
+    cache: dict[str, set[str]] = {}
+    findings: list[Finding] = []
+    for citation in citations:
+        design_relative = Path(citation.design_path)
+        if design_relative not in audited_file_set:
+            findings.append(Finding(citation, "design document is not tracked"))
+            continue
+        if not (root / design_relative).is_file():
+            findings.append(Finding(citation, "design document does not exist"))
+            continue
+        if citation.design_path not in cache:
+            cache[citation.design_path] = headings_in(root, design_relative)
+        if citation.title not in cache[citation.design_path]:
+            findings.append(Finding(citation, "quoted heading does not exist"))
+    return citations, sorted(findings)
+
+
+def fixture_audit(root: Path) -> tuple[list[Citation], list[Finding]]:
+    return audit(root, fixture_files(root))
+
+
+def assert_selftest(
+    label: str,
+    actual: object,
+    expected: object,
+) -> bool:
+    if actual == expected:
+        return True
+    print(
+        f"selftest: FAIL: {label}: produced={actual!r} expected={expected!r}",
+        file=sys.stderr,
+    )
+    return False
+
+
+def selftest(repository_root: Path) -> int:
+    fixtures = repository_root / "tests/fixtures/design-citation-headings"
+    accepting_citations, accepting_findings = fixture_audit(fixtures / "accepting")
+    stale_citations, stale_findings = fixture_audit(fixtures / "stale-435b0f6")
+    separator_citations, separator_findings = fixture_audit(
+        fixtures / "stale-new-separators"
+    )
+    untracked_root = fixtures / "untracked-design"
+    untracked_source = Path("tools/untracked-target-reference.txt")
+    untracked_citations, untracked_findings = audit(
+        untracked_root, [untracked_source]
+    )
+
+    expected_accepting = sorted(
+        [
+            (
+                "Product gate contract",
+                ".github/workflows/site-reference-freshness.yml",
+            ),
+            ("Ruleset drift audit", ".github/workflows/ruleset-drift-audit.yml"),
+            (
+                "Ruleset drift audit",
+                ".github/workflows/site-reference-freshness.yml",
+            ),
+            ("Sharded pre-merge Linux evidence", ".github/workflows/ci.yml"),
+            ("Ruleset drift audit", ".github/workflows/ci.yml"),
+            ("Merge readiness contract", "tools/colon-reference.txt"),
+            ("Merge readiness contract", "tools/section-word-reference.txt"),
+        ]
+    )
+    produced_accepting = sorted(
+        (citation.title, citation.source.as_posix()) for citation in accepting_citations
+    )
+    expected_stale = [
+        (".github/workflows/ci.yml", 2, "Merge queue (planned, not yet enabled)"),
+        (".github/workflows/ci.yml", 5, "Merge queue (planned, not yet enabled)"),
+        (
+            "tools/check-product-gate-scope.sh",
+            2,
+            "Merge queue (planned, not yet enabled)",
+        ),
+    ]
+    produced_stale = [
+        (
+            finding.citation.source.as_posix(),
+            finding.citation.line,
+            finding.citation.title,
+        )
+        for finding in stale_findings
+    ]
+    expected_separator_findings = [
+        (
+            "tools/broken-separators.txt",
+            1,
+            "Colon heading removed",
+            "quoted heading does not exist",
+        ),
+        (
+            "tools/broken-separators.txt",
+            2,
+            "Section-word heading removed",
+            "quoted heading does not exist",
+        ),
+    ]
+    produced_separator_findings = [
+        (
+            finding.citation.source.as_posix(),
+            finding.citation.line,
+            finding.citation.title,
+            finding.reason,
+        )
+        for finding in separator_findings
+    ]
+    expected_untracked_findings = [
+        (
+            "tools/untracked-target-reference.txt",
+            1,
+            "Ambient-only heading",
+            "design document is not tracked",
+        )
+    ]
+    produced_untracked_findings = [
+        (
+            finding.citation.source.as_posix(),
+            finding.citation.line,
+            finding.citation.title,
+            finding.reason,
+        )
+        for finding in untracked_findings
+    ]
+    checks = (
+        assert_selftest("accepting citations", produced_accepting, expected_accepting),
+        assert_selftest("accepting findings", accepting_findings, []),
+        assert_selftest("historical CHANGELOG exclusion", len(accepting_citations), 7),
+        assert_selftest("435b0f6 citations", len(stale_citations), 4),
+        assert_selftest("435b0f6 exact findings", produced_stale, expected_stale),
+        assert_selftest(
+            "435b0f6 reasons",
+            {finding.reason for finding in stale_findings},
+            {"quoted heading does not exist"},
+        ),
+        assert_selftest("new separator citations", len(separator_citations), 2),
+        assert_selftest(
+            "new separator exact findings",
+            produced_separator_findings,
+            expected_separator_findings,
+        ),
+        assert_selftest("untracked target citations", len(untracked_citations), 1),
+        assert_selftest(
+            "untracked target exact findings",
+            produced_untracked_findings,
+            expected_untracked_findings,
+        ),
+    )
+    if not all(checks):
+        return 1
+    print(
+        "selftest: PASS: produced=7 accepting/0 findings, "
+        "3 issue citations/3 exact stale findings, 2 new-separator findings, "
+        "and 1 untracked-target finding; expected=same"
+    )
+    return 0
+
+
+def check(root: Path, list_all: bool) -> int:
+    citations, findings = audit(root, tracked_files(root))
+    if list_all:
+        for citation in citations:
+            print(
+                f"CITATION {citation.source}:{citation.line}: "
+                f"{citation.design_path} -> {citation.title!r}"
+            )
+    for finding in findings:
+        citation = finding.citation
+        print(
+            f"{citation.source}:{citation.line}: {finding.reason}: "
+            f"{citation.design_path} -> {citation.title!r}",
+            file=sys.stderr,
+        )
+    print(f"summary: citations={len(citations)} findings={len(findings)}")
+    return 1 if findings else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("check", "selftest"))
+    parser.add_argument("root", nargs="?", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--list", action="store_true", help="list every recognized citation"
+    )
+    args = parser.parse_args()
+    root = args.root.resolve()
+    try:
+        if args.command == "selftest":
+            return selftest(root)
+        return check(root, args.list)
+    except AuditError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -34,6 +34,13 @@ check_core_contracts() {
 }
 
 check_automation() {
+  # ShellCheck's extra masked-return analysis covers the pipeline/process-
+  # substitution regressions from #898. The companion stdlib lint requires
+  # Bash-4+ scripts to fail closed before executing any other command.
+  python3 tools/check-shell-scripts.py selftest
+  python3 tools/check-shell-scripts.py
+  python3 tools/check-bash-version-guards.py selftest
+  python3 tools/check-bash-version-guards.py check
   node --test .github/scripts/report-post-merge-ci.test.mjs
   # The privileged post-merge reporter has issues: write. Its separate
   # parser-backed workflow-shape controls reject comments, decoys, and shell

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -95,6 +95,8 @@ check_automation() {
   # split check-product-gate-scope.sh's own `selftest` versus its real
   # `diff_scope` invocation uses.
   ./tools/aggregate_changelog.sh selftest
+  python3 tools/check-design-citation-headings.py selftest
+  python3 tools/check-design-citation-headings.py check
 }
 
 case "${1:-all}" in

--- a/tools/check-merge-readiness.sh
+++ b/tools/check-merge-readiness.sh
@@ -74,6 +74,10 @@ check_automation() {
   ./tools/check-shard-artifact-cohort.sh selftest
   python3 -m pytest tests/test_shard_artifact_workflow.py -v
   python3 .github/scripts/validate-shard-artifact-workflow.py
+  # The frozen Python compatibility registries and DESIGN-document index must
+  # move together. Keep this detector in required pre-merge repository
+  # evidence; it is not part of the Rust-native product gate.
+  python3 -m pytest tests/test_coupled_change_meta.py -v
   # Accepting/rejecting controls for the ruleset drift audit's compareRuleset/
   # validateContract classifier (docs/DESIGN-ci.md, "Ruleset drift audit").
   node --test .github/scripts/audit-ruleset-drift.test.mjs

--- a/tools/check-native-integration.sh
+++ b/tools/check-native-integration.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "check-native-integration.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -103,10 +104,13 @@ check_rust_tests() {
     exit 2
   fi
 
-  local installed
-  installed="$(cargo nextest --version 2>&1 | awk -F': ' '/^release:/ {print $2}')"
+  local installed nextest_version_output
+  installed="$(cargo nextest --version 2>&1 | awk -F': ' '/^release:/ {print $2}')" \
+    || { echo "check-native-integration: could not inspect cargo-nextest version" >&2; exit 1; }
   if [ "$installed" != "$NEXTEST_VERSION" ]; then
-    echo "check-native-integration: requires exactly cargo-nextest $NEXTEST_VERSION; observed release '$installed' (raw: $(cargo nextest --version 2>&1 | head -n1))" >&2
+    # The raw output is diagnostic only after the authoritative comparison failed.
+    nextest_version_output="$(cargo nextest --version 2>&1 || true)"
+    echo "check-native-integration: requires exactly cargo-nextest $NEXTEST_VERSION; observed release '$installed' (raw: ${nextest_version_output%%$'\n'*})" >&2
     exit 1
   fi
 
@@ -224,7 +228,9 @@ check_rust_tests() {
     echo "check-native-integration: shard $spec listed zero tests -- N is likely larger than the test count, or the partition math is wrong" >&2
     exit 1
   }
-  if [ -n "$(comm -23 <(sort -u "$shard") <(sort -u "$full"))" ]; then
+  local shard_extra
+  shard_extra="$(comm -23 "$shard" "$full")"
+  if [ -n "$shard_extra" ]; then
     echo "check-native-integration: shard $spec names tests absent from the full workspace listing" >&2
     exit 1
   fi

--- a/tools/check-product-gate-scope.sh
+++ b/tools/check-product-gate-scope.sh
@@ -145,21 +145,29 @@ check() {
 
 selftest() {
   local failures=0
+  local actual
 
+  actual="$(printf 'src/main.rs\nrust/fsl-core/src/lib.rs\n' | classify_diff)" || return 1
   check "all-product-paths" product \
-    "$(printf 'src/main.rs\nrust/fsl-core/src/lib.rs\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf '.claude/skills/x/SKILL.md\nCHANGELOG.md\n' | classify_diff)" || return 1
   check "mixed exempt + CHANGELOG.md" exempt \
-    "$(printf '.claude/skills/x/SKILL.md\nCHANGELOG.md\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf '.claude/skills/x/SKILL.md\nrust/fsl-core/src/lib.rs\n' | classify_diff)" || return 1
   check "mixed exempt + product" product \
-    "$(printf '.claude/skills/x/SKILL.md\nrust/fsl-core/src/lib.rs\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf 'CLAUDE.md.d/x\n' | classify_diff)" || return 1
   check "filename-prefix near-miss" product \
-    "$(printf 'CLAUDE.md.d/x\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf '' | classify_diff)" || return 1
   check "empty input fail-closed" product \
-    "$(printf '' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf 'changelog.d/691-a.added.md\n' | classify_diff)" || return 1
   check "changelog.d/ fragment is exempt" exempt \
-    "$(printf 'changelog.d/691-a.added.md\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
+  actual="$(printf 'changelog.dx/y\n' | classify_diff)" || return 1
   check "changelog.d/ directory-prefix near-miss" product \
-    "$(printf 'changelog.dx/y\n' | classify_diff)" || failures=$((failures + 1))
+    "$actual" || failures=$((failures + 1))
 
   if [ "$failures" -ne 0 ]; then
     echo "check-product-gate-scope.sh selftest: $failures assertion(s) failed" >&2

--- a/tools/check-release-binary-linkage.sh
+++ b/tools/check-release-binary-linkage.sh
@@ -21,7 +21,10 @@ check_glibc() {
     printf 'release ABI check failed: %s has no GLIBC requirement\n' "$binary" >&2
     return 1
   fi
-  if ! test "$(printf '%s\n' GLIBC_2.39 "$required" | sort -V | tail -1)" = GLIBC_2.39; then
+  local maximum
+  maximum="$(printf '%s\n' GLIBC_2.39 "$required" | sort -V | tail -1)" \
+    || return 1
+  if ! test "$maximum" = GLIBC_2.39; then
     printf 'release ABI check failed: %s requires %s; maximum supported GLIBC version is GLIBC_2.39\n' \
       "$binary" "$required" >&2
     return 1

--- a/tools/check-shard-artifact-cohort.sh
+++ b/tools/check-shard-artifact-cohort.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "check-shard-artifact-cohort.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 
 # Validate one downloaded cohort of stable-name sharded artifacts before the
@@ -145,11 +146,17 @@ check_cohort() {
     expect_equal run_id "$expected_run_id" "$run_id" "$artifact_name"
     expect_equal head_revision "$expected_revision" "$revision" "$artifact_name"
     expect_equal shard.total "$expected_total" "$total" "$artifact_name"
-    [[ "$index" =~ ^[1-9][0-9]*$ ]] && [ "$index" -le "$expected_total" ] \
-      || fail "$artifact_name: shard.index out of range: expected '1..$expected_total', actual '$index'"
+    if [[ "$index" =~ ^[1-9][0-9]*$ ]] && [ "$index" -le "$expected_total" ]; then
+      :
+    else
+      fail "$artifact_name: shard.index out of range: expected '1..$expected_total', actual '$index'"
+    fi
     expect_equal artifact_name "$expected_name" "$artifact_name" "$artifact_name"
-    [ "$attempt" -ge 1 ] && [ "$attempt" -le "$current_attempt" ] \
-      || fail "$artifact_name: run_attempt out of range: expected '1..$current_attempt', actual '$attempt'"
+    if [ "$attempt" -ge 1 ] && [ "$attempt" -le "$current_attempt" ]; then
+      :
+    else
+      fail "$artifact_name: run_attempt out of range: expected '1..$current_attempt', actual '$attempt'"
+    fi
     if [[ " ${seen[*]-} " = *" $index "* ]]; then
       fail "$artifact_name: duplicate shard.index: expected unique '1..$expected_total', actual '$index'"
     fi
@@ -291,9 +298,9 @@ write_provenance() {
 }
 
 make_rust_fixture() {
-  local directory="$1" attempts="$2"
+  local directory="$1" attempt_list="$2"
   local -a attempt_values
-  IFS=, read -r -a attempt_values <<<"$attempts"
+  IFS=, read -r -a attempt_values <<<"$attempt_list"
   local index
   for index in 1 2 3; do
     local artifact="$directory/rust-test-shard-$index-77"
@@ -309,9 +316,9 @@ make_rust_fixture() {
 }
 
 make_semantic_fixture() {
-  local directory="$1" attempts="$2"
+  local directory="$1" attempt_list="$2"
   local -a attempt_values
-  IFS=, read -r -a attempt_values <<<"$attempts"
+  IFS=, read -r -a attempt_values <<<"$attempt_list"
   local index
   for index in 1 2 3; do
     local artifact="$directory/semantic-mutation-operators-$index-77"
@@ -368,6 +375,7 @@ selftest() {
   real_sort="$(command -v sort)" || fail "selftest could not resolve sort"
   real_paste="$(command -v paste)" || fail "selftest could not resolve paste"
   mkdir -p "$tmp/failing-sort" "$tmp/failing-paste"
+  # shellcheck disable=SC2016 # generated wrapper expands these variables when it runs
   printf '%s\n' \
     '#!/usr/bin/env bash' \
     'for argument in "$@"; do' \
@@ -379,6 +387,7 @@ selftest() {
     'done' \
     'exec "$REAL_SORT" "$@"' >"$tmp/failing-sort/sort" \
     || fail "selftest comparison-sort wrapper creation failed"
+  # shellcheck disable=SC2016 # generated wrapper expands these variables when it runs
   printf '%s\n' \
     '#!/usr/bin/env bash' \
     'if [ "${FSL_COHORT_JOIN_CONTEXT:-}" = "attempts" ]; then' \

--- a/tools/check-shard-union.sh
+++ b/tools/check-shard-union.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "check-shard-union.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 #
 # Generic, line-set based shard-completeness guard (issue: CI wall-clock
@@ -72,7 +73,8 @@ check_union() {
 
   local -a shard_paths=("$@")
   local -a shard_sets=()
-  local index
+  local index comparison_dir
+  comparison_dir="$(mktemp -d)" || fail "could not create comparison directory"
   for index in "${!shard_paths[@]}"; do
     shard_sets+=("$(line_set "${shard_paths[$index]}")")
   done
@@ -80,9 +82,14 @@ check_union() {
   # Each shard must be a subset of full.
   for index in "${!shard_paths[@]}"; do
     local extra
-    extra="$(comm -23 <(printf '%s\n' "${shard_sets[$index]}") <(printf '%s\n' "$full") || true)"
+    printf '%s\n' "${shard_sets[$index]}" >"$comparison_dir/left"
+    printf '%s\n' "$full" >"$comparison_dir/right"
+    extra="$(comm -23 "$comparison_dir/left" "$comparison_dir/right")"
     if [ -n "$extra" ]; then
-      fail "shard '${shard_paths[$index]}' names entries absent from '$full_path': $(printf '%s' "$extra" | tr '\n' ' ')"
+      extra_display="$(printf '%s' "$extra" | tr '\n' ' ')" \
+        || { rm -rf "$comparison_dir"; fail "could not format extra shard entries"; }
+      rm -rf "$comparison_dir"
+      fail "shard '${shard_paths[$index]}' names entries absent from '$full_path': $extra_display"
     fi
   done
 
@@ -91,9 +98,14 @@ check_union() {
   for ((i = 0; i < ${#shard_paths[@]}; i++)); do
     for ((j = i + 1; j < ${#shard_paths[@]}; j++)); do
       local overlap
-      overlap="$(comm -12 <(printf '%s\n' "${shard_sets[$i]}") <(printf '%s\n' "${shard_sets[$j]}") || true)"
+      printf '%s\n' "${shard_sets[$i]}" >"$comparison_dir/left"
+      printf '%s\n' "${shard_sets[$j]}" >"$comparison_dir/right"
+      overlap="$(comm -12 "$comparison_dir/left" "$comparison_dir/right")"
       if [ -n "$overlap" ]; then
-        fail "shard '${shard_paths[$i]}' and shard '${shard_paths[$j]}' both name: $(printf '%s' "$overlap" | tr '\n' ' ')"
+        overlap_display="$(printf '%s' "$overlap" | tr '\n' ' ')" \
+          || { rm -rf "$comparison_dir"; fail "could not format overlapping shard entries"; }
+        rm -rf "$comparison_dir"
+        fail "shard '${shard_paths[$i]}' and shard '${shard_paths[$j]}' both name: $overlap_display"
       fi
     done
   done
@@ -102,18 +114,34 @@ check_union() {
   local union
   union="$(printf '%s\n' "${shard_sets[@]}" | sort -u)"
   local missing
-  missing="$(comm -23 <(printf '%s\n' "$full") <(printf '%s\n' "$union") || true)"
+  printf '%s\n' "$full" >"$comparison_dir/left"
+  printf '%s\n' "$union" >"$comparison_dir/right"
+  missing="$(comm -23 "$comparison_dir/left" "$comparison_dir/right")"
   if [ -n "$missing" ]; then
-    fail "$(printf '%s' "$missing" | grep -c . ) entr$([ "$(printf '%s' "$missing" | grep -c .)" = 1 ] && echo y || echo ies) in '$full_path' covered by no shard (silent coverage loss): $(printf '%s' "$missing" | tr '\n' ' ')"
+    local missing_count missing_suffix missing_display
+    missing_count="$(printf '%s' "$missing" | grep -c .)" \
+      || { rm -rf "$comparison_dir"; fail "could not count missing shard entries"; }
+    if [ "$missing_count" -eq 1 ]; then missing_suffix=y; else missing_suffix=ies; fi
+    missing_display="$(printf '%s' "$missing" | tr '\n' ' ')" \
+      || { rm -rf "$comparison_dir"; fail "could not format missing shard entries"; }
+    rm -rf "$comparison_dir"
+    fail "$missing_count entr$missing_suffix in '$full_path' covered by no shard (silent coverage loss): $missing_display"
   fi
 
   local extra_union
-  extra_union="$(comm -13 <(printf '%s\n' "$full") <(printf '%s\n' "$union") || true)"
+  extra_union="$(comm -13 "$comparison_dir/left" "$comparison_dir/right")"
   if [ -n "$extra_union" ]; then
-    fail "union names entries absent from '$full_path': $(printf '%s' "$extra_union" | tr '\n' ' ')"
+    extra_union_display="$(printf '%s' "$extra_union" | tr '\n' ' ')" \
+      || { rm -rf "$comparison_dir"; fail "could not format extra union entries"; }
+    rm -rf "$comparison_dir"
+    fail "union names entries absent from '$full_path': $extra_union_display"
   fi
 
-  echo "check-shard-union: PASS -- $(printf '%s\n' "$full" | grep -c .) entries in '$full_path', $(( ${#shard_paths[@]} )) shard(s), union matches exactly"
+  local full_count
+  full_count="$(printf '%s\n' "$full" | grep -c .)" \
+    || { rm -rf "$comparison_dir"; fail "could not count full-list entries"; }
+  rm -rf "$comparison_dir"
+  echo "check-shard-union: PASS -- $full_count entries in '$full_path', $(( ${#shard_paths[@]} )) shard(s), union matches exactly"
 }
 
 # See the "check-groups" usage block above. Format: non-comment, non-blank

--- a/tools/check-shell-scripts.py
+++ b/tools/check-shell-scripts.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Run the repository ShellCheck contract and audit suppression reasons."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+SUPPRESSION = re.compile(r"#\s*shellcheck\s+disable=[^#\n]+(?P<reason>#.*)?$")
+
+
+def shell_files(root: Path) -> list[Path]:
+    return sorted((root / "tools").glob("*.sh")) + sorted(
+        (root / ".github/scripts").glob("*.sh")
+    )
+
+
+def tracked_shell_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--", "tools", ".github/scripts"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"git ls-files failed with exit {result.returncode}: {detail or '(no stderr)'}"
+        )
+    try:
+        names = result.stdout.decode("utf-8").split("\0")
+    except UnicodeDecodeError as error:
+        raise RuntimeError(f"git returned a non-UTF-8 path: {error}") from error
+    allowed_parents = {Path("tools"), Path(".github/scripts")}
+    return sorted(
+        root / relative
+        for name in names
+        if name
+        for relative in (Path(name),)
+        if relative.parent in allowed_parents and relative.suffix == ".sh"
+    )
+
+
+def inventory_findings(discovered: list[Path], tracked: list[Path]) -> list[str]:
+    if not tracked:
+        return ["tracked shell-script inventory is unexpectedly empty"]
+    if not discovered:
+        return ["discovered shell-script inventory is unexpectedly empty"]
+    missing = sorted(set(tracked) - set(discovered))
+    if not missing:
+        return []
+    return [
+        "tracked shell script missing from discovery: " + path.as_posix()
+        for path in missing
+    ]
+
+
+def selftest(root: Path) -> int:
+    fixture_root = root / "tests/fixtures/shell-script-inventory/accepting"
+    tracked = sorted(
+        [
+            fixture_root / "tools/check-one.sh",
+            fixture_root / "tools/run-one.sh",
+            fixture_root / ".github/scripts/report-one.sh",
+        ]
+    )
+    discovered = shell_files(fixture_root)
+    cases = {
+        "complete discovery": (discovered, tracked, []),
+        "untracked addition": (
+            [*discovered, fixture_root / "tools/untracked-extra.sh"],
+            tracked,
+            [],
+        ),
+        "narrowed tools glob": (
+            [path for path in discovered if path.name.startswith("check-")],
+            tracked,
+            ["run-one.sh", "report-one.sh"],
+        ),
+        "github directory omitted": (
+            [path for path in discovered if path.parent.name == "tools"],
+            tracked,
+            ["report-one.sh"],
+        ),
+        "empty discovery": ([], tracked, ["unexpectedly empty"]),
+        "empty tracked authority": (discovered, [], ["unexpectedly empty"]),
+    }
+    ok = True
+    for label, (case_discovered, case_tracked, expected_fragments) in cases.items():
+        produced = inventory_findings(case_discovered, case_tracked)
+        fragments_match = all(
+            any(fragment in finding for finding in produced)
+            for fragment in expected_fragments
+        )
+        if fragments_match and bool(produced) == bool(expected_fragments):
+            continue
+        print(
+            f"selftest: FAIL: {label}: produced={produced!r} "
+            f"expected_fragments={expected_fragments!r}",
+            file=sys.stderr,
+        )
+        ok = False
+    if ok:
+        print("selftest: PASS: inventory_accepting=2 inventory_rejecting=4")
+        return 0
+    return 1
+
+
+def check(root: Path) -> int:
+    files = shell_files(root)
+    try:
+        tracked = tracked_shell_files(root)
+    except RuntimeError as error:
+        print(f"check-shell-scripts: {error}", file=sys.stderr)
+        return 1
+    inventory_errors = inventory_findings(files, tracked)
+    if inventory_errors:
+        print("\n".join(inventory_errors), file=sys.stderr)
+        return 1
+    findings: list[str] = []
+    for path in files:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for line_number, line in enumerate(lines, 1):
+            match = SUPPRESSION.search(line)
+            if match and not (match.group("reason") or "").lstrip("# ").strip():
+                findings.append(
+                    f"{path.relative_to(root)}:{line_number}: "
+                    "shellcheck suppression needs an inline reason"
+                )
+    if findings:
+        print("\n".join(findings), file=sys.stderr)
+        return 1
+
+    executable = shutil.which("shellcheck")
+    if executable is None:
+        print("check-shell-scripts: shellcheck not found", file=sys.stderr)
+        return 1
+    version_result = subprocess.run(
+        [executable, "--version"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    version = next(
+        (
+            line.partition(":")[2].strip()
+            for line in version_result.stdout.splitlines()
+            if line.startswith("version:")
+        ),
+        "",
+    )
+    if version_result.returncode != 0 or not version:
+        detail = (version_result.stderr or version_result.stdout).strip()
+        print(
+            "check-shell-scripts: cannot determine shellcheck version"
+            f" (exit {version_result.returncode}): {detail or '(no output)'}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"check-shell-scripts: shellcheck version {version}", flush=True)
+    result = subprocess.run(
+        [executable, "--enable=check-extra-masked-returns", *map(str, files)],
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        return result.returncode
+    print(f"check-shell-scripts: PASS -- {len(files)} script(s)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "command", nargs="?", choices=("check", "selftest"), default="check"
+    )
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parent.parent
+    if args.command == "selftest":
+        return selftest(root)
+    return check(root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_rust_ast_parity.py
+++ b/tools/check_rust_ast_parity.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare Rust expression ASTs with the authoritative Python parser."""
+"""Optional developer-run compatibility check for the shared expression subset.
+
+Run only when intentionally changing shared expression syntax or its frozen-Python
+projection. It compares the 20 registered expression fixtures exactly; it is not a
+general parser-correctness test, product verification, or a CI/promotion/release gate.
+The native parser tests remain authoritative.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_cli_snapshot.py
+++ b/tools/check_rust_cli_snapshot.py
@@ -1,7 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare the Rust native CLI projection with the shared-language golden."""
+"""Optional developer-run check of a bounded frozen-Python CLI snapshot.
+
+Run only for an explicitly scoped frozen-Python CLI compatibility change. The snapshot
+is a historical 190-entry subset, not the current corpus authority: record provenance,
+never regenerate it merely to accept native evolution, and never present a pass as
+product verification. This script is not a CI/promotion/release gate; native CLI,
+schema, corpus, and Worker tests remain authoritative.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_corpus_cli_parity.py
+++ b/tools/check_rust_corpus_cli_parity.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare stable Python/Rust CLI verdicts across the complete FSL corpus."""
+"""Compare stable Python/Rust CLI verdicts across the complete FSL corpus.
+
+Deletion deferred (F1): no native corpus control binds every
+``verify`` envelope result class to its process exit. Deletion requires that
+native control plus a rejecting mutation.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_dialect_parity.py
+++ b/tools/check_rust_dialect_parity.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare native and Python business/requirements/governance envelopes."""
+"""Compare native and Python business/requirements/governance envelopes.
+
+Deletion deferred (F2): dialect dispatch is covered, but there is no focused
+native induction output contract for all three paths. Deletion requires those
+native induction cases.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_dialect_parity.py
+++ b/tools/check_rust_dialect_parity.py
@@ -17,8 +17,8 @@ from typing import Any
 from fslc.cli import run_check, run_verify
 
 from check_rust_cli_snapshot import DEFAULT_RUST_BIN, _invoke
-from check_rust_full_envelope import _diff, _normalize as _normalize_bmc
 from check_rust_induction_parity import _normalize as _normalize_induction
+from rust_parity_util import _diff, _normalize as _normalize_bmc
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tools/check_rust_full_envelope.py
+++ b/tools/check_rust_full_envelope.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare Python and Rust CLI envelopes with a narrow reviewed allowlist."""
+"""Compare Python and Rust CLI envelopes with a narrow reviewed allowlist.
+
+Disposition: calibrated native/Worker parity owns this
+detector, so deletion is permitted once its shared ``_diff``/``_normalize``
+helpers move without breaking the retained dialect/induction/Phase-2 tools.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_full_envelope.py
+++ b/tools/check_rust_full_envelope.py
@@ -11,119 +11,16 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 from pathlib import Path
 from typing import Any
 
 from fslc.cli import run_check, run_verify
 
 from check_rust_cli_snapshot import DEFAULT_RUST_BIN, _invoke
+from rust_parity_util import _diff, _normalize
 
 
 ROOT = Path(__file__).resolve().parents[1]
-
-# Witness choices are not unique. Their semantic equivalence is established by
-# check_rust_bmc_parity.py and check_rust_scenarios_parity.py through
-# cross-implementation Monitor replay. These are the only witness paths whose
-# concrete values are normalized here.
-TRACE_PATHS = {
-    "$.trace",
-    "$.deadlock.trace",
-}
-
-
-def _value_shape(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {key: _value_shape(item) for key, item in sorted(value.items())}
-    if isinstance(value, list):
-        return [_value_shape(item) for item in value]
-    return f"<{type(value).__name__}>"
-
-
-def _trace_shape(trace: Any) -> Any:
-    if not isinstance(trace, list):
-        return _value_shape(trace)
-    shaped = []
-    for entry in trace:
-        if not isinstance(entry, dict):
-            shaped.append(_value_shape(entry))
-            continue
-        item: dict[str, Any] = {"keys": sorted(entry)}
-        if "action" in entry:
-            action = entry["action"]
-            item["action_keys"] = sorted(action) if isinstance(action, dict) else _value_shape(action)
-        if "changes" in entry:
-            changes = entry["changes"]
-            if isinstance(changes, dict):
-                item["changes_shape"] = sorted(
-                    {
-                        tuple(sorted(change)) if isinstance(change, dict) else ("<non-object>",)
-                        for change in changes.values()
-                    }
-                )
-            else:
-                item["changes_shape"] = _value_shape(changes)
-        if "blame" in entry:
-            blame = entry["blame"]
-            item["blame_keys"] = sorted(blame) if isinstance(blame, dict) else _value_shape(blame)
-        shaped.append(item)
-    return shaped
-
-
-def _normalize(value: Any, path: str = "$") -> Any:
-    if path in TRACE_PATHS:
-        return _trace_shape(value)
-    if path.startswith("$.reachables.") and path.endswith(".witness"):
-        return _trace_shape(value)
-    if path == "$.cost.elapsed_s":
-        return "<elapsed>"
-    if path in {"$.violating_bindings", "$.last_action.params"}:
-        return _value_shape(value)
-    if path.startswith("$.blame.conjuncts.") and path.endswith(".violating_bindings"):
-        return _value_shape(value)
-    if isinstance(value, dict):
-        return {
-            key: _normalize(item, f"{path}.{key}")
-            for key, item in sorted(value.items())
-            if key != "fsl"
-        }
-    if isinstance(value, list):
-        return [_normalize(item, f"{path}.{index}") for index, item in enumerate(value)]
-    if (
-        path.startswith("$.warnings.")
-        and path.endswith(".message")
-        and isinstance(value, str)
-    ):
-        return re.sub(r"(deadlock reachable at step \d+) \(state: .*\)$", r"\1 (state: <witness>)", value)
-    return value
-
-
-def _diff(expected: Any, actual: Any, path: str = "$") -> list[dict[str, Any]]:
-    if type(expected) is not type(actual):
-        return [{"path": path, "python": expected, "rust": actual}]
-    if isinstance(expected, dict):
-        failures = []
-        for key in sorted(set(expected) | set(actual)):
-            if key not in expected or key not in actual:
-                failures.append(
-                    {
-                        "path": f"{path}.{key}",
-                        "python": expected.get(key, "<missing>"),
-                        "rust": actual.get(key, "<missing>"),
-                    }
-                )
-            else:
-                failures.extend(_diff(expected[key], actual[key], f"{path}.{key}"))
-        return failures
-    if isinstance(expected, list):
-        if len(expected) != len(actual):
-            return [{"path": path, "python": expected, "rust": actual}]
-        failures = []
-        for index, (left, right) in enumerate(zip(expected, actual)):
-            failures.extend(_diff(left, right, f"{path}.{index}"))
-        return failures
-    return [] if expected == actual else [{"path": path, "python": expected, "rust": actual}]
-
 
 def run(root: Path, binary: Path, depth: int) -> dict[str, Any]:
     failures = []

--- a/tools/check_rust_grammar_fuzz.py
+++ b/tools/check_rust_grammar_fuzz.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Deterministic grammar-derived expression fuzzing across Python and Rust."""
+"""Optional developer-run compatibility fuzzing for shared expression grammar.
+
+Run only when intentionally changing shared expression syntax or its frozen-Python
+projection. It compares 256 generated ASTs exactly with seed 195; preserve that seed
+and comparison, and never convert divergences into broad allowlists. This is not
+product verification or a CI/promotion/release gate; native parser tests are authoritative.
+"""
 
 from __future__ import annotations
 

--- a/tools/check_rust_induction_parity.py
+++ b/tools/check_rust_induction_parity.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare native and Python k-induction envelopes over focused corpus slices."""
+"""Compare native and Python k-induction envelopes over focused corpus slices.
+
+Deletion deferred (F3): native CLI ownership covers only part of the
+16-case envelope/exit matrix. Deletion requires native cases for its stable
+fields and exits, with explicit exclusions and negative controls.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_induction_parity.py
+++ b/tools/check_rust_induction_parity.py
@@ -3,9 +3,10 @@
 
 """Compare native and Python k-induction envelopes over focused corpus slices.
 
-Deletion deferred (F3): native CLI ownership covers only part of the
-16-case envelope/exit matrix. Deletion requires native cases for its stable
-fields and exits, with explicit exclusions and negative controls.
+Deletion disposition (F3): ``rust/fslc/tests/induction_cli_contract.rs`` owns
+all 16 native CLI stable-envelope/exit cases with live exclusions and negative
+controls. Retain this harness only while its Python compatibility comparison is
+still required by the broader parity-harness retirement.
 """
 from __future__ import annotations
 

--- a/tools/check_rust_induction_parity.py
+++ b/tools/check_rust_induction_parity.py
@@ -19,7 +19,7 @@ from typing import Any
 from fslc.cli import run_verify
 
 from check_rust_cli_snapshot import DEFAULT_RUST_BIN
-from check_rust_full_envelope import _normalize as _normalize_bmc
+from rust_parity_util import _normalize as _normalize_bmc
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tools/check_rust_kernel_parity.py
+++ b/tools/check_rust_kernel_parity.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare direct Rust kernel lowering with Python ``parse_src`` output."""
+"""Optional developer-run compatibility check for Python-shaped kernel lowering.
+
+Run only when intentionally changing compatible lowering or its frozen-Python
+projection. It compares registered specification/compose kernel ASTs exactly. It must
+not replace or redefine the authoritative native v1/v2 Kernel goldens and is not
+product verification or a CI/promotion/release gate.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_leadsto_parity.py
+++ b/tools/check_rust_leadsto_parity.py
@@ -3,9 +3,10 @@
 
 """Compare bounded leadsTo decisions and cross-replay liveness witnesses.
 
-Deletion deferred (F4): calibrated invariant replay exists, but no native
-liveness-lasso replay matrix. Deletion requires isolated state/action/loop
-corruption controls for these witnesses.
+Deletion remains deferred (F4). Candidate native owner
+``rust/fslc/tests/liveness_witness_replay.rs`` covers the three legacy cases
+with an exact 3x3 state/action/loop corruption matrix; harness retirement still
+requires review of that evidence.
 """
 from __future__ import annotations
 

--- a/tools/check_rust_leadsto_parity.py
+++ b/tools/check_rust_leadsto_parity.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare bounded leadsTo decisions and cross-replay liveness witnesses."""
+"""Compare bounded leadsTo decisions and cross-replay liveness witnesses.
+
+Deletion deferred (F4): calibrated invariant replay exists, but no native
+liveness-lasso replay matrix. Deletion requires isolated state/action/loop
+corruption controls for these witnesses.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_phase2_commands.py
+++ b/tools/check_rust_phase2_commands.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from check_rust_cli_snapshot import DEFAULT_RUST_BIN
-from check_rust_full_envelope import _diff
+from rust_parity_util import _diff
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tools/check_rust_phase2_commands.py
+++ b/tools/check_rust_phase2_commands.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare Phase-2 sweep and chain command contracts with Python."""
+"""Compare Phase-2 sweep and chain command contracts with Python.
+
+Deletion deferred (F5): ``--keep-going`` failure continuation and
+the human-readable ``Layer`` stderr table unowned. Deletion requires native
+assertions for both observations.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_refinement_parity.py
+++ b/tools/check_rust_refinement_parity.py
@@ -3,9 +3,10 @@
 
 """Compare bounded native refinement envelopes with the Python reference.
 
-Deletion deferred (F6): the native manifest is broader in cases but
-not in output fields. Deletion requires a complete observed stable projection,
-reasoned exclusions, and dead-exclusion checks.
+Native owner (F6): ``rust/fslc/tests/refine_corpus_parity.rs`` compares the
+complete observed stable projection, documents its sole ``impl_trace``
+exclusion, and rejects dead exclusions. This compatibility harness is retained
+for now; it is not a product or CI gate.
 """
 from __future__ import annotations
 

--- a/tools/check_rust_refinement_parity.py
+++ b/tools/check_rust_refinement_parity.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare bounded native refinement envelopes with the Python reference."""
+"""Compare bounded native refinement envelopes with the Python reference.
+
+Deletion deferred (F6): the native manifest is broader in cases but
+not in output fields. Deletion requires a complete observed stable projection,
+reasoned exclusions, and dead-exclusion checks.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_replay_parity.py
+++ b/tools/check_rust_replay_parity.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare the public native and Python replay command contracts."""
+"""Compare the public native and Python replay command contracts.
+
+Deletion deferred (F7): there is no focused native owner for the legacy
+unversioned ``{"events": [...]}`` wrapper. Deletion requires positive and
+rejecting native tests for that wrapper and its public projection.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/check_rust_replay_parity.py
+++ b/tools/check_rust_replay_parity.py
@@ -3,9 +3,11 @@
 
 """Compare the public native and Python replay command contracts.
 
-Deletion deferred (F7): there is no focused native owner for the legacy
-unversioned ``{"events": [...]}`` wrapper. Deletion requires positive and
-rejecting native tests for that wrapper and its public projection.
+Deletion remains deferred (F7). Candidate native owner
+``legacy_object_wrapper_*`` in ``rust/fslc/tests/replay_trace_contract.rs``
+compares complete success/rejection envelopes and rejects wrong keys, value
+types, and extra root keys; harness retirement still requires review of that
+evidence.
 """
 from __future__ import annotations
 

--- a/tools/check_rust_surface_parity.py
+++ b/tools/check_rust_surface_parity.py
@@ -1,7 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Compare Rust shared surface ASTs with the Python parser corpus."""
+"""Optional developer-run surface compatibility check for the registered subset.
+
+Run only when intentionally changing the shared frozen-Python surface subset. It
+compares registered surface ASTs exactly and parse-error line/column locations; a
+Python-only accepted construct must not constrain native evolution unless compatibility
+is explicitly changed. This is not product verification, browser AST coverage, or a
+CI/promotion/release gate; native parser/corpus tests remain authoritative.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/run-fault-operators.sh
+++ b/tools/run-fault-operators.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "run-fault-operators.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 #
 # Implementation fault operators (#537 C5). See
@@ -90,13 +91,15 @@ export CARGO_TARGET_DIR="$work/target"
 lock="$work/lock"
 mkdir -p "$work"
 if ! mkdir "$lock" 2>/dev/null; then
+  # shellcheck disable=SC2312 # the explicit fallback turns an unreadable stale holder into the intended diagnostic
   echo "fault-operators: another invocation holds $lock ($(cat "$lock/holder" 2>/dev/null || echo unknown)).
   If that run crashed, verify no cargo/fslc process is alive and remove the
   directory by hand. Not proceeding: two runners in one scratch make every
   verdict in the matrix meaningless." >&2
   exit 1
 fi
-echo "pid $$ started $(date -u +%FT%TZ)" >"$lock/holder"
+started_at="$(date -u +%FT%TZ)"
+echo "pid $$ started $started_at" >"$lock/holder"
 trap 'rm -rf "$lock"' EXIT
 
 fail() {
@@ -127,10 +130,11 @@ read_table() {
   local name patch_file contract seam_path seam_anchor primary_target primary_test
   local blind_target blind_test expected_change calibrated_edge source_scope extra
   while IFS='^' read -r name patch_file contract seam_path seam_anchor primary_target primary_test blind_target blind_test expected_change calibrated_edge source_scope extra; do
-    name="$(trim "${name:-}")"
+    name="$(trim "${name:-}")" || fail "$table: could not trim an operator name"
     [ -n "$name" ] || continue
     case "$name" in \#*) continue ;; esac
-    [ -z "$(trim "${extra:-}")" ] || fail "$table: row '$name' has more than twelve columns"
+    extra="$(trim "${extra:-}")" || fail "$table: could not trim the extra-column field"
+    [ -z "$extra" ] || fail "$table: row '$name' has more than twelve columns"
     patch_file="$(trim "${patch_file:-}")"
     [ -n "$patch_file" ] || fail "$table: row '$name' names no patch file"
     [ -f "$operators_dir/$patch_file" ] || fail "$table: row '$name' names a missing patch file '$patch_file'"
@@ -221,7 +225,14 @@ sync_scratch() {
   # seam". It reproduced only where the scratch's own `.git` was absent or
   # unusable, which is why it appeared in CI and never locally, and why the same
   # revision returned different verdicts on different runs.
-  if [ "$(cd "$scratch" && git rev-parse --show-toplevel 2>/dev/null || true)" != "$(cd "$scratch" && pwd -P)" ]; then
+  local scratch_toplevel scratch_physical
+  if scratch_toplevel="$(cd "$scratch" && git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    scratch_toplevel=""
+  fi
+  scratch_physical="$(cd "$scratch" && pwd -P)"
+  if [ "$scratch_toplevel" != "$scratch_physical" ]; then
     rm -rf "$scratch/.git"
     git -C "$scratch" init --quiet
   fi
@@ -335,16 +346,20 @@ run_detector() {
   local target="$1" name="$2" log="$3" status=0
   # `$target` is a cargo test-target selector ("--lib", "--test <name>") and
   # is deliberately word-split.
-  # shellcheck disable=SC2086
+  # shellcheck disable=SC2086 # deliberate word splitting applies the table's cargo arguments
   if ! (cd "$scratch" && cargo test --manifest-path rust/Cargo.toml -p fslc-rust $target --locked --no-run) >"$log.build" 2>&1; then
     tail -40 "$log.build" >&2
     fail "the patched checkout does not compile (target: $target). Full log: $log.build"
   fi
   local binary
   binary="$(executable_from_build_log "$log.build")"
-  [ -n "$binary" ] && [ -f "$binary" ] || fail "cargo reported no executable for
-  target '$target', so nothing here can prove which binary the detector ran.
-  Full log: $log.build"
+  if [ -n "$binary" ] && [ -f "$binary" ]; then
+    :
+  else
+    fail "cargo reported no executable for
+    target '$target', so nothing here can prove which binary the detector ran.
+    Full log: $log.build"
+  fi
   detector_binary_hash="$(hash_file "$binary")"
   # The `fslc` executable the detector may spawn instead of, or in addition to,
   # exercising the library in-process. `cargo test` builds the package's bins so
@@ -352,7 +367,7 @@ run_detector() {
   # this one is named directly rather than read back.
   detector_cli_hash=""
   [ -f "$CARGO_TARGET_DIR/debug/fslc" ] && detector_cli_hash="$(hash_file "$CARGO_TARGET_DIR/debug/fslc")"
-  # shellcheck disable=SC2086
+  # shellcheck disable=SC2086 # deliberate word splitting applies the table's cargo arguments
   (cd "$scratch" && cargo test --manifest-path rust/Cargo.toml -p fslc-rust $target --locked -- --exact "$name") >"$log" 2>&1 || status=$?
   if ! grep -q -- "^test ${name} \.\.\. " "$log"; then
     tail -20 "$log" >&2
@@ -451,7 +466,10 @@ no_op_cli_hashes=()
 # genuinely faulted binary equal the unfaulted one, so this only ever fires on
 # a real reuse, never on a flaky digest.
 assert_fault_reached_source() {
-  local file="$1" name="$2" patched seen=0
+  local file="$1" name="$2" patched seen=0 patched_paths
+  patched_paths="$(mktemp)" || fail "operator '$name': could not create patched-path inventory"
+  sed -n 's/^+++ b\///p' "$file" | sort -u >"$patched_paths" \
+    || { rm -f "$patched_paths"; fail "operator '$name': could not enumerate patched paths"; }
   while IFS= read -r patched; do
     [ -n "$patched" ] || continue
     seen=$((seen + 1))
@@ -463,7 +481,8 @@ assert_fault_reached_source() {
   the source the detector is about to be built from. Any verdict below would be
   a property of the harness, not of the fault."
     fi
-  done < <(sed -n 's/^+++ b\///p' "$file" | sort -u)
+  done <"$patched_paths"
+  rm -f "$patched_paths"
   [ "$seen" -gt 0 ] || fail "operator '$name': its patch names no files, so
   there is nothing to verify reached the scratch."
 }
@@ -531,12 +550,15 @@ executed_names=()
 for index in "${assigned_indices[@]}"; do
   executed_names+=("${names[$index]}")
 done
-table_operators_json="$(printf '%s\n' "${names[@]}" | jq -R . | jq -s .)"
-executed_operators_json="$(printf '%s\n' "${executed_names[@]}" | jq -R . | jq -s .)"
+table_operators_json="$(printf '%s\n' "${names[@]}" | jq -R . | jq -s .)" \
+  || fail "could not serialize the full operator inventory"
+executed_operators_json="$(printf '%s\n' "${executed_names[@]}" | jq -R . | jq -s .)" \
+  || fail "could not serialize the executed operator inventory"
+base_revision="$(git -C "$root" rev-parse HEAD)"
 jq -n \
   --arg schema "fslc.fault-operator-shard-manifest.v1" \
   --argjson schema_version 1 \
-  --arg base_revision "$(git -C "$root" rev-parse HEAD)" \
+  --arg base_revision "$base_revision" \
   --argjson shard_index "$shard_index" \
   --argjson shard_total "$shard_total" \
   --argjson table_operators "$table_operators_json" \

--- a/tools/run-fsl-logic-test.sh
+++ b/tools/run-fsl-logic-test.sh
@@ -26,5 +26,5 @@ if ! jq -e '.complete == true and .expected == .executed and (.cases | length) =
   echo "fsl-logic: incomplete report $report" >&2
   exit 1
 fi
-printf 'fsl-logic: tier=%s cases=%s report=%s\n' \
-  "$tier" "$(jq -r '.executed' "$report")" "$report"
+executed="$(jq -r '.executed' "$report")"
+printf 'fsl-logic: tier=%s cases=%s report=%s\n' "$tier" "$executed" "$report"

--- a/tools/run-semantic-mutation-gate.sh
+++ b/tools/run-semantic-mutation-gate.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+(( BASH_VERSINFO[0] >= 4 )) || { echo "run-semantic-mutation-gate.sh requires Bash 4 or newer" >&2; exit 1; }
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -101,8 +102,9 @@ run_operators_lane() {
 }
 
 if [ "$lane" != "operators" ]; then
-  if [ "$(cargo mutants --version)" != "$runner_version" ]; then
-    echo "semantic-mutation: requires exactly $runner_version; observed $(cargo mutants --version 2>&1)" >&2
+  observed_runner_version="$(cargo mutants --version 2>&1)"
+  if [ "$observed_runner_version" != "$runner_version" ]; then
+    echo "semantic-mutation: requires exactly $runner_version; observed $observed_runner_version" >&2
     exit 1
   fi
 fi
@@ -176,18 +178,23 @@ if [ "$mode" = changed ]; then
     cargo mutants "${args[@]}" "${diff_args[@]}" --list
   ) >"$filtered"
   if [ ! -s "$filtered" ]; then
-    changed_scope_paths="$(comm -12 \
-      <(sed -n 's|^+++ b/||p' "$diff_file" | sort -u) \
-      <(jq -r '.decisions[].path | sub("^rust/"; "")' "$scope" | sort -u))"
+    changed_diff_paths="$output/changed-diff-paths.txt"
+    changed_scope_inventory="$output/changed-scope-paths.txt"
+    sed -n 's|^+++ b/||p' "$diff_file" | sort -u >"$changed_diff_paths"
+    jq -r '.decisions[].path | sub("^rust/"; "")' "$scope" \
+      | sort -u >"$changed_scope_inventory"
+    changed_scope_paths="$(comm -12 "$changed_diff_paths" "$changed_scope_inventory")"
     if [ -z "$changed_scope_paths" ]; then
       (
         cd "$scratch/rust"
         cargo test --locked -p fsl-verifier -p fslc-rust \
           --test solver_fail_closed --test triangulated_assurance
       )
-      paths_json="$(sed -n 's|^+++ b/||p' "$diff_file" | sort -u | jq -Rsc 'split("\n") | map(select(length > 0) | "rust/" + .)')"
+      paths_json="$(sed -n 's|^+++ b/||p' "$diff_file" | sort -u | jq -Rsc 'split("\n") | map(select(length > 0) | "rust/" + .)')" \
+        || { echo "semantic-mutation: could not serialize changed paths" >&2; exit 1; }
+      report_revision="$(git -C "$root" rev-parse HEAD)"
       jq -n \
-        --arg revision "$(git -C "$root" rev-parse HEAD)" \
+        --arg revision "$report_revision" \
         --arg diff_base "${FSL_MUTATION_BASE:-unknown}" \
         --argjson paths "$paths_json" \
         '{
@@ -293,6 +300,8 @@ fi
 # source lines are derived from exact maintained anchors at run time, so line
 # movement cannot silently turn a decision ID into a bare function name.
 decision_anchors='[]'
+decision_rows="$output/decision-rows.jsonl"
+jq -c '.decisions[]' "$scope" >"$decision_rows"
 while IFS= read -r decision; do
   decision_id="$(jq -r '.id' <<<"$decision")"
   decision_path="$(jq -r '.path' <<<"$decision")"
@@ -313,7 +322,7 @@ while IFS= read -r decision; do
     --argjson line "$decision_line" \
     '. + [{id: $id, path: $path, function: $function, line: $line}]' \
     <<<"$decision_anchors")"
-done < <(jq -c '.decisions[]' "$scope")
+done <"$decision_rows"
 
 jq \
   --arg revision "$base_revision" \
@@ -388,6 +397,14 @@ jq \
 # failing tests in each mutant's log. A caught classification without the
 # detector that actually failed is not reviewable mutation evidence, so enrich
 # every killed row and fail closed if the runner log cannot supply one.
+caught_mutant_rows="$output/caught-mutant-rows.tsv"
+jq -r '
+  [.outcomes[] | select(.scenario != "Baseline")]
+  | to_entries[]
+  | select(.value.summary == "CaughtMutant")
+  | [.key, .value.log_path]
+  | @tsv
+' "$raw/outcomes.json" >"$caught_mutant_rows"
 while IFS=$'\t' read -r mutant_index log_path; do
   case "$log_path" in
     log/*) ;;
@@ -415,15 +432,7 @@ while IFS=$'\t' read -r mutant_index log_path; do
     '.mutants[$mutant_index].primary_failing_test = $primary_failing_test' \
     "$output/implementation-mutation-report.v1.json" >"$report_tmp"
   mv "$report_tmp" "$output/implementation-mutation-report.v1.json"
-done < <(
-  jq -r '
-    [.outcomes[] | select(.scenario != "Baseline")]
-    | to_entries[]
-    | select(.value.summary == "CaughtMutant")
-    | [.key, .value.log_path]
-    | @tsv
-  ' "$raw/outcomes.json"
-)
+done <"$caught_mutant_rows"
 
 FSL_IMPLEMENTATION_MUTATION_REPORT="$output/implementation-mutation-report.v1.json" \
   cargo test --manifest-path "$root/rust/Cargo.toml" -p fslc-rust \

--- a/tools/rust_parity_util.py
+++ b/tools/rust_parity_util.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Ryoichi Izumita
+
+"""Shared normalization and comparison helpers for Rust parity harnesses."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+# Witness choices are not unique. Their semantic equivalence is established by
+# check_rust_bmc_parity.py and check_rust_scenarios_parity.py through
+# cross-implementation Monitor replay. These are the only witness paths whose
+# concrete values are normalized here.
+TRACE_PATHS = {
+    "$.trace",
+    "$.deadlock.trace",
+}
+
+
+def _value_shape(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _value_shape(item) for key, item in sorted(value.items())}
+    if isinstance(value, list):
+        return [_value_shape(item) for item in value]
+    return f"<{type(value).__name__}>"
+
+
+def _trace_shape(trace: Any) -> Any:
+    if not isinstance(trace, list):
+        return _value_shape(trace)
+    shaped = []
+    for entry in trace:
+        if not isinstance(entry, dict):
+            shaped.append(_value_shape(entry))
+            continue
+        item: dict[str, Any] = {"keys": sorted(entry)}
+        if "action" in entry:
+            action = entry["action"]
+            item["action_keys"] = sorted(action) if isinstance(action, dict) else _value_shape(action)
+        if "changes" in entry:
+            changes = entry["changes"]
+            if isinstance(changes, dict):
+                item["changes_shape"] = sorted(
+                    {
+                        tuple(sorted(change)) if isinstance(change, dict) else ("<non-object>",)
+                        for change in changes.values()
+                    }
+                )
+            else:
+                item["changes_shape"] = _value_shape(changes)
+        if "blame" in entry:
+            blame = entry["blame"]
+            item["blame_keys"] = sorted(blame) if isinstance(blame, dict) else _value_shape(blame)
+        shaped.append(item)
+    return shaped
+
+
+def _normalize(value: Any, path: str = "$") -> Any:
+    if path in TRACE_PATHS:
+        return _trace_shape(value)
+    if path.startswith("$.reachables.") and path.endswith(".witness"):
+        return _trace_shape(value)
+    if path == "$.cost.elapsed_s":
+        return "<elapsed>"
+    if path in {"$.violating_bindings", "$.last_action.params"}:
+        return _value_shape(value)
+    if path.startswith("$.blame.conjuncts.") and path.endswith(".violating_bindings"):
+        return _value_shape(value)
+    if isinstance(value, dict):
+        return {
+            key: _normalize(item, f"{path}.{key}")
+            for key, item in sorted(value.items())
+            if key != "fsl"
+        }
+    if isinstance(value, list):
+        return [_normalize(item, f"{path}.{index}") for index, item in enumerate(value)]
+    if (
+        path.startswith("$.warnings.")
+        and path.endswith(".message")
+        and isinstance(value, str)
+    ):
+        return re.sub(r"(deadlock reachable at step \d+) \(state: .*\)$", r"\1 (state: <witness>)", value)
+    return value
+
+
+def _diff(expected: Any, actual: Any, path: str = "$") -> list[dict[str, Any]]:
+    if type(expected) is not type(actual):
+        return [{"path": path, "python": expected, "rust": actual}]
+    if isinstance(expected, dict):
+        failures = []
+        for key in sorted(set(expected) | set(actual)):
+            if key not in expected or key not in actual:
+                failures.append(
+                    {
+                        "path": f"{path}.{key}",
+                        "python": expected.get(key, "<missing>"),
+                        "rust": actual.get(key, "<missing>"),
+                    }
+                )
+            else:
+                failures.extend(_diff(expected[key], actual[key], f"{path}.{key}"))
+        return failures
+    if isinstance(expected, list):
+        if len(expected) != len(actual):
+            return [{"path": path, "python": expected, "rust": actual}]
+        failures = []
+        for index, (left, right) in enumerate(zip(expected, actual)):
+            failures.extend(_diff(left, right, f"{path}.{index}"))
+        return failures
+    return [] if expected == actual else [{"path": path, "python": expected, "rust": actual}]


### PR DESCRIPTION
## Promotion of release candidate v4.4.1

- **Candidate SHA**: `155203331d95a12f912b39a84e8803fa79f45ed1` (`chore(release): v4.4.1`, merged via #914)
- **Version**: 4.4.1 (workspace, VS Code extension, `fslc --version` exact-match verified)
- **Scope**: 15 changelog entries since v4.4.0 / production `fe3d5f4`.

Soundness fixes: #832 (check/verify false green for alias members **and** typed binders across every dialect), #826 (unresolved init writes now collide with concrete keys), #904 (legacy BFS stops reporting terminal states as deadlocks; the `deadlock_step` agreement exclusion self-retires), #786 (frozen-Python implements override). Detection strengthening: #898 (shellcheck + bash-version-guard lint wired into merge readiness), #742, #746, #761 native owners F1–F4/F6/F7 and the parity-harness disposition record, #757's first natural production partial re-run recorded. Docs: #762, the accepted BFS/BMC migration design.

**Release-procedure gap closed in the candidate**: #906's induction contract golden records each envelope's `versions` block, but neither `docs/RELEASE.md` step 6 nor `is_release_bump_path` named it — every future release would have failed its own complete gate. Both are fixed here.

## Gate results

- Candidate's own push CI on `main`: **success**, including the complete `product gate` (14/14 jobs, zero failures).
- **Dry-run** (`workflow_dispatch` of release.yml, `head_sha == 1552033` verified): https://github.com/ymm-oss/fsl/actions/runs/33017024014 — four native targets, Agent Skill bundle, VS Code extension, both Kernel bundles, and the atomic release-unit assembly all pass; publish correctly skipped for dispatch.
- Local complete gate on the candidate tree: rust, wasm, fault-operators and fsl-logic legs green. `semantic-mutation complete` reported **14 timeouts with zero surviving mutants** — a measured local-performance difference (mutant builds reach 775 s against the 600 s build timeout; baseline build alone is 322 s), while **CI's `mutation mutants` on the same tree tested 55 mutants: 47 caught, 8 unviable, 0 timeouts**. No threshold was relaxed.

## Residual risk

- `native Z3 4.16` matrix lanes are promotion-time evidence (#806 tracks the structural gap); they run on this promotion path.
- #841 (nested `Option`) remains an open contract disagreement; its accepted design (#916) lands separately and changes no shipped behavior in this release.

## Next steps after merge

Revalidate on the exact `production` HEAD (complete gate + release.yml dispatch with matching `head_sha`), regenerate notes from the 4.4.1 section, then tag `v4.4.1` on production — with explicit confirmation immediately before the tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)