### PR TITLE
test(wasm): compare the uncovered Worker error-envelope routes against native

### DIFF
--- a/changelog.d/937-worker-error-route-parity.required.md
+++ b/changelog.d/937-worker-error-route-parity.required.md
@@ -1,0 +1,4 @@
+Required (#937): Worker `check` and pre-solver `verify` error routes now have
+full native-envelope comparisons, an explicit route registry, and calibrated
+detectors for requirement traces, build failures, boundary violations, and
+implements finalization.

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -596,6 +596,12 @@ mod tests {
 
     /// Every Worker `check`/`verify` error-return route has exactly one row.
     ///
+    /// This is a test-local inventory, not a reflection of `check`/`verify`.
+    /// Adding an implementation return without adding an `ErrorRoute` variant
+    /// remains a population risk: the registry cannot prove that route is
+    /// compared.  The exhaustive inventory guard below prevents omissions only
+    /// after a route has been deliberately added to this enum.
+    ///
     /// `Compared` rows name a full-envelope `assert_eq!(worker, native)` cell.
     /// `NotComparable` rows are deliberately retained with the concrete
     /// boundary that prevents a native/Worker pair; they are not a tolerated
@@ -643,6 +649,27 @@ mod tests {
             Self::VerifyImplements,
         ];
 
+        /// Adding a variant to `ErrorRoute` breaks this match, which is the only
+        /// compile-time forcing point.  Having added an arm here, also raise
+        /// `COUNT`, append the variant to `ALL`, and add its
+        /// `ERROR_ROUTE_REGISTRY` row: each of those three is enforced, but by a
+        /// different mechanism, and the diagnostics do not name each other.
+        ///
+        /// Measured on 2026-08-28, one isolated mutation each, reverted to
+        /// SHA-256 `7b769a4e…` between them:
+        ///
+        /// - variant only -> `E0004 non-exhaustive patterns` (`exit=101`)
+        /// - `COUNT` raised, `ALL` left alone -> `E0308 expected an array with a
+        ///   size of 16, found one with a size of 15` (`exit=101`)
+        /// - `ALL` appended, registry row omitted ->
+        ///   `error_route_registry_is_total_and_exclusions_are_specific` fails
+        ///   with `left: {0..=14}` vs `right: {0..=15}` (`exit=101`)
+        /// - variant plus this arm only, `COUNT` left at its old value ->
+        ///   `cargo test` **passes** (`exit=0`); only
+        ///   `clippy -D warnings` rejects it, as `variant is never constructed`
+        ///   (`exit=101`).  That last catcher is incidental rather than designed,
+        ///   and its message does not mention `COUNT`, `ALL`, or the registry --
+        ///   which is why this comment exists.
         const fn discriminant(self) -> usize {
             match self {
                 Self::CheckAiProject => 0,
@@ -674,25 +701,25 @@ mod tests {
     /// full-envelope comparison pair in this native-host test.
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     enum NonComparableReason {
-        VerifyDeadlockWorkerRequestOption,
-        VerifyVerifierRequiresBrowserSolverAndPrivateNativeComposite,
-        VerifyReplayRequiresBrowserSolverAndPrivateNativeComposite,
-        VerifyReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite,
+        DeadlockWorkerRequestOption,
+        VerifierRequiresBrowserSolverAndPrivateNativeComposite,
+        ReplayRequiresBrowserSolverAndPrivateNativeComposite,
+        ReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite,
     }
 
     impl NonComparableReason {
         const fn detail(self) -> &'static str {
             match self {
-                Self::VerifyDeadlockWorkerRequestOption => {
+                Self::DeadlockWorkerRequestOption => {
                     "`options.deadlock` is a Worker request field; native CLI argument parsing is a distinct public input path, so no native request pair exists."
                 }
-                Self::VerifyVerifierRequiresBrowserSolverAndPrivateNativeComposite => {
+                Self::VerifierRequiresBrowserSolverAndPrivateNativeComposite => {
                     "a native/Worker composite verify pair requires the binary-private native `run_verify*` API and an initialized browser Z3 bridge; neither is available to this native-host test."
                 }
-                Self::VerifyReplayRequiresBrowserSolverAndPrivateNativeComposite => {
+                Self::ReplayRequiresBrowserSolverAndPrivateNativeComposite => {
                     "replay is reached only after a browser-solver BMC result; the equivalent native composite verifier is binary-private and cannot be invoked here without public API expansion."
                 }
-                Self::VerifyReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite => {
+                Self::ReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite => {
                     "reachable diagnosis is reached only after browser-solver BMC; a native composite pair is unavailable without exposing `run_verify*`."
                 }
             }
@@ -763,7 +790,7 @@ mod tests {
         RouteRegistration {
             route: ErrorRoute::VerifyDeadlockOption,
             coverage: RouteCoverage::NotComparable(
-                NonComparableReason::VerifyDeadlockWorkerRequestOption,
+                NonComparableReason::DeadlockWorkerRequestOption,
             ),
         },
         RouteRegistration {
@@ -775,19 +802,19 @@ mod tests {
         RouteRegistration {
             route: ErrorRoute::VerifyVerifier,
             coverage: RouteCoverage::NotComparable(
-                NonComparableReason::VerifyVerifierRequiresBrowserSolverAndPrivateNativeComposite,
+                NonComparableReason::VerifierRequiresBrowserSolverAndPrivateNativeComposite,
             ),
         },
         RouteRegistration {
             route: ErrorRoute::VerifyReplay,
             coverage: RouteCoverage::NotComparable(
-                NonComparableReason::VerifyReplayRequiresBrowserSolverAndPrivateNativeComposite,
+                NonComparableReason::ReplayRequiresBrowserSolverAndPrivateNativeComposite,
             ),
         },
         RouteRegistration {
             route: ErrorRoute::VerifyReachableDiagnostics,
             coverage: RouteCoverage::NotComparable(
-                NonComparableReason::VerifyReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite,
+                NonComparableReason::ReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite,
             ),
         },
         RouteRegistration {
@@ -1123,16 +1150,16 @@ mod tests {
                 RouteCoverage::NotComparable(reason) => {
                     let expected_reason = match entry.route {
                         ErrorRoute::VerifyDeadlockOption => {
-                            NonComparableReason::VerifyDeadlockWorkerRequestOption
+                            NonComparableReason::DeadlockWorkerRequestOption
                         }
                         ErrorRoute::VerifyVerifier => {
-                            NonComparableReason::VerifyVerifierRequiresBrowserSolverAndPrivateNativeComposite
+                            NonComparableReason::VerifierRequiresBrowserSolverAndPrivateNativeComposite
                         }
                         ErrorRoute::VerifyReplay => {
-                            NonComparableReason::VerifyReplayRequiresBrowserSolverAndPrivateNativeComposite
+                            NonComparableReason::ReplayRequiresBrowserSolverAndPrivateNativeComposite
                         }
                         ErrorRoute::VerifyReachableDiagnostics => {
-                            NonComparableReason::VerifyReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite
+                            NonComparableReason::ReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite
                         }
                         route => panic!("{route:?} is non-comparable without a route-specific reason"),
                     };

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -461,7 +461,7 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
     if let Err(failure) = add_reachable_diagnostics(&model, &mut result, &mut statistics).await {
         return verifier_error(solver_version, &failure);
     }
-    let (mut output, _) = fslc_rust::verification_output::render_bmc_output(
+    let (output, _) = fslc_rust::verification_output::render_bmc_output(
         envelope(solver_version),
         &model,
         &result,
@@ -476,11 +476,35 @@ async fn verify(request: &Request, solver_version: &str) -> Value {
             skip_vacuity_probe: false,
         },
     );
+    finalize_verify_output(
+        request,
+        solver_version,
+        &model,
+        has_trace_contract,
+        output,
+        compose_warnings,
+    )
+}
+
+/// Apply the common post-verification metadata after a BMC result is rendered.
+///
+/// This stays separate from solver execution so the native-host unit tests can
+/// exercise the `verify` caller's `implements` error return without a browser
+/// Z3 bridge.  The Worker and the native CLI both delegate the final
+/// `implements` rendering to [`fslc_rust::verification_output`].
+fn finalize_verify_output(
+    request: &Request,
+    solver_version: &str,
+    model: &KernelModel,
+    has_trace_contract: bool,
+    mut output: Value,
+    compose_warnings: Vec<Value>,
+) -> Value {
     prepend_compose_warnings(&mut output, compose_warnings);
     add_frontend_metadata(
         request,
         solver_version,
-        &model,
+        model,
         has_trace_contract,
         request.options.depth,
         output,
@@ -560,6 +584,7 @@ pub fn internal_error(message: String) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::future::Future;
     use std::task::{Context, Poll, Waker};
 
@@ -568,6 +593,159 @@ mod tests {
     use fsl_verifier::{BmcResult, BmcViolation, LeadsToViolation};
 
     const TEST_SOLVER_VERSION: &str = "Z3 4.16.0.0";
+
+    /// Every Worker `check`/`verify` error-return route has exactly one row.
+    ///
+    /// `Compared` rows name a full-envelope `assert_eq!(worker, native)` cell.
+    /// `NotComparable` rows are deliberately retained with the concrete
+    /// boundary that prevents a native/Worker pair; they are not a tolerated
+    /// envelope difference.  The native CLI's `run_verify*` composition remains
+    /// binary-private, and the native-host unit test has no initialized browser
+    /// Z3 bridge, so a solver-dependent Worker return cannot be driven alongside
+    /// the native composite route without widening that public API.
+    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+    enum ErrorRoute {
+        CheckAiProject,
+        CheckSurfaceParse,
+        CheckBuild,
+        CheckRequirementTrace,
+        CheckGovernance,
+        CheckImplements,
+        VerifySurfaceParse,
+        VerifyBuild,
+        VerifyRequirementTrace,
+        VerifyDeadlockOption,
+        VerifyBoundary,
+        VerifyVerifier,
+        VerifyReplay,
+        VerifyReachableDiagnostics,
+        VerifyImplements,
+    }
+
+    impl ErrorRoute {
+        const ALL: [Self; 15] = [
+            Self::CheckAiProject,
+            Self::CheckSurfaceParse,
+            Self::CheckBuild,
+            Self::CheckRequirementTrace,
+            Self::CheckGovernance,
+            Self::CheckImplements,
+            Self::VerifySurfaceParse,
+            Self::VerifyBuild,
+            Self::VerifyRequirementTrace,
+            Self::VerifyDeadlockOption,
+            Self::VerifyBoundary,
+            Self::VerifyVerifier,
+            Self::VerifyReplay,
+            Self::VerifyReachableDiagnostics,
+            Self::VerifyImplements,
+        ];
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum RouteCoverage {
+        Compared { cell: &'static str },
+        NotComparable { reason: &'static str },
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    struct RouteRegistration {
+        route: ErrorRoute,
+        coverage: RouteCoverage,
+    }
+
+    const ERROR_ROUTE_REGISTRY: &[RouteRegistration] = &[
+        RouteRegistration {
+            route: ErrorRoute::CheckAiProject,
+            coverage: RouteCoverage::Compared {
+                cell: "check_error_envelopes_match_native_across_parse_guard_and_name",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::CheckSurfaceParse,
+            coverage: RouteCoverage::Compared {
+                cell: "check_error_envelopes_match_native_across_parse_guard_and_name",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::CheckBuild,
+            coverage: RouteCoverage::Compared {
+                cell: "build_rejects_duplicate_action_writes",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::CheckRequirementTrace,
+            coverage: RouteCoverage::Compared {
+                cell: "check_requirement_trace_error_envelope_matches_native",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::CheckGovernance,
+            coverage: RouteCoverage::Compared {
+                cell: "check_rejects_an_incomplete_governance_contract",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::CheckImplements,
+            coverage: RouteCoverage::Compared {
+                cell: "check_keeps_inline_enum_conversion_error_location",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::VerifySurfaceParse,
+            coverage: RouteCoverage::Compared {
+                cell: "verify_surface_parse_error_envelope_matches_native",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::VerifyBuild,
+            coverage: RouteCoverage::Compared {
+                cell: "verify_build_error_envelope_matches_native",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::VerifyRequirementTrace,
+            coverage: RouteCoverage::Compared {
+                cell: "verify_requirement_trace_error_envelope_matches_native",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::VerifyDeadlockOption,
+            coverage: RouteCoverage::NotComparable {
+                reason: "`options.deadlock` is a Worker request field; native CLI argument parsing is a distinct public input path, so no native request pair exists.",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::VerifyBoundary,
+            coverage: RouteCoverage::Compared {
+                cell: "verify_boundary_error_envelope_matches_native",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::VerifyVerifier,
+            coverage: RouteCoverage::NotComparable {
+                reason: "a native/Worker composite verify pair requires the binary-private native `run_verify*` API and an initialized browser Z3 bridge; neither is available to this native-host test.",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::VerifyReplay,
+            coverage: RouteCoverage::NotComparable {
+                reason: "replay is reached only after a browser-solver BMC result; the equivalent native composite verifier is binary-private and cannot be invoked here without public API expansion.",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::VerifyReachableDiagnostics,
+            coverage: RouteCoverage::NotComparable {
+                reason: "reachable diagnosis is reached only after browser-solver BMC; a native composite pair is unavailable without exposing `run_verify*`.",
+            },
+        },
+        RouteRegistration {
+            route: ErrorRoute::VerifyImplements,
+            coverage: RouteCoverage::Compared {
+                cell: "verify_implements_error_envelope_matches_native",
+            },
+        },
+    ];
 
     fn block_on<F: Future>(future: F) -> F::Output {
         let mut context = Context::from_waker(Waker::noop());
@@ -662,6 +840,44 @@ mod tests {
         );
     }
 
+    fn native_requirement_trace_error(request: &Request, solver_version: &str) -> Value {
+        let resolver = MemoryResolver {
+            files: request.files.clone(),
+        };
+        let kernel = fsl_core::parse_kernel_source_with_file(
+            &request.source,
+            &resolver,
+            &request.source_file,
+        )
+        .expect("fixture must lower before its requirement trace failure");
+        let model = fsl_core::build_model(kernel).expect("fixture must build before trace failure");
+        fslc_rust::verification_output::validate_requirement_trace_source(
+            &envelope(solver_version),
+            &request.source,
+            &model,
+        )
+        .expect("fixture trace validation must run")
+        .0
+        .expect("fixture must fail native requirement trace validation")
+    }
+
+    fn assert_worker_requirement_trace_error_matches_native(
+        request: &Request,
+        fixture: &str,
+        command: &str,
+    ) {
+        let worker = match command {
+            "check" => block_on(check(request, TEST_SOLVER_VERSION)),
+            "verify" => block_on(verify(request, TEST_SOLVER_VERSION)),
+            _ => panic!("unsupported Worker command {command}"),
+        };
+        let native = native_requirement_trace_error(request, TEST_SOLVER_VERSION);
+        assert_eq!(
+            worker, native,
+            "Worker/native {command} requirement-trace envelope diverged for {fixture}"
+        );
+    }
+
     fn native_verify_surface_parse_error(request: &Request, solver_version: &str) -> Value {
         let failure = fsl_syntax::parse_surface_document(&request.source)
             .expect_err("fixture must fail native verify surface parsing");
@@ -674,6 +890,59 @@ mod tests {
         assert_eq!(
             worker, native,
             "Worker/native verify surface-parse envelope diverged for {fixture}"
+        );
+    }
+
+    fn native_verify_boundary_error(request: &Request, solver_version: &str) -> Value {
+        let resolver = MemoryResolver {
+            files: request.files.clone(),
+        };
+        let kernel = fsl_core::parse_kernel_source_with_file(
+            &request.source,
+            &resolver,
+            &request.source_file,
+        )
+        .expect("fixture must lower before its boundary violation");
+        let model =
+            fsl_core::build_model(kernel).expect("fixture must build before boundary violation");
+        let (violation, trace) = fsl_runtime::find_boundary_violation(
+            &model,
+            request.options.depth,
+            fsl_runtime::CONCRETE_PROBE_BUDGET,
+        )
+        .expect("boundary probe must run")
+        .finding
+        .expect("fixture must find a boundary violation");
+        assert_ne!(
+            violation.kind, "partial_op",
+            "fixture must use the boundary return"
+        );
+        fslc_rust::verification_output::render_boundary_output(
+            envelope(solver_version),
+            &model,
+            &violation,
+            &trace,
+            &fslc_rust::verification_output::BmcOutputOptions {
+                depth: request.options.depth,
+                deadlock: fslc_rust::verification_output::DeadlockMode::parse(
+                    &request.options.deadlock,
+                )
+                .expect("fixture has a valid deadlock mode"),
+                checked_bounds: None,
+                elapsed_s: 0.0,
+                statistics: &fsl_solver::VerificationStatistics::default(),
+                skip_vacuity_probe: false,
+            },
+        )
+        .0
+    }
+
+    fn assert_worker_verify_boundary_error_matches_native(request: &Request, fixture: &str) {
+        let worker = block_on(verify(request, TEST_SOLVER_VERSION));
+        let native = native_verify_boundary_error(request, TEST_SOLVER_VERSION);
+        assert_eq!(
+            worker, native,
+            "Worker/native verify boundary envelope diverged for {fixture}"
         );
     }
 
@@ -735,6 +1004,70 @@ mod tests {
             worker, native,
             "Worker/native implements error diverged for {fixture}"
         );
+    }
+
+    fn assert_verify_finalization_implements_error_matches_native(
+        request: &Request,
+        fixture: &str,
+    ) {
+        let resolver = MemoryResolver {
+            files: request.files.clone(),
+        };
+        let kernel = fsl_core::parse_kernel_source_with_file(
+            &request.source,
+            &resolver,
+            &request.source_file,
+        )
+        .expect("fixture must lower before its implements failure");
+        let model = fsl_core::build_model(kernel).expect("fixture must build before implements");
+        // The error branch intentionally replaces the rendered BMC payload
+        // with the native implements envelope, so this value is inert while
+        // still exercising `verify`'s extracted finalization caller.
+        let worker = finalize_verify_output(
+            request,
+            TEST_SOLVER_VERSION,
+            &model,
+            false,
+            json!({"result": "verified"}),
+            Vec::new(),
+        );
+        let native = native_implements_error(request, TEST_SOLVER_VERSION);
+        assert_eq!(
+            worker, native,
+            "Worker/native verify implements envelope diverged for {fixture}"
+        );
+    }
+
+    #[test]
+    fn error_route_registry_is_total_and_exclusions_are_specific() {
+        let expected = ErrorRoute::ALL.into_iter().collect::<BTreeSet<_>>();
+        let registered = ERROR_ROUTE_REGISTRY
+            .iter()
+            .map(|entry| entry.route)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            registered, expected,
+            "every Worker error route needs one registry row"
+        );
+        assert_eq!(
+            registered.len(),
+            ERROR_ROUTE_REGISTRY.len(),
+            "Worker error-route registry contains duplicates"
+        );
+        for entry in ERROR_ROUTE_REGISTRY {
+            match entry.coverage {
+                RouteCoverage::Compared { cell } => assert!(
+                    !cell.trim().is_empty(),
+                    "{:?} is compared without a detector cell",
+                    entry.route
+                ),
+                RouteCoverage::NotComparable { reason } => assert!(
+                    reason.contains("native") || reason.contains("Worker"),
+                    "{:?} lacks a concrete comparison boundary: {reason}",
+                    entry.route
+                ),
+            }
+        }
     }
 
     #[test]
@@ -804,6 +1137,109 @@ mod tests {
             options: Options::default(),
         };
         assert_worker_verify_surface_parse_error_matches_native(&request, "surface parse");
+    }
+
+    #[test]
+    fn check_requirement_trace_error_envelope_matches_native() {
+        let request = Request {
+            cmd: "check".to_owned(),
+            source: include_str!(
+                "../../fslc/tests/fixtures/requirements_acceptance_walk_violation.fsl"
+            )
+            .to_owned(),
+            source_file: "requirements_acceptance_walk_violation.fsl".to_owned(),
+            files: BTreeMap::new(),
+            options: Options::default(),
+        };
+        assert_worker_requirement_trace_error_matches_native(
+            &request,
+            "requirements acceptance walk",
+            "check",
+        );
+    }
+
+    #[test]
+    fn verify_build_error_envelope_matches_native() {
+        let request = Request {
+            cmd: "verify".to_owned(),
+            source: "spec Duplicate { state { x: Bool } init { x = false } action write_twice() { x = true x = false } }".to_owned(),
+            source_file: "duplicate.fsl".to_owned(),
+            files: BTreeMap::new(),
+            options: Options::default(),
+        };
+        let worker = block_on(verify(&request, TEST_SOLVER_VERSION));
+        let native = native_check_error(&request, TEST_SOLVER_VERSION);
+        assert_eq!(
+            worker, native,
+            "Worker/native verify build envelope diverged"
+        );
+    }
+
+    #[test]
+    fn verify_requirement_trace_error_envelope_matches_native() {
+        let request = Request {
+            cmd: "verify".to_owned(),
+            source: include_str!(
+                "../../fslc/tests/fixtures/requirements_acceptance_walk_violation.fsl"
+            )
+            .to_owned(),
+            source_file: "requirements_acceptance_walk_violation.fsl".to_owned(),
+            files: BTreeMap::new(),
+            options: Options::default(),
+        };
+        assert_worker_requirement_trace_error_matches_native(
+            &request,
+            "requirements acceptance walk",
+            "verify",
+        );
+    }
+
+    #[test]
+    fn verify_boundary_error_envelope_matches_native() {
+        let request = Request {
+            cmd: "verify".to_owned(),
+            source: include_str!(
+                "../../../examples/gallery/errors/violated_type_bound_missing_guard.fsl"
+            )
+            .to_owned(),
+            source_file: "violated_type_bound_missing_guard.fsl".to_owned(),
+            files: BTreeMap::new(),
+            options: Options {
+                depth: 2,
+                deadlock: "warn".to_owned(),
+            },
+        };
+        assert_worker_verify_boundary_error_matches_native(&request, "type bound");
+    }
+
+    #[test]
+    fn verify_implements_error_envelope_matches_native() {
+        let request = Request {
+            cmd: "verify".to_owned(),
+            source: r#"requirements Impl {
+  implements Abs from "abs.fsl" {
+    enum conversion stage ImplStage -> AbsStage { A -> A }
+    map status = convert(stage, stage)
+    action step() -> step()
+  }
+  enum ImplStage { A, B }
+  state { stage: ImplStage }
+  init { stage = A }
+  action step() { stage = B }
+}
+"#
+            .to_owned(),
+            source_file: "impl.fsl".to_owned(),
+            files: BTreeMap::from([(
+                "abs.fsl".to_owned(),
+                "spec Abs { enum AbsStage { A, B } state { status: AbsStage } init { status = A } action step() { status = B } }".to_owned(),
+            )]),
+            options: Options::default(),
+        };
+        assert_verify_finalization_implements_error_matches_native(
+            &request,
+            "inline enum conversion",
+        );
     }
 
     #[test]

--- a/rust/fsl-wasm/src/lib.rs
+++ b/rust/fsl-wasm/src/lib.rs
@@ -623,7 +623,9 @@ mod tests {
     }
 
     impl ErrorRoute {
-        const ALL: [Self; 15] = [
+        const COUNT: usize = 15;
+
+        const ALL: [Self; Self::COUNT] = [
             Self::CheckAiProject,
             Self::CheckSurfaceParse,
             Self::CheckBuild,
@@ -640,12 +642,61 @@ mod tests {
             Self::VerifyReachableDiagnostics,
             Self::VerifyImplements,
         ];
+
+        const fn discriminant(self) -> usize {
+            match self {
+                Self::CheckAiProject => 0,
+                Self::CheckSurfaceParse => 1,
+                Self::CheckBuild => 2,
+                Self::CheckRequirementTrace => 3,
+                Self::CheckGovernance => 4,
+                Self::CheckImplements => 5,
+                Self::VerifySurfaceParse => 6,
+                Self::VerifyBuild => 7,
+                Self::VerifyRequirementTrace => 8,
+                Self::VerifyDeadlockOption => 9,
+                Self::VerifyBoundary => 10,
+                Self::VerifyVerifier => 11,
+                Self::VerifyReplay => 12,
+                Self::VerifyReachableDiagnostics => 13,
+                Self::VerifyImplements => 14,
+            }
+        }
     }
 
     #[derive(Clone, Copy, Debug)]
     enum RouteCoverage {
         Compared { cell: &'static str },
-        NotComparable { reason: &'static str },
+        NotComparable(NonComparableReason),
+    }
+
+    /// An explicit native/Worker boundary for a route that cannot form a
+    /// full-envelope comparison pair in this native-host test.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum NonComparableReason {
+        VerifyDeadlockWorkerRequestOption,
+        VerifyVerifierRequiresBrowserSolverAndPrivateNativeComposite,
+        VerifyReplayRequiresBrowserSolverAndPrivateNativeComposite,
+        VerifyReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite,
+    }
+
+    impl NonComparableReason {
+        const fn detail(self) -> &'static str {
+            match self {
+                Self::VerifyDeadlockWorkerRequestOption => {
+                    "`options.deadlock` is a Worker request field; native CLI argument parsing is a distinct public input path, so no native request pair exists."
+                }
+                Self::VerifyVerifierRequiresBrowserSolverAndPrivateNativeComposite => {
+                    "a native/Worker composite verify pair requires the binary-private native `run_verify*` API and an initialized browser Z3 bridge; neither is available to this native-host test."
+                }
+                Self::VerifyReplayRequiresBrowserSolverAndPrivateNativeComposite => {
+                    "replay is reached only after a browser-solver BMC result; the equivalent native composite verifier is binary-private and cannot be invoked here without public API expansion."
+                }
+                Self::VerifyReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite => {
+                    "reachable diagnosis is reached only after browser-solver BMC; a native composite pair is unavailable without exposing `run_verify*`."
+                }
+            }
+        }
     }
 
     #[derive(Clone, Copy, Debug)]
@@ -711,9 +762,9 @@ mod tests {
         },
         RouteRegistration {
             route: ErrorRoute::VerifyDeadlockOption,
-            coverage: RouteCoverage::NotComparable {
-                reason: "`options.deadlock` is a Worker request field; native CLI argument parsing is a distinct public input path, so no native request pair exists.",
-            },
+            coverage: RouteCoverage::NotComparable(
+                NonComparableReason::VerifyDeadlockWorkerRequestOption,
+            ),
         },
         RouteRegistration {
             route: ErrorRoute::VerifyBoundary,
@@ -723,21 +774,21 @@ mod tests {
         },
         RouteRegistration {
             route: ErrorRoute::VerifyVerifier,
-            coverage: RouteCoverage::NotComparable {
-                reason: "a native/Worker composite verify pair requires the binary-private native `run_verify*` API and an initialized browser Z3 bridge; neither is available to this native-host test.",
-            },
+            coverage: RouteCoverage::NotComparable(
+                NonComparableReason::VerifyVerifierRequiresBrowserSolverAndPrivateNativeComposite,
+            ),
         },
         RouteRegistration {
             route: ErrorRoute::VerifyReplay,
-            coverage: RouteCoverage::NotComparable {
-                reason: "replay is reached only after a browser-solver BMC result; the equivalent native composite verifier is binary-private and cannot be invoked here without public API expansion.",
-            },
+            coverage: RouteCoverage::NotComparable(
+                NonComparableReason::VerifyReplayRequiresBrowserSolverAndPrivateNativeComposite,
+            ),
         },
         RouteRegistration {
             route: ErrorRoute::VerifyReachableDiagnostics,
-            coverage: RouteCoverage::NotComparable {
-                reason: "reachable diagnosis is reached only after browser-solver BMC; a native composite pair is unavailable without exposing `run_verify*`.",
-            },
+            coverage: RouteCoverage::NotComparable(
+                NonComparableReason::VerifyReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite,
+            ),
         },
         RouteRegistration {
             route: ErrorRoute::VerifyImplements,
@@ -1040,17 +1091,25 @@ mod tests {
 
     #[test]
     fn error_route_registry_is_total_and_exclusions_are_specific() {
-        let expected = ErrorRoute::ALL.into_iter().collect::<BTreeSet<_>>();
-        let registered = ERROR_ROUTE_REGISTRY
-            .iter()
-            .map(|entry| entry.route)
+        let expected_discriminants = (0..ErrorRoute::COUNT).collect::<BTreeSet<_>>();
+        let all_discriminants = ErrorRoute::ALL
+            .into_iter()
+            .map(ErrorRoute::discriminant)
             .collect::<BTreeSet<_>>();
         assert_eq!(
-            registered, expected,
+            all_discriminants, expected_discriminants,
+            "ErrorRoute::ALL must contain every discriminant exactly once"
+        );
+        let registered_discriminants = ERROR_ROUTE_REGISTRY
+            .iter()
+            .map(|entry| entry.route.discriminant())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            registered_discriminants, expected_discriminants,
             "every Worker error route needs one registry row"
         );
         assert_eq!(
-            registered.len(),
+            registered_discriminants.len(),
             ERROR_ROUTE_REGISTRY.len(),
             "Worker error-route registry contains duplicates"
         );
@@ -1061,11 +1120,31 @@ mod tests {
                     "{:?} is compared without a detector cell",
                     entry.route
                 ),
-                RouteCoverage::NotComparable { reason } => assert!(
-                    reason.contains("native") || reason.contains("Worker"),
-                    "{:?} lacks a concrete comparison boundary: {reason}",
-                    entry.route
-                ),
+                RouteCoverage::NotComparable(reason) => {
+                    let expected_reason = match entry.route {
+                        ErrorRoute::VerifyDeadlockOption => {
+                            NonComparableReason::VerifyDeadlockWorkerRequestOption
+                        }
+                        ErrorRoute::VerifyVerifier => {
+                            NonComparableReason::VerifyVerifierRequiresBrowserSolverAndPrivateNativeComposite
+                        }
+                        ErrorRoute::VerifyReplay => {
+                            NonComparableReason::VerifyReplayRequiresBrowserSolverAndPrivateNativeComposite
+                        }
+                        ErrorRoute::VerifyReachableDiagnostics => {
+                            NonComparableReason::VerifyReachableDiagnosticsRequiresBrowserSolverAndPrivateNativeComposite
+                        }
+                        route => panic!("{route:?} is non-comparable without a route-specific reason"),
+                    };
+                    assert_eq!(
+                        reason,
+                        expected_reason,
+                        "{:?} has the wrong comparison boundary: {}",
+                        entry.route,
+                        reason.detail()
+                    );
+                    assert!(!reason.detail().trim().is_empty());
+                }
             }
         }
     }


### PR DESCRIPTION
Resolves #937. Closes the last issue in **M18**.

## Problem

#810 added gates that genuinely compare native CLI and Worker error envelopes —
`assert_eq!(worker, native)` over the whole envelope, with one-sided mutations as
negative controls. It did not cover every `check`/`verify` failure return. #937
listed the gaps by route name rather than by count, because a count does not tell
the next person which route to cover.

The reason that mattered: in #810's first commit a cell labelled `Parse` used
`error_envelope_broken_ai_project.fsl`, returned early on the AI-project path, and
never reached `render_surface_parse_error`. Mutating only the Worker side left
`cargo test -p fsl-wasm` at exit 0. **A comparison gate existing is not the same as
that route being compared** — a defect class that has recurred three times here.

## What this adds

Full-envelope comparison cells for the previously uncovered routes: `check`
requirement trace, `verify` build, `verify` trace, `verify` boundary, and `verify`
implements.

`ERROR_ROUTE_REGISTRY` maps every route to either a `Compared { cell }` row or a
`NotComparable(NonComparableReason)` row. `NonComparableReason` is a typed enum
whose `detail()` is an exhaustive match, so an exclusion cannot be a vague string:
each names the concrete boundary that prevents a native/Worker pair — `verify`
verifier/replay/reachable need the binary-private native `run_verify*` API and an
initialized browser Z3 bridge; `options.deadlock` is a Worker request field with no
native request counterpart.

## Detector calibration

Each cell was calibrated with a one-sided mutation inserting a unique key; all five
failed as cited, restore proven by SHA-256 `9346db22…c88c0a`.

## Totality: measured, one isolated mutation at a time

The first revision computed totality against `const ALL: [Self; 15]`, a
hand-written fixed-length array. Adding an enum variant left that literal valid and
the totality test comparing two sets that were both missing the new route — it
passed. That was rejected and replaced with a wildcard-free `discriminant` match.

Each mutation below was applied alone and reverted to SHA-256 `7b769a4e…` before
the next, with `git diff` empty against the commit:

| mutation | expected | produced |
| --- | --- | --- |
| variant only | compile error | `exit=101` — `E0004 non-exhaustive patterns: ErrorRoute::CalibrationA not covered` |
| `COUNT` raised, `ALL` untouched | compile error | `exit=101` — `E0308 expected an array with a size of 16, found one with a size of 15` |
| `ALL` appended, registry row omitted | totality test fails | `exit=101` — `every Worker error route needs one registry row`, `left: {0..=14}` vs `right: {0..=15}` |
| variant + arm only, `COUNT` left at 15 | **unknown before measuring** | `cargo test` **`exit=0`**; `clippy -D warnings` `exit=101` — `variant CalibrationD is never constructed` |

**The fourth row is the one worth reading.** That case is caught, but only by
`clippy::dead_code` under `-D warnings`, and `cargo test` alone passes it. The
required `rust checks` job runs that clippy invocation, so CI stops it — a developer
running only tests would not see it. The catcher is also incidental rather than
designed, and `never constructed` says nothing about `COUNT`, `ALL`, or the
registry.

So the obligation chain is recorded as a doc comment at `discriminant`, carrying
these four measurements, because the mechanism that enforces each link does not
name the others.

## Residual limitation, stated in the code

`ErrorRoute` is a test-local inventory, not a reflection of `check`/`verify`. Adding
an implementation return without adding a variant **remains a population risk**; the
guard prevents omissions only after a route has been deliberately added to the enum.
`rust/fsl-wasm/src/lib.rs:599` says so, so the guard is not read as more than it is.

## Not in scope

Exposing a native composite verify API. Three routes are `NotComparable` for that
reason, each recorded with the boundary. That is a design decision to take
separately.

## Verification

Every gate's exit status was read from its log rather than inferred from having
launched it:

| gate | exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets --locked -- -D warnings` | 0 |
| `cargo test -p fsl-wasm --locked` | 0 (17 passed) |
| `cargo test -p fslc-rust --locked` | 0 (142 suites) |

That distinction was not cosmetic here: an earlier round reported these as run while
they were still queued behind the repository's Cargo serialization lock, and the
clippy invocation was in fact failing at `exit=101` on `enum_variant_names`. Filed
as #946 (nested `cargo_lock.py` self-deadlock) and #948 (make the reporting rule
explicit).

Fragment: `changelog.d/937-worker-error-route-parity.required.md`.

Authorship note for review: this branch was produced under my orchestration and the
calibration above was executed by me rather than by an independent reviewer, so
please read it as an authored change.