### PR TITLE
docs(release): pin the promotion pull request head to the recorded candidate SHA

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -99,8 +99,12 @@ a feature-flag system solely to accommodate this flow.
 ## Promote main to production
 
 1. Verify `production` is an ancestor of, or can be merged cleanly with, `main`.
-2. Freeze the candidate by recording the exact `main` SHA in the promotion pull
-   request. If unrelated changes land, rerun the gate or replace the candidate.
+2. Freeze the candidate by recording the exact `main` SHA. Follow the canonical
+   pinned-head and pre-/post-merge tree-identity procedure in
+   `docs/RELEASE.md` §2, steps 3–4: create the candidate branch at that SHA,
+   use it as the promotion pull request head, and perform both identity checks.
+   Do not open a moving `main -> production` pull request. If unrelated changes
+   land, rerun the gate or replace the candidate.
 3. Confirm the release commit preparation is already on `main`:
    - bump `rust/Cargo.toml`'s workspace version and regenerate `rust/Cargo.lock`
      with Cargo; do not bump the frozen `pyproject.toml` package for a native
@@ -119,15 +123,18 @@ a feature-flag system solely to accommodate this flow.
    `workflow_dispatch` is non-publishing and must never attach Release assets, even for a tag ref. Add
    focused formal, mutation, platform, or compatibility evidence when the
    changed contract requires it.
-5. Open `main -> production`. State the candidate SHA, version, included changes,
-   known residual risk, exact gates, and artifact evidence.
-6. Merge without squashing away the promoted history. Verify the resulting
-   `production` tree matches the approved `main` tree. Record the new production
-   merge SHA; it is distinct from the gated candidate SHA unless promotion was a
-   true fast-forward.
+5. Open the promotion pull request from the pinned candidate branch to
+   `production`. State the candidate SHA, version, included changes, known
+   residual risk, exact gates, and artifact evidence.
+6. Complete the canonical checks in `docs/RELEASE.md` §2, step 4 before and
+   after merge. Record the new production merge SHA; it is distinct from the
+   gated candidate SHA unless promotion was a true fast-forward.
 
 Do not merge newer `main` work into an open promotion implicitly. Close or update
-the promotion and rerun its evidence against the new SHA.
+the promotion and rerun its evidence against the new SHA. Before the next
+promotion, also follow `docs/RELEASE.md` §2's required v4.4.1 carry-forward:
+explicitly reapply `docs/DESIGN-nested-option-support.md` and verify that it
+exists on `production` after merge.
 
 ## Cut the release
 

