### PR TITLE
fix(trace): preserve nested Option JSON projection across trace, replay, testgen, and Worker

### DIFF
--- a/changelog.d/841-nested-option-lossless-json.fixed.md
+++ b/changelog.d/841-nested-option-lossless-json.fixed.md
@@ -1,0 +1,6 @@
+Fixed (#841): ordinary trace, replay, testgen, and Worker JSON no longer collapse
+`none` and `some(none)` for a nested `Option` state value; the tagged form
+`{"kind":"some","value":…}` is introduced only where the declared payload is
+itself an `Option`, so every previously supported `Option<scalar>` byte is
+unchanged, and trace changes are computed from typed values so a struct's own
+`kind`/`value` fields are never mistaken for an `Option` tag.

--- a/rust/fsl-core/src/trace_json.rs
+++ b/rust/fsl-core/src/trace_json.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::{Map, Value, json};
 
@@ -81,6 +81,13 @@ pub fn fsl_value_json(value: &FslValue) -> Value {
         FslValue::Bool(value) => json!(value),
         FslValue::Enum { member, .. } => json!(member),
         FslValue::None => Value::Null,
+        // State values cannot contain an Option around a struct or collection,
+        // so an untyped value can identify a nested Option from its payload.
+        // Keep the legacy scalar bytes, but retain the outer presence bit when
+        // that payload is itself an Option.
+        FslValue::Some(value) if matches!(value.as_ref(), FslValue::None | FslValue::Some(_)) => {
+            json!({"kind":"some", "value":fsl_value_json(value)})
+        }
         FslValue::Some(value) => fsl_value_json(value),
         FslValue::Struct { fields, .. } => Value::Object(
             fields
@@ -134,14 +141,17 @@ fn format_value(model: &KernelModel, value: &FslValue, ty: &TypeRef) -> String {
         FslValue::Int(value) => value.to_string(),
         FslValue::Bool(value) => value.to_string(),
         FslValue::Enum { member, .. } => member.clone(),
-        FslValue::None => "null".to_owned(),
-        FslValue::Some(value) => format_value(
-            model,
-            value,
-            match ty {
-                TypeRef::Option(inner) => inner,
-                _ => ty,
-            },
+        FslValue::None => "none".to_owned(),
+        FslValue::Some(value) => format!(
+            "some({})",
+            format_value(
+                model,
+                value,
+                match ty {
+                    TypeRef::Option(inner) => inner,
+                    _ => ty,
+                },
+            )
         ),
         FslValue::Struct { type_name, fields } => {
             let declared = model.struct_fields(type_name).unwrap_or(&[]);
@@ -267,10 +277,7 @@ pub fn trace_json(model: &KernelModel, trace: &[TraceStep]) -> Value {
                         trace.get(entry.step.saturating_sub(1)).map_or_else(
                             || Value::Object(Map::new()),
                             |previous| {
-                                Value::Object(compute_changes(
-                                    &state_json(&previous.state),
-                                    &state_json(&entry.state),
-                                ))
+                                Value::Object(compute_changes(&previous.state, &entry.state))
                             },
                         ),
                     );
@@ -281,34 +288,100 @@ pub fn trace_json(model: &KernelModel, trace: &[TraceStep]) -> Value {
     )
 }
 
-fn compute_changes(previous: &Value, current: &Value) -> Map<String, Value> {
-    fn walk(path: &str, previous: &Value, current: &Value, out: &mut Map<String, Value>) {
+fn compute_changes(
+    previous: &BTreeMap<String, FslValue>,
+    current: &BTreeMap<String, FslValue>,
+) -> Map<String, Value> {
+    fn insert_change(
+        path: &str,
+        previous: Option<&FslValue>,
+        current: Option<&FslValue>,
+        out: &mut Map<String, Value>,
+    ) {
+        out.insert(
+            path.to_owned(),
+            json!({
+                "from": previous.map_or(Value::Null, fsl_value_json),
+                "to": current.map_or(Value::Null, fsl_value_json),
+            }),
+        );
+    }
+
+    fn walk(
+        path: &str,
+        previous: Option<&FslValue>,
+        current: Option<&FslValue>,
+        out: &mut Map<String, Value>,
+    ) {
         if previous == current {
             return;
         }
-        if let (Value::Object(previous), Value::Object(current)) = (previous, current) {
-            let mut keys = previous.keys().chain(current.keys()).collect::<Vec<_>>();
-            keys.sort_unstable();
-            keys.dedup();
+
+        // Option values are atomic public values. In particular, do not
+        // descend into the canonical {kind,value} encoding: those fields can
+        // also occur in a legal struct and are not logical state paths.
+        if matches!(previous, Some(FslValue::None | FslValue::Some(_)))
+            || matches!(current, Some(FslValue::None | FslValue::Some(_)))
+        {
+            insert_change(path, previous, current, out);
+            return;
+        }
+
+        if let (
+            Some(FslValue::Struct {
+                fields: previous, ..
+            }),
+            Some(FslValue::Struct {
+                fields: current, ..
+            }),
+        ) = (previous, current)
+        {
+            let keys = previous
+                .keys()
+                .chain(current.keys())
+                .collect::<BTreeSet<_>>();
             for key in keys {
-                let next = if path.is_empty() {
-                    key.clone()
-                } else {
-                    format!("{path}[{key}]")
-                };
                 walk(
-                    &next,
-                    previous.get(key).unwrap_or(&Value::Null),
-                    current.get(key).unwrap_or(&Value::Null),
+                    &format!("{path}[{key}]"),
+                    previous.get(key),
+                    current.get(key),
                     out,
                 );
             }
-        } else if !path.is_empty() {
-            out.insert(path.to_owned(), json!({"from": previous, "to": current}));
+            return;
         }
+
+        if let (Some(FslValue::Map(previous)), Some(FslValue::Map(current))) = (previous, current) {
+            let keys = previous
+                .keys()
+                .chain(current.keys())
+                .collect::<BTreeSet<_>>();
+            for key in keys {
+                walk(
+                    &format!("{path}[{}]", map_key(key)),
+                    previous.get(key),
+                    current.get(key),
+                    out,
+                );
+            }
+            return;
+        }
+
+        insert_change(path, previous, current, out);
     }
 
     let mut changes = Map::new();
-    walk("", previous, current, &mut changes);
+    let keys = previous
+        .keys()
+        .chain(current.keys())
+        .collect::<BTreeSet<_>>();
+    for key in keys {
+        walk(
+            &display_name(key),
+            previous.get(key),
+            current.get(key),
+            &mut changes,
+        );
+    }
     changes
 }

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -561,7 +561,7 @@ mod tests {
     use std::task::{Context, Poll, Waker};
 
     use super::*;
-    use fsl_core::{FslValue, TraceAction, TraceStep, trace_json};
+    use fsl_core::{FslValue, TraceAction, TraceStep, state_summary, trace_json};
     use fsl_verifier::{BmcResult, BmcViolation, LeadsToViolation};
 
     const TEST_SOLVER_VERSION: &str = "Z3 4.16.0.0";
@@ -973,5 +973,111 @@ mod tests {
             !changes.contains_key("job"),
             "whole-struct key must not appear, got {changes:?}"
         );
+    }
+
+    #[test]
+    fn nested_option_trace_matches_native_encoding() {
+        let model = model_from(
+            "spec NestedOption {
+               type Bit = 0..1
+               state { x: Option<Option<Bit>> }
+               init { x = none }
+               action wrap() { x = some(none) }
+               action fill() { x = some(some(1)) }
+             }",
+        );
+        let trace = vec![
+            TraceStep {
+                step: 0,
+                state: BTreeMap::from([("x".to_owned(), FslValue::None)]),
+                action: None,
+                changes: BTreeMap::new(),
+            },
+            TraceStep {
+                step: 1,
+                state: BTreeMap::from([("x".to_owned(), FslValue::Some(Box::new(FslValue::None)))]),
+                action: Some(TraceAction {
+                    name: "wrap".to_owned(),
+                    params: BTreeMap::new(),
+                }),
+                changes: BTreeMap::new(),
+            },
+            TraceStep {
+                step: 2,
+                state: BTreeMap::from([(
+                    "x".to_owned(),
+                    FslValue::Some(Box::new(FslValue::Some(Box::new(FslValue::Int(1))))),
+                )]),
+                action: Some(TraceAction {
+                    name: "fill".to_owned(),
+                    params: BTreeMap::new(),
+                }),
+                changes: BTreeMap::new(),
+            },
+        ];
+
+        let worker = trace_json(&model, &trace);
+        let native = fslc_rust::trace_json(&model, &trace);
+        assert_eq!(worker, native);
+        assert_eq!(worker[1]["state"]["x"], json!({"kind":"some","value":null}));
+        assert_eq!(worker[2]["state"]["x"], json!({"kind":"some","value":1}));
+        assert_eq!(
+            worker[1]["changes"],
+            json!({"x":{"from":null,"to":{"kind":"some","value":null}}})
+        );
+        assert_eq!(
+            worker[2]["changes"],
+            json!({"x":{"from":{"kind":"some","value":null},"to":{"kind":"some","value":1}}})
+        );
+        assert_eq!(state_summary(&model, &trace[1].state), "x=some(none)");
+        assert_eq!(state_summary(&model, &trace[2].state), "x=some(some(1))");
+
+        let struct_model = model_from(
+            "spec StructFields {
+               struct Packet { kind: Int, value: Int }
+               state { packet: Packet }
+               init { packet = Packet { kind: 0, value: 0 } }
+             }",
+        );
+        let struct_trace = vec![
+            TraceStep {
+                step: 0,
+                state: BTreeMap::from([(
+                    "packet".to_owned(),
+                    FslValue::Struct {
+                        type_name: "Packet".to_owned(),
+                        fields: BTreeMap::from([
+                            ("kind".to_owned(), FslValue::Int(0)),
+                            ("value".to_owned(), FslValue::Int(0)),
+                        ]),
+                    },
+                )]),
+                action: None,
+                changes: BTreeMap::new(),
+            },
+            TraceStep {
+                step: 1,
+                state: BTreeMap::from([(
+                    "packet".to_owned(),
+                    FslValue::Struct {
+                        type_name: "Packet".to_owned(),
+                        fields: BTreeMap::from([
+                            ("kind".to_owned(), FslValue::Int(1)),
+                            ("value".to_owned(), FslValue::Int(1)),
+                        ]),
+                    },
+                )]),
+                action: Some(TraceAction {
+                    name: "write".to_owned(),
+                    params: BTreeMap::new(),
+                }),
+                changes: BTreeMap::new(),
+            },
+        ];
+        let rendered = trace_json(&struct_model, &struct_trace);
+        assert_eq!(rendered[1]["state"]["packet"], json!({"kind":1,"value":1}));
+        assert!(rendered[1]["changes"].get("packet[kind]").is_some());
+        assert!(rendered[1]["changes"].get("packet[value]").is_some());
+        assert!(rendered[1]["changes"].get("packet").is_none());
     }
 }

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -16114,6 +16114,26 @@ fn snapshot_value(
         TypeRef::Option(inner) => {
             if value.is_null() {
                 Ok(FslValue::None)
+            } else if matches!(inner.as_ref(), TypeRef::Option(_)) {
+                let object = value.as_object().ok_or_else(|| {
+                    format!(
+                        "{path} nested Option must be null or {{\"kind\":\"some\",\"value\":...}}"
+                    )
+                })?;
+                if object.len() != 2
+                    || object.get("kind") != Some(&Value::String("some".to_owned()))
+                    || !object.contains_key("value")
+                {
+                    return Err(format!(
+                        "{path} nested Option must be null or {{\"kind\":\"some\",\"value\":...}}"
+                    ));
+                }
+                Ok(FslValue::Some(Box::new(snapshot_value(
+                    model,
+                    inner,
+                    object.get("value").expect("checked value key"),
+                    path,
+                )?)))
             } else {
                 Ok(FslValue::Some(Box::new(snapshot_value(
                     model, inner, value, path,

--- a/rust/fslc/tests/fixtures/nested_option_replay.fsl
+++ b/rust/fslc/tests/fixtures/nested_option_replay.fsl
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+spec NestedOptionReplay {
+  type Bit = 0..1
+  state { x: Option<Option<Bit>> }
+  init { x = none }
+  action wrap() {
+    requires x == none
+    x = some(none)
+  }
+  action fill() {
+    requires x == some(none)
+    x = some(some(1))
+  }
+  action clear() {
+    requires x == some(some(1))
+    x = none
+  }
+}

--- a/rust/fslc/tests/kernel_contract.rs
+++ b/rust/fslc/tests/kernel_contract.rs
@@ -232,6 +232,18 @@ spec NestedOption {
             .any(|state| state["state"]["x"]["kind"] == "some")
     );
     assert!(
+        states
+            .iter()
+            .any(|state| { state["state"]["x"] == json!({"kind":"some","value":{"kind":"none"}}) }),
+        "conformance must preserve some(none): {states:#?}"
+    );
+    assert!(
+        states.iter().any(|state| {
+            state["state"]["x"] == json!({"kind":"some","value":{"kind":"some","value":1}})
+        }),
+        "conformance must preserve some(some(1)): {states:#?}"
+    );
+    assert!(
         output["vectors"]
             .as_array()
             .expect("vectors")

--- a/rust/fslc/tests/replay_trace_contract.rs
+++ b/rust/fslc/tests/replay_trace_contract.rs
@@ -213,6 +213,70 @@ fn public_v1_replays_complete_tick_ordered_observations() {
 }
 
 #[test]
+fn nested_option_state_round_trips_without_flattening() {
+    let trace = json!({
+        "$schema": fsl_core::REPLAY_TRACE_V1_SCHEMA_ID,
+        "schema_version": fsl_core::REPLAY_TRACE_V1_SCHEMA_VERSION,
+        "kernel_schema_version": fsl_core::KERNEL_SCHEMA_VERSION,
+        "spec": "NestedOptionReplay",
+        "initial": {"x": null},
+        "events": [
+            {"tick": 1, "action": "wrap", "params": {},
+             "state": {"x": {"kind": "some", "value": null}}},
+            {"tick": 2, "action": "fill", "params": {},
+             "state": {"x": {"kind": "some", "value": 1}}},
+            {"tick": 3, "action": "clear", "params": {}, "state": {"x": null}}
+        ]
+    });
+    let path = write_trace(&trace);
+    let output = replay_spec_path(&fixture("nested_option_replay.fsl"), &path);
+    std::fs::remove_file(&path).expect("remove trace");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(json(&output)["final_state"], json!({"x": null}));
+
+    let mut rejected = trace.clone();
+    rejected["events"]
+        .as_array_mut()
+        .expect("events")
+        .truncate(1);
+    rejected["events"]
+        .as_array_mut()
+        .expect("events")
+        .push(json!({
+            "tick": 2,
+            "action": "wrap",
+            "params": {},
+            "state": {"x": {"kind": "some", "value": null}}
+        }));
+    let path = write_trace(&rejected);
+    let output = replay_spec_path(&fixture("nested_option_replay.fsl"), &path);
+    std::fs::remove_file(path).expect("remove trace");
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        json(&output)["state_before"],
+        json!({"x": {"kind":"some","value":null}})
+    );
+
+    for (label, nested_value) in [
+        ("untagged", json!(1)),
+        ("missing", json!({"kind":"some"})),
+        ("extra", json!({"kind":"some","value":1,"extra":true})),
+    ] {
+        let mut malformed = trace.clone();
+        malformed["events"][1]["state"]["x"] = nested_value;
+        let path = write_trace(&malformed);
+        let output = replay_spec_path(&fixture("nested_option_replay.fsl"), &path);
+        std::fs::remove_file(path).expect("remove trace");
+        assert_eq!(output.status.code(), Some(2), "{label}");
+        assert_eq!(json(&output)["kind"], "io", "{label}");
+    }
+}
+
+#[test]
 fn well_typed_observed_state_divergence_is_nonconformant_with_leaf_evidence() {
     let output = replay("replay_trace.state-mismatch.v1.json");
     assert_eq!(output.status.code(), Some(1));

--- a/rust/fslc/tests/testgen_contract.rs
+++ b/rust/fslc/tests/testgen_contract.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use serde_json::json;
 use sha2::{Digest, Sha256};
 
 static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(0);
@@ -94,6 +95,39 @@ fn all_six_public_kernel_targets_match_the_pre_migration_goldens() {
             "{target} output changed"
         );
     }
+}
+
+#[test]
+fn nested_option_expected_state_is_lossless() {
+    let source = r#"
+spec NestedOptionTestgen {
+  type Bit = 0..1
+  state { x: Option<Option<Bit>> }
+  init { x = none }
+  action wrap() { requires x == none  x = some(none) }
+  action fill() { requires x == some(none)  x = some(some(1)) }
+  action clear() { requires x == some(some(1))  x = none }
+}
+"#;
+    let kernel = fsl_core::parse_kernel_source(source, &fsl_core::FsResolver::new("."))
+        .expect("parse nested Option testgen model");
+    let model = fsl_core::build_model(kernel).expect("build nested Option testgen model");
+    let fslc_rust::TestgenWalk::Clean(trace) =
+        fslc_rust::testgen_trace_vectors(&model).expect("generate nested Option testgen trace")
+    else {
+        panic!("nested Option cycle must not violate");
+    };
+
+    assert_eq!(trace["initial"], json!({"x": null}));
+    assert_eq!(
+        trace["steps"][0]["expected"],
+        json!({"x": {"kind":"some","value":null}})
+    );
+    assert_eq!(
+        trace["steps"][1]["expected"],
+        json!({"x": {"kind":"some","value":1}})
+    );
+    assert_eq!(trace["steps"][2]["expected"], json!({"x": null}));
 }
 
 #[test]

--- a/rust/fslc/tests/testgen_contract.rs
+++ b/rust/fslc/tests/testgen_contract.rs
@@ -99,7 +99,7 @@ fn all_six_public_kernel_targets_match_the_pre_migration_goldens() {
 
 #[test]
 fn nested_option_expected_state_is_lossless() {
-    let source = r#"
+    let source = r"
 spec NestedOptionTestgen {
   type Bit = 0..1
   state { x: Option<Option<Bit>> }
@@ -108,7 +108,7 @@ spec NestedOptionTestgen {
   action fill() { requires x == some(none)  x = some(some(1)) }
   action clear() { requires x == some(some(1))  x = none }
 }
-"#;
+";
     let kernel = fsl_core::parse_kernel_source(source, &fsl_core::FsResolver::new("."))
         .expect("parse nested Option testgen model");
     let model = fsl_core::build_model(kernel).expect("build nested Option testgen model");


### PR DESCRIPTION
## Problem

#841 の PR2。設計 `docs/DESIGN-nested-option-support.md` §5 が述べるとおり:

> Full language support is incomplete if engines distinguish `none` from `some(none)`
> internally but ordinary traces, generated harnesses, or replay collapse them.

PR1(#923、`de829b3`)で typed boundary と3エンジン意味論は入ったが、**通常の JSON では
`none` と `some(none)` がどちらも `null` になり**、replay は `null` を外側の `None` として
デコードしていた。

## Contract change(設計 §5 の規範表を実装)

| 論理値 | 正規 JSON |
|---|---|
| `Option<T> = none` | `null` |
| `Option<T> = some(1)` | `1` |
| `Option<Option<T>> = none` | `null` |
| `Option<Option<T>> = some(none)` | `{"kind":"some","value":null}` |
| `Option<Option<T>> = some(some(1))` | `{"kind":"some","value":1}` |

**タグは宣言された payload 自身が `Option` のときにだけ入る。** デコードは型駆動で、
`Option<Option<_>>` は `null` か厳密に閉じた `{kind:"some", value:…}` のみ受理する。

触った面(設計 §6 の結合面):`rust/fsl-core/src/trace_json.rs`(+133、正規エンコードと
型駆動デコード)/ `rust/fsl-wasm/src/lib.rs`(+108、Worker projection)/
`rust/fslc/src/main.rs`(+20、replay デコード)。

## Test evidence

### オーケストレーターによる独立検証(実 trace で規範表を確認)

`Option<Option<Bit>>` を `none → some(none) → some(some(1))` と遷移させた反例 trace:

```json
[{"step":0,"state":{"x":null}},
 {"step":1,"state":{"x":{"kind":"some","value":null}},
  "changes":{"x":{"from":null,"to":{"kind":"some","value":null}}}},
 {"step":2,"state":{"x":{"kind":"some","value":1}},
  "changes":{"x":{"from":{"kind":"some","value":null},"to":{"kind":"some","value":1}}}}]
```

**3つの値が設計の表と完全一致し、変化パスは論理 state パス `x` のまま**(`x[kind]` や
`x[value]` に分解されていない)。

**既存 `Option<scalar>` のバイト列不変** — `Option<Bit>` の trace は `[{"y":null},{"y":1}]` で
タグが入らない。

**設計が警告した罠を実際に突いた** — `struct Rec { kind: Bit, value: Bit }` を state に置いた spec で:

| 対象 | 変化パス | 判定 |
|---|---|---|
| struct `Rec { kind, value }` | **`r[kind]`** に分解 | 通常の struct として降下 |
| `Option<Option<Bit>>` | **`x`** のまま(原子的) | Option として扱われる |

同じフィールド名でも型付き走査で区別されている。**フィールド名で Option タグを判定する実装なら
`r` が原子化され、この対照が落ちる。**

### ワーカー側の検証(設計 §8 の要求どおり)

- 4つの focused control を**各2回** → すべて exit 0
- 既存6 target の `Option<scalar>` golden → exit 0(バイト列不変の証明)
- **検出器の校正**: flattening 変異で replay / testgen / Worker が、期待
  `{"kind":"some","value":null}` に対し **produced `null`** となり exit 101 で失敗。
  復元は source SHA-256 一致で証明
- `./tools/check-native-integration.sh fsl-logic pr` → **exit 0(16 cases)**

### マージ後の再確認(`origin/main` = `7bcb12b` 取り込み後、いずれも exit 0)

`kernel_contract` 19 passed / `replay_trace_contract` 15 passed / `testgen_contract` 5 passed /
`fsl-wasm` 10 passed。

## Scope

**PR3(規範文書と結合面)と PR4(校正済みクロスエンジン対照)は含めない。** 設計が4本に分けている。
conformance-vector 形式は**別の versioned contract**なので設計の指示どおり触っていない。

changelog fragment は `fixed`(既存3件は PR1 と設計のもの。`changelog.d/README.md` が同一
(id, category) の重複を禁じている)。修正した欠陥は「`none` と `some(none)` がどちらも `null` に
なる」ことなので `fixed` が正確。

## Linked issue

Part of #841. PR1: #923。設計: #916(`docs/DESIGN-nested-option-support.md` §5 / §7.3 / §7.4 / §8)。
