### PR TITLE
test(wasm): compare Worker error envelopes against native instead of pinning them separately

### DIFF
--- a/changelog.d/810-worker-error-envelope-parity.required.md
+++ b/changelog.d/810-worker-error-envelope-parity.required.md
@@ -1,2 +1,2 @@
-Required (#810): native/Worker error-envelope comparisons now cover AI-project parse,
-guard, and name failures with a calibrated one-sided rejecting control.
+Required (#810): native/Worker error-envelope comparisons now cover AI-project and
+surface parsing, guard, and name failures with calibrated one-sided rejecting controls.

--- a/changelog.d/810-worker-error-envelope-parity.required.md
+++ b/changelog.d/810-worker-error-envelope-parity.required.md
@@ -1,0 +1,2 @@
+Required (#810): native/Worker error-envelope comparisons now cover AI-project parse,
+guard, and name failures with a calibrated one-sided rejecting control.

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -99,14 +99,10 @@ fn implements_error(
     solver_version: &str,
     failure: &fslc_rust::verification_output::RequirementsImplementsError,
 ) -> Value {
-    let mut output = error(solver_version, "type", &failure.message);
-    if let Some(span) = failure.span
-        && let Some(object) = output.as_object_mut()
-    {
-        object.insert("loc".to_owned(), span.python_loc());
-        object.insert("span".to_owned(), json!(span));
-    }
-    output
+    fslc_rust::verification_output::render_requirements_implements_error(
+        envelope(solver_version),
+        failure,
+    )
 }
 
 /// Render a solver or verifier failure, which names no construct in the source:
@@ -610,6 +606,107 @@ mod tests {
         .0
     }
 
+    /// Render the native check path's error payload with the Worker-owned
+    /// delivery metadata. The metadata is deliberately shared here so the
+    /// comparison has no excluded output fields; it is not a native identity
+    /// assertion (`versions.verifier` necessarily names `fsl-wasm`).
+    fn native_check_error(request: &Request, solver_version: &str) -> Value {
+        if let Some((output, status)) = fslc_rust::frontend_output::ai_project_check_output(
+            &request.source,
+            &request.source_file,
+            envelope(solver_version),
+        ) {
+            assert_eq!(status, 2, "test fixture must be a failing AI project");
+            return output;
+        }
+        let resolver = MemoryResolver {
+            files: request.files.clone(),
+        };
+        let diagnostic = fslc_rust::source_diagnostic::diagnostics(
+            &request.source,
+            &request.source_file,
+            &resolver,
+        )
+        .into_iter()
+        .find(|diagnostic| diagnostic.kind != "migration")
+        .expect("test fixture must fail native source diagnostics");
+        fslc_rust::verification_output::render_semantic_error(
+            envelope(solver_version),
+            &diagnostic.message,
+            diagnostic.located.then(|| diagnostic.span.python_loc()),
+            diagnostic.kind == "name",
+        )
+    }
+
+    fn assert_worker_check_error_matches_native(request: &Request, fixture: &str) {
+        let worker = block_on(check(request, TEST_SOLVER_VERSION));
+        let native = native_check_error(request, TEST_SOLVER_VERSION);
+        assert_eq!(
+            worker, native,
+            "Worker/native error envelope diverged for {fixture}"
+        );
+    }
+
+    fn native_governance_error(request: &Request, solver_version: &str) -> Value {
+        let resolver = MemoryResolver {
+            files: request.files.clone(),
+        };
+        let failure = fslc_rust::verification_output::governance_output(
+            &request.source,
+            &resolver,
+            |preservation| {
+                let error = resolver
+                    .read(&preservation.after_path)
+                    .expect_err("fixture must leave governance dependency absent");
+                Err(governance_error(error.to_string(), preservation.span))
+            },
+        )
+        .expect_err("fixture must fail native governance output");
+        fslc_rust::verification_output::render_governance_error(envelope(solver_version), &failure)
+    }
+
+    fn assert_worker_governance_error_matches_native(request: &Request, fixture: &str) {
+        let worker = block_on(check(request, TEST_SOLVER_VERSION));
+        let native = native_governance_error(request, TEST_SOLVER_VERSION);
+        assert_eq!(
+            worker, native,
+            "Worker/native governance error diverged for {fixture}"
+        );
+    }
+
+    fn native_implements_error(request: &Request, solver_version: &str) -> Value {
+        let resolver = MemoryResolver {
+            files: request.files.clone(),
+        };
+        let kernel = fsl_core::parse_kernel_source_with_file(
+            &request.source,
+            &resolver,
+            &request.source_file,
+        )
+        .expect("fixture must lower before its implements failure");
+        let model = fsl_core::build_model(kernel).expect("fixture must build before implements");
+        let failure = fslc_rust::verification_output::requirements_implements_output(
+            &request.source,
+            &resolver,
+            &model,
+            8,
+        )
+        .expect_err("fixture must fail native implements output");
+        fslc_rust::verification_output::render_requirements_implements_error(
+            envelope(solver_version),
+            &failure,
+        )
+    }
+
+    fn assert_worker_implements_error_matches_native(request: &Request, fixture: &str) {
+        let worker = block_on(check(request, TEST_SOLVER_VERSION));
+        let native = native_implements_error(request, TEST_SOLVER_VERSION);
+        assert_eq!(
+            worker, native,
+            "Worker/native implements error diverged for {fixture}"
+        );
+    }
+
     #[test]
     fn build_rejects_duplicate_action_writes() {
         let request = Request {
@@ -620,34 +717,45 @@ mod tests {
             options: Options::default(),
         };
 
-        let error = build(&request, TEST_SOLVER_VERSION)
+        let worker = build(&request, TEST_SOLVER_VERSION)
             .expect_err("duplicate write must fail in Worker build");
-
-        assert_eq!(error["kind"], json!("semantics"));
-        assert!(
-            error["message"]
-                .as_str()
-                .is_some_and(|message| message.contains("same state location"))
+        let native = native_check_error(&request, TEST_SOLVER_VERSION);
+        assert_eq!(
+            worker, native,
+            "Worker/native duplicate-write envelope diverged"
         );
     }
 
     #[test]
-    fn check_preserves_ai_project_parser_location_and_code() {
-        let request = Request {
-            cmd: "check".to_owned(),
-            source: include_str!("../../fslc/tests/fixtures/error_envelope_broken_ai_project.fsl")
-                .to_owned(),
-            source_file: "broken_ai_project.fsl".to_owned(),
-            files: BTreeMap::new(),
-            options: Options::default(),
-        };
-
-        let error = block_on(check(&request, TEST_SOLVER_VERSION));
-
-        assert_eq!(error["result"], json!("error"));
-        assert_eq!(error["kind"], json!("parse"));
-        assert_eq!(error["diagnostic_code"], json!("FSL-PARSE"));
-        assert_eq!(error["loc"], json!({"line": 9, "column": 3}));
+    fn check_error_envelopes_match_native_across_parse_guard_and_name() {
+        for (fixture, source, source_file) in [
+            (
+                "AI project parse",
+                include_str!("../../fslc/tests/fixtures/error_envelope_broken_ai_project.fsl"),
+                "broken_ai_project.fsl",
+            ),
+            (
+                "domain guard",
+                include_str!("../../fslc/tests/fixtures/domain_await_routing_rejected.fsl"),
+                "await_routing_rejected.fsl",
+            ),
+            (
+                "domain name",
+                include_str!(
+                    "../../fslc/tests/fixtures/domain_characterization/invalid_unknown_name.fsl"
+                ),
+                "invalid_unknown_name.fsl",
+            ),
+        ] {
+            let request = Request {
+                cmd: "check".to_owned(),
+                source: source.to_owned(),
+                source_file: source_file.to_owned(),
+                files: BTreeMap::new(),
+                options: Options::default(),
+            };
+            assert_worker_check_error_matches_native(&request, fixture);
+        }
     }
 
     #[test]
@@ -661,16 +769,7 @@ mod tests {
             options: Options::default(),
         };
 
-        let error = block_on(check(&request, TEST_SOLVER_VERSION));
-
-        assert_eq!(error["result"], json!("error"));
-        assert_eq!(error["kind"], json!("type"));
-        assert_eq!(error["loc"], json!({"line": 4, "column": 3}));
-        assert!(
-            error["message"]
-                .as_str()
-                .is_some_and(|message| message.contains("governance preservation missing before"))
-        );
+        assert_worker_governance_error_matches_native(&request, "missing governance before");
     }
 
     #[test]
@@ -684,16 +783,7 @@ mod tests {
             options: Options::default(),
         };
 
-        let error = block_on(check(&request, TEST_SOLVER_VERSION));
-
-        assert_eq!(error["result"], json!("error"));
-        assert_eq!(error["kind"], json!("type"));
-        assert_eq!(error["loc"], json!({"line": 6, "column": 5}));
-        assert!(
-            error["message"]
-                .as_str()
-                .is_some_and(|message| message.contains("missing-before.fsl"))
-        );
+        assert_worker_governance_error_matches_native(&request, "missing governance dependency");
     }
 
     #[test]
@@ -721,17 +811,7 @@ mod tests {
             options: Options::default(),
         };
 
-        let failure = block_on(check(&request, TEST_SOLVER_VERSION));
-
-        assert_eq!(failure["result"], "error");
-        assert_eq!(failure["kind"], "type");
-        assert_eq!(failure["loc"], json!({"line": 3, "column": 5}));
-        assert!(failure["span"].is_object());
-        assert!(
-            failure["message"]
-                .as_str()
-                .is_some_and(|message| message.contains("missing source: [B]"))
-        );
+        assert_worker_implements_error_matches_native(&request, "inline enum conversion");
     }
 
     #[test]
@@ -777,14 +857,8 @@ mod tests {
             "{wrong}"
         );
 
-        let incomplete = block_on(check(
-            &request(source.replace(" C -> Y", "")),
-            TEST_SOLVER_VERSION,
-        ));
-        assert_eq!(incomplete["result"], "error", "{incomplete}");
-        assert_eq!(incomplete["kind"], "type", "{incomplete}");
-        assert_eq!(incomplete["loc"], json!({"line": 3, "column": 5}));
-        assert!(incomplete["span"].is_object(), "{incomplete}");
+        let incomplete = request(source.replace(" C -> Y", ""));
+        assert_worker_implements_error_matches_native(&incomplete, "incomplete enum abstraction");
     }
 
     #[test]

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -9,10 +9,17 @@ use serde::Deserialize;
 use serde_json::{Map, Value, json};
 use wasm_bindgen::prelude::*;
 
+#[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_namespace = performance, js_name = now)]
     fn performance_now() -> f64;
+}
+
+/// Native unit tests exercise pre-solver error paths without a browser clock.
+#[cfg(not(target_arch = "wasm32"))]
+const fn performance_now() -> f64 {
+    0.0
 }
 
 #[derive(Debug, Deserialize)]
@@ -619,6 +626,14 @@ mod tests {
             assert_eq!(status, 2, "test fixture must be a failing AI project");
             return output;
         }
+        if let Err(failure) =
+            fsl_syntax::parse_document(fsl_syntax::SourceFile::new(&request.source))
+        {
+            return fslc_rust::frontend_output::render_surface_parse_error(
+                envelope(solver_version),
+                &failure,
+            );
+        }
         let resolver = MemoryResolver {
             files: request.files.clone(),
         };
@@ -644,6 +659,21 @@ mod tests {
         assert_eq!(
             worker, native,
             "Worker/native error envelope diverged for {fixture}"
+        );
+    }
+
+    fn native_verify_surface_parse_error(request: &Request, solver_version: &str) -> Value {
+        let failure = fsl_syntax::parse_surface_document(&request.source)
+            .expect_err("fixture must fail native verify surface parsing");
+        fslc_rust::frontend_output::render_surface_parse_error(envelope(solver_version), &failure)
+    }
+
+    fn assert_worker_verify_surface_parse_error_matches_native(request: &Request, fixture: &str) {
+        let worker = block_on(verify(request, TEST_SOLVER_VERSION));
+        let native = native_verify_surface_parse_error(request, TEST_SOLVER_VERSION);
+        assert_eq!(
+            worker, native,
+            "Worker/native verify surface-parse envelope diverged for {fixture}"
         );
     }
 
@@ -735,6 +765,11 @@ mod tests {
                 "broken_ai_project.fsl",
             ),
             (
+                "surface parse",
+                include_str!("../../../examples/gallery/errors/parse_missing_expression.fsl"),
+                "parse_missing_expression.fsl",
+            ),
+            (
                 "domain guard",
                 include_str!("../../fslc/tests/fixtures/domain_await_routing_rejected.fsl"),
                 "await_routing_rejected.fsl",
@@ -756,6 +791,19 @@ mod tests {
             };
             assert_worker_check_error_matches_native(&request, fixture);
         }
+    }
+
+    #[test]
+    fn verify_surface_parse_error_envelope_matches_native() {
+        let request = Request {
+            cmd: "verify".to_owned(),
+            source: include_str!("../../../examples/gallery/errors/parse_missing_expression.fsl")
+                .to_owned(),
+            source_file: "parse_missing_expression.fsl".to_owned(),
+            files: BTreeMap::new(),
+            options: Options::default(),
+        };
+        assert_worker_verify_surface_parse_error_matches_native(&request, "surface parse");
     }
 
     #[test]

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -14907,10 +14907,7 @@ fn implements_result_from_source(
 fn implements_error_output(
     error: &fslc_rust::verification_output::RequirementsImplementsError,
 ) -> Value {
-    error.span.map_or_else(
-        || error_output("type", &error.message),
-        |span| located_error_output("type", &error.message, span),
-    )
+    fslc_rust::verification_output::render_requirements_implements_error(envelope(), error)
 }
 
 fn mismatch_paths(

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -38,6 +38,25 @@ impl fmt::Display for RequirementsImplementsError {
 
 impl std::error::Error for RequirementsImplementsError {}
 
+/// Render a requirements `implements` diagnostic using the public JSON contract.
+///
+/// The caller supplies its delivery-surface metadata in `output`; the failure
+/// fields themselves are identical for native and browser entry points.
+#[must_use]
+pub fn render_requirements_implements_error(
+    mut output: Map<String, Value>,
+    error: &RequirementsImplementsError,
+) -> Value {
+    output.insert("result".to_owned(), json!("error"));
+    output.insert("kind".to_owned(), json!("type"));
+    output.insert("message".to_owned(), json!(error.message));
+    if let Some(span) = error.span {
+        output.insert("loc".to_owned(), span.python_loc());
+        output.insert("span".to_owned(), json!(span));
+    }
+    Value::Object(output)
+}
+
 /// Why a requirements step could not be replayed across semantic-diff models.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RequirementStepRelationError {


### PR DESCRIPTION
## Problem

Closes #810.(M18)

`AGENTS.md` は native CLI と Worker の出力一致を不変条件にしている:

> Native CLI and Worker output must preserve the JSON envelope, exit codes, locations, and
> replayable evidence contract.

しかし**機械的に強制するものが無かった**。両側が同じ fixture に対して**それぞれ自分の期待値を
pin する**ので、片方が正当な理由で変わっても他方は古い値を主張し続け、**両方のスイートが緑のまま
封筒が乖離する**。

## 起票時の前提の訂正

issue は「`fsl-wasm` cannot import `fslc`'s envelope construction, so a comparison test is a design
change rather than a bug fix」を理由に、比較テストを設計変更として範囲外に置いた。**その前提は
現 HEAD では成り立たない**:

- `rust/fsl-wasm/Cargo.toml:20` に `fslc-rust = { path = "../fslc", default-features = false }` が
  **通常依存として存在する**(`[dev-dependencies]` ではない)。この PR が追加したものではない。
- 先例もあった。PR #936(#841 PR2)の `nested_option_trace_matches_native_encoding` が
  `assert_eq!(worker, native)` で trace 投影を比較している。

したがって設計変更ではなく、**先例に倣った実装**として実施した。

## Contract change

Worker 側の error 封筒テストを、**期待値の pin から native との全体比較へ移行**した。
4つの比較ヘルパを置いた:

| ヘルパ | 覆う経路 |
|---|---|
| `assert_worker_check_error_matches_native`(`:656`) | `check` の surface parse / AI project parse / build error |
| `assert_worker_verify_surface_parse_error_matches_native`(`:671`) | `verify` の surface parse |
| `assert_worker_governance_error_matches_native`(`:698`) | `check` の governance failure |
| `assert_worker_implements_error_matches_native`(`:731`) | `check` の implements failure |

いずれも **`assert_eq!(worker, native)` の全体比較**であり、手で選んだフィールド一覧ではない。
issue は `result` / `kind` / `loc` / `diagnostic_code` / exit status を挙げていたが、
**手選びは逆方向の2実装を両方通す**(#801 / PR #918 で実証済み)ため全体比較にした。

implements error renderer は両側で共有化した。

## Test evidence

### オーケストレーターによる独立の負対照(2回。1回目で穴が出た)

**1回目 — 穴を検出した。** `check` の surface-parse 経路(`render_surface_parse_error`)の
`diagnostic_code` を **Worker 側だけ** `"FSL-ORCHESTRATOR-MUTANT"` に差し替えた:

| 項目 | 結果 |
|---|---|
| 変異の適用 | `lib.rs` の SHA-256 が `664910eb…` → `491d39e8…` |
| コンパイル | ログに `Compiling fsl-wasm v4.4.1` |
| `cargo test -p fsl-wasm` | **exit 0**(比較テストも ok)= **検出できていない** |
| 復元 | SHA-256 が baseline に一致、`git diff` 空 |

原因は fixture の選択だった。`Parse` と名付けられたセルが
`error_envelope_broken_ai_project.fsl` を使っており、`check` は **AI-project 経路で先に return**
するため `render_surface_parse_error` に到達していなかった。**ラベルが `Parse` でありながら
surface parse を通っていない**状態で、このリポジトリが言う「detector と称する preservation
control」に近い。

**2回目 — 修正後は検出する。** 同じ変異を再適用:

```
MUTATED exit: 101
check_error_envelopes_match_native_across_parse_guard_and_name ... FAILED
  "Worker/native error envelope diverged for surface parse"
  produced diagnostic_code: "FSL-ORCHESTRATOR-MUTANT"   (期待は "FSL-PARSE")
```

セル名に `surface parse` が出ているので、**追加されたセルが実際にその経路を通っている**。
復元は SHA-256 一致(`438ae3ea…`)と空 `git diff` で証明し、復元後 11 passed / exit 0。

### ワーカー側の負対照

Worker のみ `FSL-MUTATED` にすると native の `FSL-PARSE` と不一致になり exit 101 で検出。
復元は snapshot SHA-256 完全一致。

### 検証(いずれも exit 0)

`cargo test -p fsl-wasm`(11 passed、変更 control は復元後2回)/
`cargo test -p fslc-rust --test error_envelope_parity`(23 passed)/ `cargo fmt --check` /
**workspace Clippy `--all-targets` `-D warnings`** / changelog fragment check。

## Scope — 未被覆経路は #937 に記録した

`check` / `verify` の**全ての**失敗 return 経路は覆えていない。覆えていない4経路を
**経路名で**列挙して **#937** に起票した(`check` requirement trace、`verify` build/trace/
deadlock-option、`verify` boundary/verifier/replay/reachable、`verify` implements)。
うち `verify` boundary 系は **native CLI の総合 verify API が非公開**のため、
別の fixture / API 設計が必要で、この PR の範囲を越える。

**「比較ゲートがある」ことは「その経路が比較されている」ことを意味しない** — 上の1回目の
負対照がそれを実証した。#937 はその穴を追跡する。

## Linked issue

Closes #810. Follow-up: #937。関連: #807(Worker 単独 pin の起点)、#781(native 側の
失敗クラス × コマンド matrix、クローズ済み)、#936(比較の先例)。