--- a/changelog.d/920-pinned-candidate-head.documented.md
+++ b/changelog.d/920-pinned-candidate-head.documented.md
@@ -1,0 +1,1 @@
+Documented (#920): release promotion pull requests now use a branch pinned to the approved candidate SHA, with tree-identity checks before and after merge and an explicit carry-forward for the v4.4.1 revert.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -170,12 +170,60 @@ It also rejects a dynamic dependency on `libz3`.
    all four native targets, the Agent Skill bundle, VS Code extension, and both
    Kernel bundles pass. Do not reuse evidence from a moving branch after its SHA
    changes.
-3. Open the release-promotion pull request from `main` to `production`, stating
-   the candidate SHA, version, changes, residual risk, gate results, and dry-run
-   URL.
-4. Merge without squashing away promoted history. Verify the resulting
-   `production` tree matches the approved `main` tree and record the new
-   `production` HEAD. Never tag `main`.
+3. Create a branch fixed at the recorded candidate SHA, then open the
+   release-promotion pull request from that branch to `production` — never from
+   moving `main`:
+
+   ```bash
+   git branch release/vX.Y.Z-candidate CANDIDATE_SHA
+   git push origin release/vX.Y.Z-candidate
+   ```
+
+   State the candidate SHA, version, changes, residual risk, gate results, and
+   dry-run URL in the pull request. This branch is required even when `main` is
+   currently at `CANDIDATE_SHA`: while promotion CI and review run, `main` can
+   advance, making its green result evidence for a tree nobody approved. The
+   pinned branch keeps the pull request head and its CI evidence bound to the
+   approved candidate.
+4. Before merging, verify that the promotion pull request's source branch still
+   resolves to the recorded candidate and that their trees are identical:
+
+   ```bash
+   git fetch origin "refs/heads/release/vX.Y.Z-candidate:refs/remotes/origin/release/vX.Y.Z-candidate"
+   test "$(git rev-parse origin/release/vX.Y.Z-candidate)" = "CANDIDATE_SHA"
+   test "$(git rev-parse origin/release/vX.Y.Z-candidate^{tree})" = "$(git rev-parse CANDIDATE_SHA^{tree})"
+   ```
+
+   Merge without squashing away promoted history. Then verify the resulting
+   `production` tree matches the approved candidate tree and record the new
+   `production` HEAD:
+
+   ```bash
+   git fetch origin "refs/heads/production:refs/remotes/origin/production"
+   test "$(git rev-parse origin/production^{tree})" = "$(git rev-parse CANDIDATE_SHA^{tree})"
+   git rev-parse origin/production
+   ```
+
+   Never tag `main`.
+
+The preceding promotion rule is canonical here; the release skill's `Promote
+main to production` procedure refers to these steps so there is one source of
+truth for the pinned-head and tree-identity requirements.
+
+### Required carry-forward after the v4.4.1 revert
+
+The revert on `production` does not make the reverted content reappear in a
+later promotion merge: Git will silently retain that omission unless it is
+explicitly reapplied. For the next promotion, explicitly reapply
+`docs/DESIGN-nested-option-support.md` from the approved candidate, then verify
+on `production` after the merge that the file exists:
+
+```bash
+git cat-file -e origin/production:docs/DESIGN-nested-option-support.md
+```
+
+Treat that verification as part of the post-merge tree-identity check; do not
+infer reapplication merely from the candidate branch containing the file.
 
 ## 3. Revalidate and tag production
 


### PR DESCRIPTION
Resolves #920.

## Problem

The v4.4.1 promotion (#917) opened with `main` as its head. Between recording the
candidate (`1552033`) and the promotion merge, #916 landed on `main`, so
`production` received content that was never part of the approved candidate:

- candidate tree `14345fc5f5e60c618b8ec3a265e8c30ce02b8d54`
- promoted tree `943989c3712d85238036853c5bee3ea03ae7497e`

`docs/RELEASE.md` §2 already warned against reusing evidence from a moving branch
and required a post-merge tree-identity check, yet **following the letter of the
procedure still produced this drift** — nothing said the promotion PR's *head*
must be pinned.

## Contract change

`docs/RELEASE.md` §2 is the canonical statement:

- **Step 3** requires opening the promotion PR from a branch fixed at the recorded
  candidate SHA (`git branch release/vX.Y.Z-candidate CANDIDATE_SHA`), never from
  `main` — explicitly *including* when `main` currently sits at that SHA. The
  reason is written into the text: while promotion CI and review run, `main` can
  advance, so its green result is evidence for a tree nobody approved.
- **Step 4** adds a **pre-merge** identity check (branch still resolves to the
  candidate, trees identical) alongside the existing post-merge one. A mismatch
  caught before merge costs nothing; after merge it costs a revert on a protected
  branch.

`.claude/skills/release/SKILL.md` **references** those steps rather than restating
them, so the rule has one source of truth and cannot drift between the two
authorities.

## Required carry-forward

The revert on `production` will be silently retained by the next promotion merge
rather than undone by it. `docs/RELEASE.md` §2 now records that
`docs/DESIGN-nested-option-support.md` must be explicitly reapplied at the next
promotion and verified afterwards with `git cat-file -e
origin/production:docs/DESIGN-nested-option-support.md`, and states that
reapplication must not be inferred from the candidate branch containing the file.

Verified against the live branch while preparing this PR: that path is **absent**
on `origin/production` and present on `main`, so the carry-forward note describes
the actual current state, not a predicted one.

## Scope

Documentation and skill only. **No change to the `production promotion gate`
ruleset or to any required check** — `git show --name-only` confirms nothing under
`.github/` is touched, which is issue #920's fourth acceptance criterion.

## Verification

- changelog fragment check run twice
- `git diff --check`
- cross-references resolved by opening the referenced sections, not assumed
- confirmed `tools/build_site_reference.py` does not read `docs/RELEASE.md`, so the
  site-reference freshness gate is unaffected
- `docs/DESIGN-nested-option-support.md` absence on `origin/production` confirmed
  directly

Fragment: `changelog.d/920-pinned-candidate-head.documented.md`.

Authorship note for review: this branch was produced under my orchestration, so
please review it as an authored change rather than an independent one.