### PR TITLE
fix(domain): preserve generate diagnostic locations so sibling guard envelopes agree

### DIFF
--- a/changelog.d/773-domain-generate-error-location.fixed.md
+++ b/changelog.d/773-domain-generate-error-location.fixed.md
@@ -1,0 +1,2 @@
+Fixed (#773): `domain generate` now preserves the typed source-diagnostic
+location for invalid domain guards, matching the checked-Kernel envelope.

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6902,16 +6902,15 @@ fn domain_scaffold_inputs_from_source(
     path: &Path,
     source: &str,
     domain: &fsl_syntax::DomainSpec,
-) -> Result<(Value, Value), String> {
-    let (kernel, model) =
-        load_kernel_model_from_source(path, source).map_err(|error| error.to_string())?;
+) -> Result<(Value, Value), SpecLoadError> {
+    let (kernel, model) = load_kernel_model_from_source(path, source)?;
     let contract = fsl_core::public_kernel_contract(
         &kernel,
         &model,
         &path.to_string_lossy(),
         source_dialect(source),
     )
-    .map_err(|error| error.to_string())?;
+    .map_err(|error| SpecLoadError::unlocated_semantic(error.to_string()))?;
     Ok((contract, fsl_tools::domain_scaffold_metadata(domain)))
 }
 
@@ -7062,7 +7061,7 @@ fn run_domain_generate(
     }
     let (kernel, metadata) = match domain_scaffold_inputs_from_source(path, &source, &domain) {
         Ok(input) => input,
-        Err(error) => return (semantic_error_output(&error), 2),
+        Err(error) => return (spec_load_error_output(&error), 2),
     };
     let mut result = match fsl_tools::domain_scaffold(&kernel, &metadata, target) {
         Ok(result) => result,
@@ -7572,7 +7571,7 @@ fn run_domain_testgen(
         let mut prefix = "// Auto-generated fsl-domain conformance scaffold.\n// Wire makeAdapter() to the generated aggregate adapter or your implementation adapter.\n\n".to_owned();
         let (kernel, metadata) = match domain_scaffold_inputs_from_source(path, &source, &domain) {
             Ok(input) => input,
-            Err(error) => return (semantic_error_output(&error), 2),
+            Err(error) => return (spec_load_error_output(&error), 2),
         };
         let adapter_files = match fsl_tools::domain_adapter_files(&kernel, &metadata) {
             Ok(files) => files,

--- a/rust/fslc/tests/error_envelope_parity.rs
+++ b/rust/fslc/tests/error_envelope_parity.rs
@@ -1702,13 +1702,6 @@ const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
     ),
     pin!(
         FailureClass::Guard,
-        "domain generate",
-        GUARD_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#773"
-    ),
-    pin!(
-        FailureClass::Guard,
         "domain analyze",
         GUARD_FIXTURE,
         SEMANTIC_WITHOUT_INPUT_PATH,
@@ -1762,13 +1755,6 @@ const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
         GUARD_FIXTURE,
         SEMANTIC_WITHOUT_INPUT_PATH,
         "#780"
-    ),
-    pin!(
-        FailureClass::Name,
-        "domain generate",
-        NAME_FIXTURE,
-        SEMANTIC_WITH_INPUT_PATH_WITHOUT_LOCATION,
-        "#773"
     ),
     pin!(
         FailureClass::Name,
@@ -3074,6 +3060,26 @@ fn lowering_guard_errors_are_uniform_or_pinned_across_frontend_siblings() {
     }
 }
 
+/// #773: the generation path reaches the same checked-Kernel lowering failure
+/// as `domain check`. This is a full envelope comparison: no field is excluded.
+/// The population test above independently keeps guard cells for all frontend
+/// siblings, including commands with their own deliberately pinned envelopes.
+#[test]
+fn domain_generate_guard_envelope_matches_domain_check_exactly() {
+    let checked = run("domain check", GUARD_FIXTURE);
+    let generated = run("domain generate", GUARD_FIXTURE);
+    assert_eq!(
+        generated.exit, checked.exit,
+        "generated exit={} stdout={} checked exit={} stdout={}",
+        generated.exit, generated.stdout, checked.exit, checked.stdout,
+    );
+    assert_eq!(
+        generated.json, checked.json,
+        "domain generate must preserve the full checked-Kernel guard envelope; generated stdout={} checked stdout={}",
+        generated.stdout, checked.stdout,
+    );
+}
+
 #[test]
 fn unresolved_identifier_errors_are_uniform_or_pinned_across_frontend_siblings() {
     for cell in cells(FailureClass::Name) {
@@ -3247,7 +3253,7 @@ fn approval_diff_zero_digest_negative_control_stops_before_the_diff() {
 }
 
 #[test]
-fn name_matrix_keeps_eight_uniform_countercontrols_and_one_pin() {
+fn name_matrix_keeps_nine_uniform_countercontrols() {
     let bounded_commands = [
         "check",
         "verify",
@@ -3262,27 +3268,25 @@ fn name_matrix_keeps_eight_uniform_countercontrols_and_one_pin() {
         .into_iter()
         .filter(|cell| bounded_commands.contains(&cell.command))
         .collect::<Vec<_>>();
-    let pinned = name_cells
-        .iter()
-        .filter(|cell| {
-            KNOWN_ASYMMETRIES.iter().any(|pin| {
-                pin.class == FailureClass::Name
-                    && pin.command == cell.command
-                    && pin.shape == cell.shape
-                    && pin.fixture == cell.fixture
-            })
-        })
-        .count();
     assert_eq!(
         name_cells.len(),
         9,
         "Name matrix must keep nine countercontrols"
     );
-    assert_eq!(pinned, 1, "Name matrix must keep one self-retiring pin");
     assert_eq!(
-        name_cells.len() - pinned,
-        8,
-        "Name matrix must keep eight uniform countercontrols"
+        name_cells
+            .iter()
+            .filter(|cell| {
+                KNOWN_ASYMMETRIES.iter().any(|pin| {
+                    pin.class == FailureClass::Name
+                        && pin.command == cell.command
+                        && pin.shape == cell.shape
+                        && pin.fixture == cell.fixture
+                })
+            })
+            .count(),
+        0,
+        "Name matrix must keep all nine countercontrols uniform"
     );
 }
 


### PR DESCRIPTION
## Problem

Closes #773.(M18)

同一の lowerable-construct guard 失敗に対し、`fslc domain generate` だけが機械可読な位置情報
(`loc`)を落としていた。位置は message 文字列にしか無く、consumer は message をパースするしかない。

**兄弟非対称は「どれか1つだけ挙動が違う」形で現れるため、単体テストでは検出されない。**

## 実測(現 HEAD で起票内容を再確認)

fixture `rust/fslc/tests/fixtures/domain_await_routing_rejected.fsl` の同一 guard 失敗:

| コマンド | kind | loc(修正前) | loc(修正後) |
|---|---|---|---|
| `check` | `semantics` | `{line:26, column:3}` | 同じ |
| `domain check` | `semantics` | `{line:26, column:3}` | 同じ |
| `domain analyze` | `semantics` | `{line:26, column:3}` | 同じ |
| `domain expand` | `semantics` | `{line:26, column:3}` | 同じ |
| **`domain generate`** | `semantics` | **無し** | **`{line:26, column:3}`** |
| `domain testgen` | `semantics` | `{line:26, column:3}` | 同じ |

issue が挙げていない**2つ目の呼出元**も同じ欠陥を持っていた:
`domain testgen --target vitest` のエラー経路。修正後は `loc: {line:26, column:3}` を持つ
(オーケストレーターが実測で確認)。

## Contract change

scaffold helper が型付き `SpecLoadError` を**文字列化せずに保持**し、`domain generate` と
Vitest `domain testgen` が既存の `spec_load_error_output` に渡す(`rust/fslc/src/main.rs:6901`)。

修正前は `load_kernel_model_from_source(...).map_err(|error| error.to_string())?` で型を捨て、
`semantic_error_output` に渡していたため location が復元できなかった。**型を捨てる場所が
欠陥の所在**であり、封筒構築側ではなかった。

`loc` の追加は consumer を壊さないので fragment は `fixed`。

## Test evidence

**非対称 pin を退役させた。** `error_envelope_parity.rs` は #773 の guard/name 非対称を
pin して固定していた。修正でその pin が不要になったので**外し**、代わりに
`domain generate` と `domain check` の guard 封筒を**全フィールド完全一致**で比較する検出器を
置いた(`rust/fslc/tests/error_envelope_parity.rs:3063`)。
これは「pin は修正が入ったら自己退役する」形である。

**負対照(検出器の校正)** — `semantic_error_output` に戻す変異を適用した:

| 項目 | 期待 | produced |
|---|---|---|
| `domain generate` の `loc` | `{line:26, column:3}` | **無し** |
| 完全比較の検出器 | 落ちる | 落ちた |
| guard matrix | 落ちる | 落ちた |
| name matrix | 落ちる | 落ちた |

**3つの control が同時に落ちる**ことを確認した。復元は named snapshot への SHA-256 一致で証明。

**検証(いずれも exit 0)**: `error_envelope_parity` 23 passed(**同一セッション内で2回以上**)/
`cli_regression` 33 passed(2回)/ `cargo fmt --check` / workspace Clippy `-D warnings` /
`aggregate_changelog.sh check`。`origin/main` 取り込み後にも parity 23 passed を再確認した。

## 関連する再測結果(この PR の範囲外)

同じ M18 の **#780**(dialect コマンド経由の parse エラーが `kind` を偽り `loc` と
`diagnostic_code` を落とす)は、**現 HEAD では 7コマンドすべてが generic と一致**しており
解消していた。issue にその実測表を記録した(`db check` は未測定のためクローズは保留)。

## Linked issue

Closes #773. 同種の兄弟非対称: #726。関連: M18 の #780(解消済)、#831(`compose.rs` の
ハードコードされた `1:1` — `QualifiedName` に span が無いため別原因)。
