### PR TITLE
fix(compose): stop inventing 1:1 locations and make alias spans mandatory

### DIFF
--- a/changelog.d/831-compose-unlocated-errors.fixed.md
+++ b/changelog.d/831-compose-unlocated-errors.fixed.md
@@ -1,0 +1,3 @@
+Fixed (#831): compose diagnostics no longer invent a `1:1` component location
+for unreadable files; alias-qualified type resolution and synchronized-reference
+errors now carry authored source spans into the public envelope.

--- a/rust/fsl-core/src/compose.rs
+++ b/rust/fsl-core/src/compose.rs
@@ -38,13 +38,8 @@ impl FsResolver {
 
 impl FileResolver for FsResolver {
     fn read(&self, path: &str) -> Result<String, CoreError> {
-        std::fs::read_to_string(self.base.join(path)).map_err(|error| CoreError {
-            message: error.to_string(),
-            line: 1,
-            column: 1,
-            origin: None,
-            name_resolution: false,
-        })
+        std::fs::read_to_string(self.base.join(path))
+            .map_err(|error| CoreError::unlocated(error.to_string()))
     }
 }
 
@@ -68,13 +63,9 @@ pub fn parse_kernel_source(
         SurfaceDocument::Domain(domain) => crate::lower_domain(&domain),
         SurfaceDocument::AiComponent(component) => crate::lower_ai_component(component),
         SurfaceDocument::Compose(compose) => lower_compose(compose, resolver),
-        SurfaceDocument::Refinement(_) | SurfaceDocument::Agent(_) => Err(CoreError {
-            message: "top-level document has not reached the kernel lowering gate".to_owned(),
-            line: 1,
-            column: 1,
-            origin: None,
-            name_resolution: false,
-        }),
+        SurfaceDocument::Refinement(_) | SurfaceDocument::Agent(_) => Err(CoreError::unlocated(
+            "top-level document has not reached the kernel lowering gate",
+        )),
     }?;
     kernel
         .annotations
@@ -169,10 +160,14 @@ fn component_error(
     verb: &str,
 ) -> CoreError {
     CoreError {
-        message: format!(
-            "component \"{path}\" {verb} ({} at {path}:{}:{})",
-            error.message, error.line, error.column
-        ),
+        message: if error.is_located() {
+            format!(
+                "component \"{path}\" {verb} ({} at {path}:{}:{})",
+                error.message, error.line, error.column
+            )
+        } else {
+            format!("component \"{path}\" {verb} ({})", error.message)
+        },
         line: use_span.start.line,
         column: use_span.start.column,
         // Not propagated from `error`. What this value reports is a compose-level
@@ -929,7 +924,7 @@ fn rewrite_compose_item(
             annotations,
         } => SpecItem::Invariant {
             name,
-            expr: Box::new(resolve_alias_expr_with_span(*expr, components, Some(span))?),
+            expr: Box::new(resolve_alias_expr(*expr, components, span)?),
             span,
             meta,
             annotations,
@@ -942,7 +937,7 @@ fn rewrite_compose_item(
             annotations,
         } => SpecItem::Trans {
             name,
-            expr: Box::new(resolve_alias_expr_with_span(*expr, components, Some(span))?),
+            expr: Box::new(resolve_alias_expr(*expr, components, span)?),
             span,
             meta,
             annotations,
@@ -955,7 +950,7 @@ fn rewrite_compose_item(
             annotations,
         } => SpecItem::Reachable {
             name,
-            expr: Box::new(resolve_alias_expr_with_span(*expr, components, Some(span))?),
+            expr: Box::new(resolve_alias_expr(*expr, components, span)?),
             span,
             meta,
             annotations,
@@ -985,7 +980,7 @@ fn resolve_alias_statement(
             span,
         } => Statement::Assign {
             target,
-            value: resolve_alias_expr(value, components)?,
+            value: resolve_alias_expr(value, components, span)?,
             span,
         },
         Statement::If {
@@ -994,7 +989,7 @@ fn resolve_alias_statement(
             else_statements,
             span,
         } => Statement::If {
-            condition: resolve_alias_expr(condition, components)?,
+            condition: resolve_alias_expr(condition, components, span)?,
             then_statements: then_statements
                 .into_iter()
                 .map(|statement| resolve_alias_statement(statement, components))
@@ -1010,7 +1005,7 @@ fn resolve_alias_statement(
             statements,
             span,
         } => Statement::ForAll {
-            binder: resolve_alias_binder(binder, components, Some(span))?,
+            binder: resolve_alias_binder(binder, components, span)?,
             statements: statements
                 .into_iter()
                 .map(|statement| resolve_alias_statement(statement, components))
@@ -1034,25 +1029,20 @@ fn sync_action(
     let mut items = Vec::new();
     let mut fair_constituents = Vec::new();
     for reference in &action.refs {
-        let component = components.get(&reference.alias).ok_or_else(|| CoreError {
-            message: format!("unknown alias '{}'", reference.alias),
-            line: action.span.start.line,
-            column: action.span.start.column,
-            origin: None,
-            name_resolution: false,
-        })?;
+        let component = components
+            .get(&reference.alias)
+            .ok_or_else(|| error_at(format!("unknown alias '{}'", reference.alias), action.span))?;
         let source = component
             .spec
             .items
             .iter()
             .find(|item| matches!(item, SpecItem::Action { name, .. } if name == &reference.action))
             .cloned()
-            .ok_or_else(|| CoreError {
-                message: format!("unknown action '{}.{}'", reference.alias, reference.action),
-                line: action.span.start.line,
-                column: action.span.start.column,
-                origin: None,
-                name_resolution: false,
+            .ok_or_else(|| {
+                error_at(
+                    format!("unknown action '{}.{}'", reference.alias, reference.action),
+                    action.span,
+                )
             })?;
         // Fairness is not inherited through synchronization (docs/LANGUAGE.md
         // "Compose"): capture the constituent's own `fair` marker here, before
@@ -1089,7 +1079,10 @@ fn sync_action(
                 let name = match param {
                     Param::Typed(name, _) | Param::Range(name, _, _) => name.clone(),
                 };
-                Ok((name, resolve_alias_expr(arg.clone(), components)?))
+                Ok((
+                    name,
+                    resolve_alias_expr(arg.clone(), components, action.span)?,
+                ))
             })
             .collect::<Result<HashMap<_, _>, CoreError>>()?;
         items.extend(
@@ -1137,12 +1130,12 @@ fn resolve_alias_param(
     Ok(match param {
         Param::Typed(name, qualified) => Param::Typed(
             name,
-            resolve_alias_qualified_name(qualified, components, Some(span))?,
+            resolve_alias_qualified_name(qualified, components, span)?,
         ),
         Param::Range(name, lo, hi) => Param::Range(
             name,
-            resolve_alias_expr(lo, components)?,
-            resolve_alias_expr(hi, components)?,
+            resolve_alias_expr(lo, components, span)?,
+            resolve_alias_expr(hi, components, span)?,
         ),
     })
 }
@@ -1150,33 +1143,15 @@ fn resolve_alias_param(
 fn resolve_alias_qualified_name(
     qualified: QualifiedName,
     components: &BTreeMap<String, Component>,
-    span: Option<fsl_syntax::Span>,
+    span: fsl_syntax::Span,
 ) -> Result<QualifiedName, CoreError> {
     if let Some(alias) = qualified.namespace {
-        let component = components.get(&alias).ok_or_else(|| {
-            span.map_or_else(
-                || CoreError {
-                    message: format!("unknown alias '{alias}'"),
-                    line: 1,
-                    column: 1,
-                    origin: None,
-                    name_resolution: false,
-                },
-                |span| error_at(format!("unknown alias '{alias}'"), span),
-            )
-        })?;
+        let component = components
+            .get(&alias)
+            .ok_or_else(|| error_at(format!("unknown alias '{alias}'"), span))?;
         if !component.names.types.contains(&qualified.name) {
             let message = format!("unknown type '{alias}.{}'", qualified.name);
-            return Err(span.map_or_else(
-                || CoreError {
-                    message: message.clone(),
-                    line: 1,
-                    column: 1,
-                    origin: None,
-                    name_resolution: false,
-                },
-                |span| error_at(message.clone(), span),
-            ));
+            return Err(error_at(message, span));
         }
         Ok(QualifiedName {
             namespace: None,
@@ -1190,7 +1165,7 @@ fn resolve_alias_qualified_name(
 fn resolve_alias_binder(
     binder: Binder,
     components: &BTreeMap<String, Component>,
-    span: Option<fsl_syntax::Span>,
+    span: fsl_syntax::Span,
 ) -> Result<Binder, CoreError> {
     Ok(match binder {
         Binder::Typed {
@@ -1201,7 +1176,7 @@ fn resolve_alias_binder(
             name,
             type_name: resolve_alias_qualified_name(type_name, components, span)?,
             where_expr: where_expr
-                .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
+                .map(|expr| resolve_alias_expr(*expr, components, span).map(Box::new))
                 .transpose()?,
         },
         Binder::Range {
@@ -1211,10 +1186,10 @@ fn resolve_alias_binder(
             where_expr,
         } => Binder::Range {
             name,
-            lo: Box::new(resolve_alias_expr(*lo, components)?),
-            hi: Box::new(resolve_alias_expr(*hi, components)?),
+            lo: Box::new(resolve_alias_expr(*lo, components, span)?),
+            hi: Box::new(resolve_alias_expr(*hi, components, span)?),
             where_expr: where_expr
-                .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
+                .map(|expr| resolve_alias_expr(*expr, components, span).map(Box::new))
                 .transpose()?,
         },
         Binder::Collection {
@@ -1223,9 +1198,9 @@ fn resolve_alias_binder(
             where_expr,
         } => Binder::Collection {
             name,
-            collection: Box::new(resolve_alias_expr(*collection, components)?),
+            collection: Box::new(resolve_alias_expr(*collection, components, span)?),
             where_expr: where_expr
-                .map(|expr| resolve_alias_expr(*expr, components).map(Box::new))
+                .map(|expr| resolve_alias_expr(*expr, components, span).map(Box::new))
                 .transpose()?,
         },
     })
@@ -1235,15 +1210,7 @@ fn resolve_alias_binder(
 fn resolve_alias_expr(
     expr: Expr,
     components: &BTreeMap<String, Component>,
-) -> Result<Expr, CoreError> {
-    resolve_alias_expr_with_span(expr, components, None)
-}
-
-#[allow(clippy::too_many_lines)]
-fn resolve_alias_expr_with_span(
-    expr: Expr,
-    components: &BTreeMap<String, Component>,
-    diagnostic_span: Option<fsl_syntax::Span>,
+    diagnostic_span: fsl_syntax::Span,
 ) -> Result<Expr, CoreError> {
     Ok(match expr {
         Expr::Field(base, name) => {
@@ -1252,26 +1219,18 @@ fn resolve_alias_expr_with_span(
                     Expr::Var(prefix(alias, &name))
                 } else {
                     Expr::Field(
-                        Box::new(resolve_alias_expr_with_span(
-                            *base,
-                            components,
-                            diagnostic_span,
-                        )?),
+                        Box::new(resolve_alias_expr(*base, components, diagnostic_span)?),
                         name,
                     )
                 }
             } else {
                 Expr::Field(
-                    Box::new(resolve_alias_expr_with_span(
-                        *base,
-                        components,
-                        diagnostic_span,
-                    )?),
+                    Box::new(resolve_alias_expr(*base, components, diagnostic_span)?),
                     name,
                 )
             }
         }
-        Expr::Some(expr) => Expr::Some(Box::new(resolve_alias_expr_with_span(
+        Expr::Some(expr) => Expr::Some(Box::new(resolve_alias_expr(
             *expr,
             components,
             diagnostic_span,
@@ -1279,13 +1238,13 @@ fn resolve_alias_expr_with_span(
         Expr::Set(items) => Expr::Set(
             items
                 .into_iter()
-                .map(|item| resolve_alias_expr_with_span(item, components, diagnostic_span))
+                .map(|item| resolve_alias_expr(item, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
         ),
         Expr::Seq(items) => Expr::Seq(
             items
                 .into_iter()
-                .map(|item| resolve_alias_expr_with_span(item, components, diagnostic_span))
+                .map(|item| resolve_alias_expr(item, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
         ),
         Expr::Struct { name, fields } => Expr::Struct {
@@ -1293,10 +1252,7 @@ fn resolve_alias_expr_with_span(
             fields: fields
                 .into_iter()
                 .map(|(name, expr)| {
-                    Ok((
-                        name,
-                        resolve_alias_expr_with_span(expr, components, diagnostic_span)?,
-                    ))
+                    Ok((name, resolve_alias_expr(expr, components, diagnostic_span)?))
                 })
                 .collect::<Result<_, CoreError>>()?,
         },
@@ -1304,57 +1260,37 @@ fn resolve_alias_expr_with_span(
             name,
             args: args
                 .into_iter()
-                .map(|arg| resolve_alias_expr_with_span(arg, components, diagnostic_span))
+                .map(|arg| resolve_alias_expr(arg, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
             span,
         },
         Expr::Index(base, index) => Expr::Index(
-            Box::new(resolve_alias_expr_with_span(
-                *base,
-                components,
-                diagnostic_span,
-            )?),
-            Box::new(resolve_alias_expr_with_span(
-                *index,
-                components,
-                diagnostic_span,
-            )?),
+            Box::new(resolve_alias_expr(*base, components, diagnostic_span)?),
+            Box::new(resolve_alias_expr(*index, components, diagnostic_span)?),
         ),
         Expr::Method {
             receiver,
             name,
             args,
         } => Expr::Method {
-            receiver: Box::new(resolve_alias_expr_with_span(
-                *receiver,
-                components,
-                diagnostic_span,
-            )?),
+            receiver: Box::new(resolve_alias_expr(*receiver, components, diagnostic_span)?),
             name,
             args: args
                 .into_iter()
-                .map(|arg| resolve_alias_expr_with_span(arg, components, diagnostic_span))
+                .map(|arg| resolve_alias_expr(arg, components, diagnostic_span))
                 .collect::<Result<_, _>>()?,
         },
         Expr::Binary { op, left, right } => Expr::Binary {
             op,
-            left: Box::new(resolve_alias_expr_with_span(
-                *left,
-                components,
-                diagnostic_span,
-            )?),
-            right: Box::new(resolve_alias_expr_with_span(
-                *right,
-                components,
-                diagnostic_span,
-            )?),
+            left: Box::new(resolve_alias_expr(*left, components, diagnostic_span)?),
+            right: Box::new(resolve_alias_expr(*right, components, diagnostic_span)?),
         },
-        Expr::Neg(expr) => Expr::Neg(Box::new(resolve_alias_expr_with_span(
+        Expr::Neg(expr) => Expr::Neg(Box::new(resolve_alias_expr(
             *expr,
             components,
             diagnostic_span,
         )?)),
-        Expr::Not(expr) => Expr::Not(Box::new(resolve_alias_expr_with_span(
+        Expr::Not(expr) => Expr::Not(Box::new(resolve_alias_expr(
             *expr,
             components,
             diagnostic_span,
@@ -1366,28 +1302,12 @@ fn resolve_alias_expr_with_span(
             spans,
         } => Expr::Conditional {
             spans,
-            condition: Box::new(resolve_alias_expr_with_span(
-                *condition,
-                components,
-                diagnostic_span,
-            )?),
-            then_expr: Box::new(resolve_alias_expr_with_span(
-                *then_expr,
-                components,
-                diagnostic_span,
-            )?),
-            else_expr: Box::new(resolve_alias_expr_with_span(
-                *else_expr,
-                components,
-                diagnostic_span,
-            )?),
+            condition: Box::new(resolve_alias_expr(*condition, components, diagnostic_span)?),
+            then_expr: Box::new(resolve_alias_expr(*then_expr, components, diagnostic_span)?),
+            else_expr: Box::new(resolve_alias_expr(*else_expr, components, diagnostic_span)?),
         },
         Expr::Is { expr, pattern } => Expr::Is {
-            expr: Box::new(resolve_alias_expr_with_span(
-                *expr,
-                components,
-                diagnostic_span,
-            )?),
+            expr: Box::new(resolve_alias_expr(*expr, components, diagnostic_span)?),
             pattern,
         },
         Expr::Quantified {
@@ -1397,11 +1317,7 @@ fn resolve_alias_expr_with_span(
         } => Expr::Quantified {
             quantifier,
             binder: resolve_alias_binder(binder, components, diagnostic_span)?,
-            body: Box::new(resolve_alias_expr_with_span(
-                *body,
-                components,
-                diagnostic_span,
-            )?),
+            body: Box::new(resolve_alias_expr(*body, components, diagnostic_span)?),
         },
         Expr::Aggregate {
             kind,
@@ -1411,32 +1327,18 @@ fn resolve_alias_expr_with_span(
             kind,
             binder: resolve_alias_binder(binder, components, diagnostic_span)?,
             value: value
-                .map(|expr| {
-                    resolve_alias_expr_with_span(*expr, components, diagnostic_span).map(Box::new)
-                })
+                .map(|expr| resolve_alias_expr(*expr, components, diagnostic_span).map(Box::new))
                 .transpose()?,
         },
         Expr::UnaryNamed { name, expr, span } => Expr::UnaryNamed {
             name,
-            expr: Box::new(resolve_alias_expr_with_span(
-                *expr,
-                components,
-                diagnostic_span,
-            )?),
+            expr: Box::new(resolve_alias_expr(*expr, components, diagnostic_span)?),
             span,
         },
         Expr::BinaryNamed { name, left, right } => Expr::BinaryNamed {
             name,
-            left: Box::new(resolve_alias_expr_with_span(
-                *left,
-                components,
-                diagnostic_span,
-            )?),
-            right: Box::new(resolve_alias_expr_with_span(
-                *right,
-                components,
-                diagnostic_span,
-            )?),
+            left: Box::new(resolve_alias_expr(*left, components, diagnostic_span)?),
+            right: Box::new(resolve_alias_expr(*right, components, diagnostic_span)?),
         },
         Expr::TernaryNamed {
             name,
@@ -1445,21 +1347,9 @@ fn resolve_alias_expr_with_span(
             third,
         } => Expr::TernaryNamed {
             name,
-            first: Box::new(resolve_alias_expr_with_span(
-                *first,
-                components,
-                diagnostic_span,
-            )?),
-            second: Box::new(resolve_alias_expr_with_span(
-                *second,
-                components,
-                diagnostic_span,
-            )?),
-            third: Box::new(resolve_alias_expr_with_span(
-                *third,
-                components,
-                diagnostic_span,
-            )?),
+            first: Box::new(resolve_alias_expr(*first, components, diagnostic_span)?),
+            second: Box::new(resolve_alias_expr(*second, components, diagnostic_span)?),
+            third: Box::new(resolve_alias_expr(*third, components, diagnostic_span)?),
         },
         other => other,
     })
@@ -1471,13 +1361,13 @@ fn resolve_alias_action_item(
 ) -> Result<ActionItem, CoreError> {
     Ok(match item {
         ActionItem::Requires(expr, span) => {
-            ActionItem::Requires(resolve_alias_expr(expr, components)?, span)
+            ActionItem::Requires(resolve_alias_expr(expr, components, span)?, span)
         }
         ActionItem::Ensures(expr, span) => {
-            ActionItem::Ensures(resolve_alias_expr(expr, components)?, span)
+            ActionItem::Ensures(resolve_alias_expr(expr, components, span)?, span)
         }
         ActionItem::Let(name, expr, span) => {
-            ActionItem::Let(name, resolve_alias_expr(expr, components)?, span)
+            ActionItem::Let(name, resolve_alias_expr(expr, components, span)?, span)
         }
         ActionItem::Statement(statement) => {
             ActionItem::Statement(resolve_alias_statement(statement, components)?)

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -102,6 +102,28 @@ pub struct CoreError {
 }
 
 impl CoreError {
+    /// Construct a diagnostic that has no source location.
+    ///
+    /// `CoreError` predates optional locations, so its numeric fields use zero
+    /// internally for absence. Public renderers must keep that sentinel out
+    /// of their envelopes and messages.
+    #[must_use]
+    pub fn unlocated(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            line: 0,
+            column: 0,
+            origin: None,
+            name_resolution: false,
+        }
+    }
+
+    /// Whether this diagnostic records a real source location.
+    #[must_use]
+    pub const fn is_located(&self) -> bool {
+        self.line != 0 && self.column != 0
+    }
+
     /// Classify this diagnostic as a name-resolution failure.
     #[must_use]
     pub fn into_name_resolution(mut self) -> Self {
@@ -120,6 +142,9 @@ impl CoreError {
 
 impl fmt::Display for CoreError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !self.is_located() {
+            return formatter.write_str(&self.message);
+        }
         if let Some(source_file) = self
             .origin
             .as_ref()

--- a/rust/fsl-core/tests/compose_alias_forall.rs
+++ b/rust/fsl-core/tests/compose_alias_forall.rs
@@ -135,3 +135,22 @@ fn declared_alias_in_forall_binder_still_lowers() {
     parse_kernel_source(source, &resolver())
         .expect("a declared alias in a forall binder must lower successfully");
 }
+
+/// Unlocated lowering failures must not pretend that the first token is the
+/// construct that failed. The CLI turns this into a semantic envelope without
+/// `loc`; this direct public-API check covers callers that render `CoreError`.
+#[test]
+fn top_level_lowering_gate_has_no_fabricated_location() {
+    let error = parse_kernel_source(
+        "refinement Mapping { impl Detailed abs Abstract }",
+        &resolver(),
+    )
+    .expect_err("a refinement is not a kernel-lowering input");
+
+    assert_eq!(error.line, 0);
+    assert_eq!(error.column, 0);
+    assert_eq!(
+        error.to_string(),
+        "top-level document has not reached the kernel lowering gate"
+    );
+}

--- a/rust/fslc/tests/fixtures/issue_832/accept_action_expr_binder.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/accept_action_expr_binder.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose AcceptActionBinder {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init { x = 0 }
+  action set() = core.noop() {
+    requires forall u: core.RealType { true }
+    x = 1
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_832/action_expr_binder.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/action_expr_binder.fsl
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose BrokenActionBinder {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init { x = 0 }
+  action set() = core.noop() {
+    requires forall u: nonexistent.UserId { true }
+    x = 1
+  }
+}

--- a/rust/fslc/tests/fixtures/issue_832/sync_unknown_alias.fsl
+++ b/rust/fslc/tests/fixtures/issue_832/sync_unknown_alias.fsl
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+compose BrokenSyncAlias {
+  use Core as core from "core.fsl"
+  state { x: Int }
+  init { x = 0 }
+  // The bad alias is deliberately not on line 1.
+  action set() = nonexistent.noop() || core.noop() {}
+}

--- a/rust/fslc/tests/issue_567_cross_file_diagnostic_loc.rs
+++ b/rust/fslc/tests/issue_567_cross_file_diagnostic_loc.rs
@@ -118,8 +118,8 @@ fn every_spec_reading_command_reports_the_same_corrected_location() {
 
 #[test]
 fn an_unreadable_component_is_located_at_its_own_use_declaration() {
-    // Same class: the read failure carried `1:1`, which in the parent is the
-    // `compose` keyword rather than the import that failed.
+    // The parent `use` owns the public `loc`; the unreadable component owns no
+    // source location, so its message must not invent one.
     let directory = Path::new(env!("CARGO_TARGET_TMPDIR")).join(format!(
         "issue-567-{}-{:?}",
         std::process::id(),
@@ -136,11 +136,11 @@ fn an_unreadable_component_is_located_at_its_own_use_declaration() {
     assert_eq!(status, 2, "{value}");
     assert_eq!(value["loc"]["line"], 2, "{value}");
     assert_eq!(value["loc"]["column"], 3, "{value}");
+    let message = value["message"].as_str().expect("message");
+    assert!(message.contains("absent.fsl"), "{value}");
     assert!(
-        value["message"]
-            .as_str()
-            .is_some_and(|message| message.contains("absent.fsl")),
-        "{value}"
+        !message.contains("absent.fsl:"),
+        "unlocated component error fabricated a coordinate: {value}"
     );
 }
 

--- a/rust/fslc/tests/issue_832_compose_check.rs
+++ b/rust/fslc/tests/issue_832_compose_check.rs
@@ -93,6 +93,31 @@ fn check_rejects_unknown_member_in_invariant_binder_at_authored_location() {
     );
 }
 
+/// Rejecting detector for #831's remaining reachable fallback: an action
+/// expression binder has its own source span and must not fall back to `1:1`.
+/// The alias is deliberately on line 8, so a placeholder cannot pass.
+#[test]
+fn check_rejects_unknown_action_binder_alias_at_authored_location() {
+    assert_rejected_by_check_and_verify(
+        "action_expr_binder",
+        "semantics",
+        "unknown alias 'nonexistent' at 8:5",
+        &json!({"line": 8, "column": 5}),
+    );
+}
+
+/// The sync-action reference producer must carry the same real source span
+/// into the envelope, rather than retaining it only in the message.
+#[test]
+fn check_rejects_unknown_sync_action_alias_at_authored_location() {
+    assert_rejected_by_check_and_verify(
+        "sync_unknown_alias",
+        "semantics",
+        "unknown alias 'nonexistent' at 8:3",
+        &json!({"line": 8, "column": 3}),
+    );
+}
+
 /// Rejecting detector for the shared typed-binder gate: requirements process
 /// lowering must not let an unknown invariant binder pass `check` and fail only
 /// when `verify` tries to enumerate its finite domain. The binder is authored
@@ -122,7 +147,11 @@ fn check_rejects_undeclared_alias_shaped_init_condition() {
 /// Accepting controls for both corrected positions.
 #[test]
 fn check_accepts_real_alias_type_and_declared_alias_condition() {
-    for name in ["accept_real_type", "accept_alias_condition"] {
+    for name in [
+        "accept_real_type",
+        "accept_alias_condition",
+        "accept_action_expr_binder",
+    ] {
         let path = fixture(name);
         let (value, status) = run_cli(&["check", &path]);
         assert_eq!(status, 0, "{name}: {value}");


### PR DESCRIPTION
## Problem

Closes #831.(M18)

`rust/fsl-core/src/compose.rs` が、**位置を持たないエラーに `line: 1, column: 1` を捏造**して
いた。issue 自身がその害を正確に述べている:

> A location field that is sometimes real and sometimes `1:1` is worse than one that is
> consistently absent, because a consumer cannot tell which it has

## 起票内容の訂正(現 HEAD で再実測してスコープを改訂した)

**issue の当初の症状は再現しなかった。** `resolve_alias_qualified_name` は既に
`span: Option<Span>` を受け取り、`Some` なら `error_at(...)` を使っていた。ハードコードされた
`1:1` は span が `None` のときのフォールバックだった。2経路を実測(いずれも**1行目ではない**位置で
— 1行目の fixture ではプレースホルダと正しい位置を区別できず、それがこの欠陥が見逃された理由):

| 入力 | produced |
|---|---|
| sync-action の qualified name(16行目に `nonexistent.Amount`) | `"unknown alias 'nonexistent' at 16:3"`, `loc {16,3}` |
| binder 経路(32行目の `forall x: nonexistent.Amount`) | `"... at 31:3"`, `loc {31,3}`(囲む invariant の span) |

**生きていた欠陥**は別だった。`FsResolver::read` の I/O 失敗が `1:1` を付け、それが
**message に漏れていた**:

```
component "definitely_missing_file.fsl" could not be read
  (No such file or directory (os error 2) at definitely_missing_file.fsl:1:1) at <path>:7:3
```

封筒の `loc` は正しい(`use` 文の実位置)が、message は**位置を持たない I/O 失敗に位置がある**
ように見せていた。

`compose.rs:73`(\"top-level document has not reached the kernel lowering gate\")も実測した:
**CLI へ `1:1` は出ていなかった**(封筒は `spec has no state block` で `loc` なし)。
それでも生の `CoreError` 表示を座標なしに統一した。

## Contract change

1. **位置を捏造しない。** I/O 読み込み失敗の message から `component:1:1` を除去し、
   親 `use` 文の実 `loc` は保持する。
2. **`Option<Span>` を廃止し、span を必須にした。** action / binder / sync 引数を含む全経路で
   `Some(span)` → `span` になった。到達不能な `1:1` フォールバックを修理するのではなく**消した**:
   残せば、次に span を渡し忘れた呼出元を黙って通す。今は**型でそれが不可能**である。
3. 掃討で**もう1件**見つかった — synchronized reference が `loc` を落としていた。`error_at` に統一。

## Test evidence

**オーケストレーターによる独立検証**(修正前に私が実測した同じ入力で):

| 検証 | produced |
|---|---|
| I/O 失敗の message に `definitely_missing_file.fsl:1:1` が残るか | **False**(消えた)。`loc {7,3}` は保持 |
| sync-action 経路(16行目) | `loc {16,3}`、`"... at 16:3"` — 回帰なし |
| binder 経路(32行目) | `loc {31,3}`、`"... at 31:3"` — 回帰なし |
| accepting: `specs/bank_system.fsl` | `result: ok` |

**ワーカー側の対照**: rejecting / accepting の両方向、**単独変異による検出器校正**、復元の完全一致。
rejecting fixture の alias は**1行目に置いていない**(issue の要求)。

**検証(いずれも exit 0)**: `fsl-core` 全件(22 スイート ok、失敗 0)/
`error_envelope_parity` 23 passed / `cli_regression` 33 passed / `cargo fmt --check` /
workspace Clippy `-D warnings`。`origin/main`(`7bcb12b`)取り込み後にも `fsl-core` と
`error_envelope_parity` を再確認した。

## Linked issue

Closes #831. 同じ M18 の loc 系: #773(PR #934 で解消)、#780(現 HEAD では既に解消、
`db check` のみ未測定)。#818 / #830 の修正中に発見された issue。
