### PR TITLE
docs(replay): document nested Option replay values and supersede the old rejection

### DIFF
--- a/docs/DESIGN-option-struct.md
+++ b/docs/DESIGN-option-struct.md
@@ -8,9 +8,10 @@ introduced.
 ## 1. Language specification changes
 
 - Types allowed for struct fields: scalar (Int / Bool / domain type / enum) **plus
-  `Option<scalar>`**. Set / Map / Seq / struct / `Option<Option<…>>` continue to be
-  rejected at check time (the hint is updated to reflect "or use Option<scalar>" added
-  to the current wording).
+  `Option<scalar>`**. Set / Map / Seq / struct continue to be rejected at check
+  time (the hint is updated to reflect "or use Option<scalar>" added to the
+  current wording). At v2.1, `Option<Option<…>>` was also rejected; that
+  rejection is superseded by the accepted #841 recursive nested-Option design.
 - Expressions and statements use the same vocabulary as scalar Option:
   `s.v == none` / `!= none` / `s.v == some(e)` / `!= some(e)` /
   `s.v is some(x)`, `s.v = some(e)` / `= none`, and literals

--- a/docs/DESIGN-replay-trace.md
+++ b/docs/DESIGN-replay-trace.md
@@ -48,8 +48,24 @@ canonical sequence `1..N`, `action` is either an exact Public Kernel action name
 or the v1.1 stutter value `null`, and `state` is the complete resulting logical
 state. Action parameters are exact; stutter requires the empty object `{}`.
 State values use the ordinary Monitor/Public Kernel representation: enum member
-strings, `null`/value for Option, objects for struct and complete Map values,
-arrays for Set/Seq, and pair arrays for relations.
+strings, objects for struct and complete Map values, arrays for Set/Seq, and
+pair arrays for relations. Option values use this canonical, type-directed
+encoding:
+
+| Logical value | Canonical ordinary JSON |
+|---|---|
+| `Option<T> = none` | `null` |
+| `Option<T> = some(1)` | `1` |
+| `Option<Option<T>> = none` | `null` |
+| `Option<Option<T>> = some(none)` | `{"kind":"some","value":null}` |
+| `Option<Option<T>> = some(some(1))` | `{"kind":"some","value":1}` |
+
+An Option value is tagged only when its declared payload is itself an Option;
+therefore every previously supported `Option<scalar>` value retains its
+`null`/value bytes. This ordinary replay representation is distinct from the
+fully tagged, versioned conformance-vector contract, which continues to use
+`{"kind":"none"}` and `{"kind":"some","value":...}` for every Option
+layer as specified in [`DESIGN-kernel-contract.md`](DESIGN-kernel-contract.md).
 
 `timestamp` is optional, non-empty, opaque producer metadata. Replay ignores it;
 it has no ordering, deadline, or formal-time meaning. Consumers use `tick` for


### PR DESCRIPTION
## Problem

#841 PR3。**設計 §8 の PR3 節をそのまま実装すると重複になる**ことが要求回復で分かったので、
スコープを実測で改訂した。

設計は「両言語リファレンス、skill リファレンス、共有診断テストを更新」と挙げているが、
**それらは PR1(#923、`de829b3`)で既に更新済み**である。設計が挙げる
「accepted design note を更新」もどの文言かを具体化していないため、勝手に足さない。

**実際に残っていたのは、マージ済みの挙動と矛盾している文書2件**である。これは #841 の題目
「`Option<Option<_>>` の契約が文書・`check`・`verify` で三者不一致」の**文書側の実体**にあたる。

## Contract change(文書のみ、+22/-5)

### 1. `docs/DESIGN-replay-trace.md`

ordinary replay 値を **`null`/値のみ**と記述していた。PR2(#936、`19abddc`)が
ordinary JSON に nested Option 用の hybrid tag を導入したので、**文書が古い挙動を述べていた**。

設計 §5 の規範表を記載し、あわせて3点を明記した:

| Logical value | Canonical ordinary JSON |
|---|---|
| `Option<T> = none` | `null` |
| `Option<T> = some(1)` | `1` |
| `Option<Option<T>> = none` | `null` |
| `Option<Option<T>> = some(none)` | `{"kind":"some","value":null}` |
| `Option<Option<T>> = some(some(1))` | `{"kind":"some","value":1}` |

- タグが入るのは**宣言された payload 自身が Option のときだけ**
- したがって**既存の `Option<scalar>` は `null`/値のバイト列を保持する**
- この ordinary 表現は、**fully tagged で versioned な conformance-vector 契約とは別物**
  (後者は全 Option 層で `{"kind":"none"}` / `{"kind":"some","value":...}` を使い続ける)

### 2. `docs/DESIGN-option-struct.md`

`Option<Option<…>>` を**拒否すると現在形で**記載していた。設計
(`docs/DESIGN-nested-option-support.md:318`)の指示どおり、**拒否文だけを supersede し、
v2.1 の履歴は書き換えていない**:

> At v2.1, `Option<Option<…>>` was also rejected; that rejection is superseded by the
> accepted #841 recursive nested-Option design.

## changelog fragment を作らない理由

既存の #841 fragment は `added` / `changed` / `documented` / `fixed` の4つで、
`changelog.d/README.md` は同一 (id, category) の重複を禁じている。

そのうえで**新規 fragment は不要**と判断した: PR2 の
`841-nested-option-lossless-json.fixed.md` が **同じ ordinary replay 挙動と legacy-byte
preservation を既に記録している**。本 PR はそのマージ済み挙動へ**文書を同期するだけ**であり、
新しい利用者可視の変更を導入しない。

## 変更不要の判断(設計が記録を要求している3面)

| 面 | 変更不要の理由 |
|---|---|
| LSP indexing(`rust/fsl-lsp/src/index.rs`) | nested Option は新しい宣言形・binder 形・参照形を導入しない。文書変更のみの本 PR では index に影響しない |
| dialect registry(`tests/dialect_registry.py`) | 新しい top-level 構文も新しい `examples/`/`specs/` ディレクトリも追加していない |
| frozen Python(`src/fslc`) | 設計 §6 の面25 が「No product behavior change」と述べている。site 生成器の利用は Python 言語意味論の変更ではない |

## Test evidence(設計 §8 の PR3 節そのまま。すべて exit 0)

- `python3 tools/build_site_reference.py` — 生成後、**追跡済み生成物に差分なし**
- `python3 -m pytest tests/test_site_reference_snapshot.py -v` — **×2、各 6 passed**
  (EN/JA のセクション数・順序・鮮度の required チェック)
- `cargo test -p fslc-rust --test lsp_diagnostic_contract` — **×2、各 1 passed**
- `env PATH="/opt/homebrew/bin:$PATH" bash ./tools/aggregate_changelog.sh check`
  (macOS 既定の bash 3.2 では動かないので Bash 4+ で実行)
- `cargo fmt --all -- --check`

同じコマンドが2回並んでいるのは設計自身の要求である。

**引用の解決も確認した**: `DESIGN-kernel-contract.md` へのリンクは同ディレクトリからの
document-relative で解決する(`test -f` で確認)。

## Linked issue

Part of #841。PR1: #923、PR2: #936。残りは PR4(校正済みクロスエンジン対照と fault operators)。
設計: `docs/DESIGN-nested-option-support.md` §5 / §8。
