### PR TITLE
docs(codex): record hook trust activation and its worktree scope so hooks are not counted as enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,9 @@ New source files must carry the repository's Apache-2.0 SPDX header.
 
 - In Codex sessions, `tasks/active.md` is the worktree-local current task packet. It is ignored by Git
   and must be reconciled with the branch, working tree, implementation, and observed command results.
-- When Codex prompts for hook trust, approve the entry; until then, the Cargo serialization hook does not run.
+- When Codex prompts for hook trust, approve the entry for local feedback if appropriate; trust is bound
+  to the hook source's absolute path, does not transfer to linked worktrees, and must not be relied on
+  as repository enforcement.
 - When a task packet declares append-only history or a no-amend rule, create a new commit rather than
   using `git commit --amend`; an exception requires explicit approval recorded in the task packet.
 - A single successful or partial verification command is not completion evidence. The task packet must

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,7 @@ New source files must carry the repository's Apache-2.0 SPDX header.
 
 - In Codex sessions, `tasks/active.md` is the worktree-local current task packet. It is ignored by Git
   and must be reconciled with the branch, working tree, implementation, and observed command results.
+- When Codex prompts for hook trust, approve the entry; until then, the Cargo serialization hook does not run.
 - When a task packet declares append-only history or a no-amend rule, create a new commit rather than
   using `git commit --amend`; an exception requires explicit approval recorded in the task packet.
 - A single successful or partial verification command is not completion evidence. The task packet must

--- a/changelog.d/929-hook-trust-activation.documented.md
+++ b/changelog.d/929-hook-trust-activation.documented.md
@@ -1,0 +1,3 @@
+Documented (#929): Codex hook activation now records machine-local entry trust,
+the resulting enforcement boundary, and a non-failing local diagnostic for
+untrusted checked-in hooks.

--- a/docs/DESIGN-hooks-enforcement.md
+++ b/docs/DESIGN-hooks-enforcement.md
@@ -28,6 +28,36 @@ directories, deliberately serializing every Cargo invocation in this
 repository common directory. This is more conservative than a target-keyed
 scheme and is the chosen response to the existing shared-resource collision.
 
+## Activation and entry-level trust
+
+Adding an entry to `.codex/hooks.json` declares it but does not make it run.
+Codex requires a machine-local, entry-level `trusted_hash` in the developer's
+`~/.codex/config.toml` under `[hooks.state]`. Its key has the form
+`<hooks.json path>:<event>:<group index>:<hook index>`, so every newly added
+entry starts untrusted even when another entry in the same file is trusted.
+
+The checked-in `.codex/config.toml` setting `[features] hooks = true` enables
+the feature but is not a substitute for that persisted trust decision. Codex
+also exposes `--dangerously-bypass-hook-trust` for an invocation that runs
+enabled hooks without persisted trust; whether to use it routinely is an
+operational decision and is deliberately not made by this design.
+
+[Issue #929](https://github.com/ymm-oss/fsl/issues/929)'s five-minute sample
+captured six independent Cargo processes in two launch forms (directly under
+Codex and through `/bin/zsh -c`). None had `cargo_lock.py` as a parent, and
+no wrapper process appeared at any sample point. At that observation, only a
+`session_start` hook entry was trusted; the Cargo `PreToolUse` entry and the
+remaining checked-in entries were not. Consequently, descriptions of hook
+behavior in this document state the behavior only after the developer has
+accepted each entry's trust prompt.
+
+Trust is local to a developer machine and therefore unavailable to CI. Hook
+configuration contract tests may verify a checked-in entry's existence,
+matcher, and command, but cannot establish that it is trusted on the machine
+that will run it. Hooks must not be counted as merge-time enforcement;
+required CI remains the merge-time owner regardless of hook configuration or
+local trust state.
+
 ## CI-owned checks and shared detectors
 
 The DESIGN-index rule remains owned by the bidirectional map test in

--- a/docs/DESIGN-hooks-enforcement.md
+++ b/docs/DESIGN-hooks-enforcement.md
@@ -51,12 +51,31 @@ remaining checked-in entries were not. Consequently, descriptions of hook
 behavior in this document state the behavior only after the developer has
 accepted each entry's trust prompt.
 
+The hook-source path in a state key is absolute, and state lookup is exact;
+trust does not transfer to a linked worktree. The read-only comparison behind
+#929 found persisted `session_start` hashes for Codex's global hook source and
+for the primary checkout's `.codex/hooks.json`, while the linked worktree's
+`.codex/hooks.json` supplied a third, different source path. Its
+`session_start` key and all four `PreToolUse`/`PostToolUse` keys were therefore
+untrusted. The local diagnostic warning listed all five as
+`session_start:0:0, pre_tool_use:0:0, pre_tool_use:1:0, post_tool_use:0:0,
+post_tool_use:0:1`. This distinction is intentionally described without
+recording a developer-specific absolute path in repository history.
+
+[AGENTS.md](../AGENTS.md) requires a dedicated branch/worktree for non-trivial
+changes. A newly created linked worktree consequently starts with no inherited
+hook trust as the ordinary case, not as an exception. Hook behavior must never
+be designed as a mechanism that becomes reliably available after a developer
+has approved it once: that approval applies only to the particular hook source
+path where it was granted.
+
 Trust is local to a developer machine and therefore unavailable to CI. Hook
 configuration contract tests may verify a checked-in entry's existence,
 matcher, and command, but cannot establish that it is trusted on the machine
 that will run it. Hooks must not be counted as merge-time enforcement;
-required CI remains the merge-time owner regardless of hook configuration or
-local trust state.
+required CI remains the merge-time owner. The linked-worktree non-inheritance
+is an additional reason: hooks are local convenience and early feedback, never
+the repository rules' enforcement owner.
 
 ## CI-owned checks and shared detectors
 

--- a/tests/test_codex_environment.py
+++ b/tests/test_codex_environment.py
@@ -4,9 +4,17 @@
 
 import json
 from pathlib import Path
+import re
 import subprocess
 import sys
-import tomllib
+import warnings
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -75,6 +83,38 @@ def test_session_start_hook_is_root_relative_and_bounded() -> None:
     assert "## Active Task State" in proc.stdout
     assert str(ROOT) not in proc.stdout
     assert len(proc.stdout.splitlines()) <= 280
+
+
+def test_untrusted_checked_in_hook_entries_are_reported_locally() -> None:
+    user_config = Path.home() / ".codex" / "config.toml"
+    # Persisted hook trust is machine-local and absent in CI. Skip there rather
+    # than failing: this diagnostic reports local untrusted entries only, and a
+    # trust requirement would make every clean CI environment permanently red.
+    if not user_config.is_file():
+        pytest.skip("local Codex configuration is unavailable")
+
+    hooks_path = (CODEX / "hooks.json").resolve()
+    hooks = json.loads(hooks_path.read_text(encoding="utf-8"))["hooks"]
+    user_state = tomllib.loads(user_config.read_text(encoding="utf-8"))
+    trusted_entries = user_state.get("hooks", {}).get("state", {})
+    untrusted_entries = []
+
+    for event, groups in hooks.items():
+        event_key = re.sub(r"(?<!^)(?=[A-Z])", "_", event).lower()
+        for group_index, group in enumerate(groups):
+            for hook_index, _hook in enumerate(group["hooks"]):
+                state_key = f"{hooks_path}:{event_key}:{group_index}:{hook_index}"
+                if state_key not in trusted_entries:
+                    untrusted_entries.append(
+                        f"{event_key}:{group_index}:{hook_index}"
+                    )
+
+    if untrusted_entries:
+        warnings.warn(
+            "untrusted checked-in Codex hook entries (not a test failure): "
+            + ", ".join(untrusted_entries),
+            stacklevel=1,
+        )
 
 
 def test_task_skills_require_explicit_invocation() -> None:


### PR DESCRIPTION
## Problem

Closes #929.(M19「宣言と執行の一致」)

#924 が追加した Codex の `PreToolUse` / `PostToolUse` hook は**発火していなかった**。
Cargo の worktree 横断直列化は inert だった。**実装ではなく活性化条件**の問題で、
それがリポジトリのどこにも書かれていなかった。

設計文書は「Codex `PreToolUse` rewrites a Bash command mentioning `cargo` to the repository Cargo
wrapper」と書き、#924 の PR 本文(私が書いた)も直列化が有効になると述べた。
**wrapper 単体の動作は証明されていたが、hook が実際に書き換えることは検証されていなかった。**

## 実測

5分間サンプリングして **6つの cargo プロセス**を捕捉し、**どれにも `cargo_lock.py` の親が無かった**。
2つの起動形態(codex 本体直下と `/bin/zsh -c` 経由)の両方で書き換えられていない。
`cargo_lock.py` プロセスは全サンプル点で 0 件。

原因は `~/.codex/config.toml` の `[hooks.state]` が **hook エントリごとに `trusted_hash`** を
要求すること。キーは `<hooks.json の絶対パス>:<event>:<index>:<index>`。
裏付け: `codex --help` の `--dangerously-bypass-hook-trust`
(「Run enabled hooks without requiring persisted hook trust for this invocation」)。
`.codex/config.toml` の `[features] hooks = true` は trust の代わりにならない。

### さらに構造的だった: trust は linked worktree に継承されない

state key が絶対パスを含み、lookup は完全一致なので、**リポジトリ本体で承認した trust は
linked worktree に転送されない**。新しい診断テストを worktree で走らせた実測:

```
UserWarning: untrusted checked-in Codex hook entries (not a test failure):
  session_start:0:0, pre_tool_use:0:0, pre_tool_use:1:0, post_tool_use:0:0, post_tool_use:0:1
```

**5エントリすべて untrusted** — `SessionStart` も含む。

`AGENTS.md` は "For non-trivial changes, use a dedicated branch/worktree" と定めている。
つまり **新しい worktree で始まる作業セッションでは hook が一度も有効にならず、これは例外ではなく
既定の状態**である。今日の観測は偶発ではなく構造的だった。

## Contract change

1. **`docs/DESIGN-hooks-enforcement.md`** に活性化条件を記載。エントリ単位の永続 trust、
   新エントリが常に untrusted から始まること、`[features] hooks = true` が代替にならないこと、
   `--dangerously-bypass-hook-trust` の存在(常用は運用判断として保留)、
   そして **linked worktree に trust が継承されないこと**。
   実測を根拠として残しつつ、**開発者固有の絶対パスをリポジトリ履歴に記録していない**。
2. **hook の挙動を「開発者が一度承認すれば確実に利用できる仕組み」として設計してはならない**
   ことを設計に固定した。その承認は付与されたその hook ソースのパスにのみ適用される。
3. **`AGENTS.md:183`**: trust は hook ソースの絶対パスに紐づき、linked worktree に転送されず、
   **依拠してはならない**。同ファイル `:203` の「専用 worktree を使う」規則と整合する。
4. **trust は CI では検査できない**(マシンごとなので)ことを明記。契約テストは hook の存在・
   matcher・コマンドを検査できるが trust 状態は検査できない。したがって
   **hook を merge-time の enforcement として数えない**。merge-time の所有者は required CI のまま。

## Test evidence

`tests/test_codex_environment.py` に **untrusted エントリを報告する診断**を追加した
(`test_untrusted_checked_in_hook_entries_are_reported_locally`)。

**意図的に fail させない設計**にした。trust はマシンローカルで CI には存在しないため、
fail させると CI が常に赤になる。`warnings.warn` で報告し、ローカル設定が無い環境では
`pytest.skip` する。理由はテストのコメントに書いた。

**この診断が実際に発火することを実測で確認した**(上記の 5エントリの warning)。
書かれているだけで機能しない検査にしないため — それは #924 と同じ「配線したが発火しない」クラスである。

**検証(exit 0)**: `check-design-citation-headings.py check`(74 citations / 0 findings)/
`aggregate_changelog.sh check`(PASS)/ `pytest tests/test_codex_environment.py`(10 passed, 1 warning、
同一セッションで2回)。`docs/` からの `../AGENTS.md` リンクの解決も `test -f` で確認した。

## この発見の出方(記録)

オーケストレーターがワーカーに「このマシンでは `PreToolUse`/`PostToolUse` の**4エントリ**が
untrusted のはず」と期待値を渡した。ワーカーは実測 **5** を報告し、**パスを無視して4件に合わせる
修正を拒否した**(「パスを無視して4件にすると entry-level trust の契約を壊します」)。
その拒否が正しく、**trust の path 依存性はそこで初めて見えた**。期待値に合わせていたら見えなかった。

## Linked issue

Closes #929. 関連: #924(hook 実装。wrapper と共有検出器は正しい — 壊れているのは活性化)。
