### PR TITLE
fix(cli): capture the explain and html source once

### DIFF
--- a/changelog.d/932-check-db-check-single-snapshot.fixed.md
+++ b/changelog.d/932-check-db-check-single-snapshot.fixed.md
@@ -1,1 +1,1 @@
-Fixed (#932): native `fslc check` and `fslc db check` now derive their validation, checked Kernel/model, verification, and post-processing from one captured root-source snapshot, preventing concurrent atomic replacements from mixing document revisions in one result.
+Fixed (#932): native `fslc check`, `fslc db check`, `fslc explain`, and `fslc html` now derive their validation, checked Kernel/model, verification, rendering, and post-processing from one captured root-source snapshot, preventing concurrent atomic replacements from mixing document revisions in one result.

--- a/changelog.d/932-explain-html-single-snapshot.fixed.md
+++ b/changelog.d/932-explain-html-single-snapshot.fixed.md
@@ -1,1 +1,0 @@
-Fixed (#932): `explain` and `html` now use one captured root-source snapshot throughout each command, with FIFO and platform-neutral regression controls against path rereads.

--- a/changelog.d/932-explain-html-single-snapshot.fixed.md
+++ b/changelog.d/932-explain-html-single-snapshot.fixed.md
@@ -1,0 +1,1 @@
+Fixed (#932): `explain` and `html` now use one captured root-source snapshot throughout each command, with FIFO and platform-neutral regression controls against path rereads.

--- a/changelog.d/932-explain-html-snapshot-controls.required.md
+++ b/changelog.d/932-explain-html-snapshot-controls.required.md
@@ -1,0 +1,1 @@
+Required (#932): `explain` and `html` each carry a FIFO control that fails when the CLI opens a second root source, plus a platform-neutral control without `#[cfg(unix)]` so Windows holds the same guarantee; the HTML parity comparison's two wall-clock exclusions are themselves asserted present in both rendered reports, so the exclusion cannot go dead unnoticed.

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -8531,9 +8531,8 @@ fn weakening_candidates(spec: &fsl_syntax::SurfaceSpec) -> Vec<WeakeningCandidat
     candidates
 }
 
-fn reachable_counterfactuals(path: &Path, depth: usize) -> Value {
-    let source = std::fs::read_to_string(path).unwrap_or_default();
-    let Ok(parsed) = parse_surface_document(path) else {
+fn reachable_counterfactuals_from_source(path: &Path, source: &str, depth: usize) -> Value {
+    let Ok(parsed) = parse_surface_document_from_source(path, source) else {
         return json!([]);
     };
     let document = match parsed {
@@ -8543,7 +8542,7 @@ fn reachable_counterfactuals(path: &Path, depth: usize) -> Value {
         | fsl_syntax::SurfaceDocument::Compose(_) => {
             let resolver =
                 fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
-            let Ok(kernel) = fsl_core::parse_kernel_source(&source, &resolver) else {
+            let Ok(kernel) = fsl_core::parse_kernel_source(source, &resolver) else {
                 return json!([]);
             };
             kernel.into_syntax()
@@ -9021,9 +9020,8 @@ fn invariant_violation_explanation(
 }
 
 #[allow(clippy::too_many_lines)]
-fn invariant_counterfactuals(path: &Path, depth: usize) -> Value {
-    let source = std::fs::read_to_string(path).unwrap_or_default();
-    let Ok(parsed) = parse_surface_document(path) else {
+fn invariant_counterfactuals_from_source(path: &Path, source: &str, depth: usize) -> Value {
+    let Ok(parsed) = parse_surface_document_from_source(path, source) else {
         return json!([]);
     };
     let document = match parsed {
@@ -9033,7 +9031,7 @@ fn invariant_counterfactuals(path: &Path, depth: usize) -> Value {
         | fsl_syntax::SurfaceDocument::Compose(_) => {
             let resolver =
                 fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
-            let Ok(kernel) = fsl_core::parse_kernel_source(&source, &resolver) else {
+            let Ok(kernel) = fsl_core::parse_kernel_source(source, &resolver) else {
                 return json!([]);
             };
             kernel.into_syntax()
@@ -9187,8 +9185,15 @@ fn invariant_counterfactuals(path: &Path, depth: usize) -> Value {
 /// no `implements`, or when computing it fails: that failure already
 /// surfaces through `verify`/`check`, and a presentation view must not
 /// itself become a second point of failure for it.
-fn readable_implements_text(path: &Path, model: &KernelModel, depth: usize) -> Option<String> {
-    let implements = implements_result(path, model, depth).ok().flatten()?;
+fn readable_implements_text_from_source(
+    path: &Path,
+    source: &str,
+    model: &KernelModel,
+    depth: usize,
+) -> Option<String> {
+    let implements = implements_result_from_source(path, source, model, depth)
+        .ok()
+        .flatten()?;
     let abs = implements.get("abs").and_then(Value::as_str).unwrap_or("?");
     let result = implements
         .get("result")
@@ -9199,13 +9204,32 @@ fn readable_implements_text(path: &Path, model: &KernelModel, depth: usize) -> O
 
 #[allow(clippy::too_many_lines)]
 fn run_explain(path: &Path, depth: usize, readable: bool) -> (Value, i32) {
-    let (source, _kernel, model) = match load_kernel_model(path) {
+    let source = match read_spec_source(path) {
+        Ok(source) => source,
+        Err(error) => return (spec_load_error_output(&error), 2),
+    };
+    run_explain_from_source(path, &source, depth, readable)
+}
+
+/// Explain one caller-owned root-source snapshot.
+///
+/// Model lowering, scenarios, counterfactuals, and the readable implements
+/// summary all derive from `source`. Dependency files loaded by `FsResolver`
+/// deliberately retain their independent read semantics.
+#[allow(clippy::too_many_lines)]
+fn run_explain_from_source(
+    path: &Path,
+    source: &str,
+    depth: usize,
+    readable: bool,
+) -> (Value, i32) {
+    let (_kernel, model) = match load_kernel_model_from_source(path, source) {
         Ok(loaded) => loaded,
         Err(error) => return (spec_load_error_output(&error), 2),
     };
-    let spec_kind = source_dialect(&source);
+    let spec_kind = source_dialect(source);
     let skeleton = model_skeleton(&model, spec_kind);
-    let (scenarios, _) = run_scenarios(path, depth, "warn");
+    let (scenarios, _) = run_scenarios_mode_from_source(path, source, depth, "warn", false);
     let mut output = envelope();
     output.insert("result".to_owned(), json!("explained"));
     output.insert("spec".to_owned(), json!(model.name));
@@ -9225,9 +9249,9 @@ fn run_explain(path: &Path, depth: usize, readable: bool) -> (Value, i32) {
     );
     output.insert(
         "counterfactuals".to_owned(),
-        invariant_counterfactuals(path, depth),
+        invariant_counterfactuals_from_source(path, source, depth),
     );
-    let mut reachable_counterfactuals = reachable_counterfactuals(path, depth);
+    let mut reachable_counterfactuals = reachable_counterfactuals_from_source(path, source, depth);
     if let Value::Array(items) = &mut reachable_counterfactuals {
         for item in items {
             if let Value::Object(item) = item {
@@ -9270,7 +9294,8 @@ fn run_explain(path: &Path, depth: usize, readable: bool) -> (Value, i32) {
         for (name, ty) in state {
             let _ = writeln!(text, "  - {}: {}", display(name), type_ref_text(ty));
         }
-        if let Some(implements) = readable_implements_text(path, &model, depth) {
+        if let Some(implements) = readable_implements_text_from_source(path, source, &model, depth)
+        {
             text.push_str("\nImplements:\n");
             text.push_str(&implements);
         }
@@ -11144,23 +11169,40 @@ fn run_html_report(
     engine: &str,
     output_path: Option<&Path>,
 ) -> (Value, i32) {
-    let model = match load_model(path) {
+    let source = match read_spec_source(path) {
+        Ok(source) => source,
+        Err(error) => return (spec_load_error_output(&error), 2),
+    };
+    run_html_report_from_source(path, &source, depth, deadlock_mode, engine, output_path)
+}
+
+/// Render one HTML report from one caller-owned root-source snapshot.
+///
+/// Model lowering, verification, explanation, and rendered source all derive
+/// from `source`. Dependency files loaded by `FsResolver` deliberately retain
+/// their independent read semantics.
+fn run_html_report_from_source(
+    path: &Path,
+    source: &str,
+    depth: usize,
+    deadlock_mode: &str,
+    engine: &str,
+    output_path: Option<&Path>,
+) -> (Value, i32) {
+    let model = match load_model_from_source(path, source) {
         Ok(model) => model,
         Err(error) => return (spec_load_error_output(&error), 2),
     };
-    let source = match std::fs::read_to_string(path) {
-        Ok(source) => source,
-        Err(error) => return (error_output("io", &error.to_string()), 2),
-    };
-    let (verification, _) = run_verify(
+    let (verification, _) = run_verify_from_source(
         path,
+        source,
         depth,
         deadlock_mode,
         engine,
         DEFAULT_EXPLICIT_BUDGET,
         1,
     );
-    let (mut explained, explain_status) = run_explain(path, depth, false);
+    let (mut explained, explain_status) = run_explain_from_source(path, source, depth, false);
     if explain_status != 0 {
         return (explained, explain_status);
     }
@@ -11177,7 +11219,7 @@ fn run_html_report(
     }
     let html = fsl_tools::render_html_report(
         &path.display().to_string(),
-        &source,
+        source,
         &explained,
         &verification,
         &fsl_tools::undecided_declarations(&model),
@@ -14923,20 +14965,6 @@ fn governance_result_from_source(
     })
 }
 
-fn implements_result(
-    path: &Path,
-    model: &KernelModel,
-    depth: usize,
-) -> Result<Option<Value>, fslc_rust::verification_output::RequirementsImplementsError> {
-    let source = std::fs::read_to_string(path).map_err(|error| {
-        fslc_rust::verification_output::RequirementsImplementsError {
-            message: error.to_string(),
-            span: None,
-        }
-    })?;
-    implements_result_from_source(path, &source, model, depth)
-}
-
 fn implements_result_from_source(
     path: &Path,
     source: &str,
@@ -16838,6 +16866,75 @@ spec InitTraceability {
         assert_eq!(status, 0, "{output:#}");
         assert_eq!(output["result"], "verified_under_assumptions", "{output:#}");
         assert_eq!(output["dbsystem"], "SafeAddNullableColumn", "{output:#}");
+    }
+
+    /// Platform-neutral #932 control for `explain`. Every explain component
+    /// must use source A after the root path is overwritten with malformed
+    /// source B; reverting a source-taking call reintroduces that path read.
+    #[test]
+    fn explain_helpers_use_the_captured_root_snapshot() {
+        let source_a = include_str!("../tests/fixtures/vacuous_leadsto.fsl");
+        let fixture = SnapshotFixture::new("explain", source_a);
+        let captured = read_spec_source(&fixture.path).expect("capture source A");
+        std::fs::write(&fixture.path, "not valid FSL source").expect("replace with source B");
+
+        let (output, status) = run_explain_from_source(&fixture.path, &captured, 4, true);
+        assert_eq!(status, 0, "{output:#}");
+        assert_eq!(output["result"], "explained", "{output:#}");
+        assert_eq!(output["spec"], "VacuousLeadstoFixture", "{output:#}");
+        assert!(
+            output["readable"]
+                .as_str()
+                .is_some_and(|text| text.contains("VacuousLeadstoFixture")),
+            "readable explain output must retain source A: {output:#}"
+        );
+    }
+
+    /// Platform-neutral #932 control for `html`. Its model, verification,
+    /// explanation, and rendered source must all use source A after the root
+    /// path is overwritten with malformed source B.
+    #[test]
+    fn html_helpers_use_the_captured_root_snapshot() {
+        let source_a = include_str!("../tests/fixtures/vacuous_leadsto.fsl");
+        let fixture = SnapshotFixture::new("html", source_a);
+        let captured = read_spec_source(&fixture.path).expect("capture source A");
+        std::fs::write(&fixture.path, "not valid FSL source").expect("replace with source B");
+
+        let (output, status) =
+            run_html_report_from_source(&fixture.path, &captured, 4, "warn", "bmc", None);
+        assert_eq!(status, 0, "{output:#}");
+        assert_eq!(output["result"], "generated", "{output:#}");
+        assert_eq!(output["spec"], "VacuousLeadstoFixture", "{output:#}");
+        assert!(
+            output["content"]
+                .as_str()
+                .is_some_and(|html| html.contains("VacuousLeadstoFixture")),
+            "HTML content must retain source A: {output:#}"
+        );
+    }
+
+    /// The only non-comparable HTML parity fields are wall-clock measurements.
+    /// Keep that exclusion live: both independently rendered reports must
+    /// actually contain the two observed timing keys.
+    #[test]
+    fn html_parity_timing_exclusions_are_present_in_both_reports() {
+        let source = include_str!("../tests/fixtures/vacuous_leadsto.fsl");
+        let fixture = SnapshotFixture::new("html-parity", source);
+        let captured = read_spec_source(&fixture.path).expect("capture source");
+        for report in [
+            run_html_report_from_source(&fixture.path, &captured, 4, "warn", "bmc", None).0,
+            run_html_report_from_source(&fixture.path, &captured, 4, "warn", "bmc", None).0,
+        ] {
+            let html = report["content"].as_str().expect("HTML content");
+            assert!(
+                html.contains("&quot;elapsed_s&quot;"),
+                "missing elapsed_s: {html}"
+            );
+            assert!(
+                html.contains("&quot;check_elapsed_s&quot;"),
+                "missing solver.check_elapsed_s: {html}"
+            );
+        }
     }
 
     /// Platform-neutral #808 control for `domain generate`. The scaffold's

--- a/rust/fslc/tests/issue_868_result_option_verdict_census.rs
+++ b/rust/fslc/tests/issue_868_result_option_verdict_census.rs
@@ -428,21 +428,14 @@ const CLASSIFICATIONS: &[Classification] = &[
     entry!(
         Verdict,
         "rust/fslc/src/main.rs",
-        14895,
+        14937,
         "governance_result_from_source",
         ResultOption
     ),
     entry!(
         Verdict,
         "rust/fslc/src/main.rs",
-        14824,
-        "implements_result",
-        ResultOption
-    ),
-    entry!(
-        Verdict,
-        "rust/fslc/src/main.rs",
-        14839,
+        14968,
         "implements_result_from_source",
         ResultOption
     ),

--- a/rust/fslc/tests/issue_932_check_snapshot.rs
+++ b/rust/fslc/tests/issue_932_check_snapshot.rs
@@ -35,7 +35,7 @@ fn run_against_two_snapshot_fifo(
     options: &[&str],
     source_a: &str,
     source_b: &str,
-) -> (Value, i32) {
+) -> (String, i32) {
     let mut fixture = TwoSnapshotFifo::new("check", source_a, source_b);
     let path = fixture.fifo.to_string_lossy().into_owned();
     let mut child = ReapedChild::new(
@@ -65,9 +65,7 @@ fn run_against_two_snapshot_fifo(
             String::from_utf8_lossy(&output.stderr)
         )
     });
-    let json = serde_json::from_str(&stdout)
-        .unwrap_or_else(|error| panic!("invalid JSON: {error}; stdout={stdout}"));
-    (json, output.status.code().expect("exit status"))
+    (stdout, output.status.code().expect("exit status"))
 }
 
 /// Reverting `run_check_from_source` to any path-reading helper opens source
@@ -76,8 +74,10 @@ fn run_against_two_snapshot_fifo(
 #[cfg(unix)]
 #[test]
 fn check_reads_one_fifo_snapshot() {
-    let (output, status) =
+    let (stdout, status) =
         run_against_two_snapshot_fifo(&["check"], &[], CHECK_SOURCE_A, CHECK_SOURCE_B);
+    let output: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("invalid JSON: {error}; stdout={stdout}"));
 
     assert_eq!(status, 0, "{output:#}");
     assert_eq!(output["result"], "ok", "{output:#}");
@@ -90,16 +90,50 @@ fn check_reads_one_fifo_snapshot() {
 #[cfg(unix)]
 #[test]
 fn db_check_reads_one_fifo_snapshot() {
-    let (output, status) = run_against_two_snapshot_fifo(
+    let (stdout, status) = run_against_two_snapshot_fifo(
         &["db", "check"],
         &["--depth", "4"],
         DB_CHECK_SOURCE_A,
         DB_CHECK_SOURCE_B,
     );
+    let output: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("invalid JSON: {error}; stdout={stdout}"));
 
     assert_eq!(status, 0, "{output:#}");
     assert_eq!(output["result"], "verified_under_assumptions", "{output:#}");
     assert_eq!(output["dbsystem"], "SafeAddNullableColumn", "{output:#}");
+}
+
+/// Reverting any source-taking call in `run_explain_from_source` to a
+/// path-taking form opens source B and fails before cleanup. The complete
+/// envelope is still pinned to source A rather than a generic success.
+#[cfg(unix)]
+#[test]
+fn explain_reads_one_fifo_snapshot() {
+    let (stdout, status) =
+        run_against_two_snapshot_fifo(&["explain"], &[], CHECK_SOURCE_A, CHECK_SOURCE_B);
+    let output: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|error| panic!("invalid JSON: {error}; stdout={stdout}"));
+
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "explained", "{output:#}");
+    assert_eq!(output["spec"], "VacuousLeadstoFixture", "{output:#}");
+}
+
+/// Reverting any source-taking call in `run_html_report_from_source` opens
+/// source B and fails before cleanup. With no output path, HTML is delivered
+/// as raw stdout, so the rendered source-A spec name is the content oracle.
+#[cfg(unix)]
+#[test]
+fn html_reads_one_fifo_snapshot() {
+    let (html, status) =
+        run_against_two_snapshot_fifo(&["html"], &[], CHECK_SOURCE_A, CHECK_SOURCE_B);
+
+    assert_eq!(status, 0, "{html}");
+    assert!(
+        html.contains("VacuousLeadstoFixture"),
+        "HTML must be rendered from source A: {html}"
+    );
 }
 
 /// Windows does not implement the FIFO read-count oracle above. This marker


### PR DESCRIPTION
Second slice of #932, after #943 did `check` and `db check`.

## Problem

`explain` and `html` read the root spec path more than once per invocation, so a
single invocation could describe two different sources if the file changed between
reads. #943's requirement recovery measured all six command families with a FIFO
whose second open is fatal; every one opened the root path twice. These are two of
the four remaining.

## Contract change

Both commands acquire the source at entry and pass that one snapshot through every
downstream helper — for `explain` that means `weakening_candidates`,
`reachable_counterfactuals`, `invariant_violation_explanation`,
`invariant_counterfactuals`, and `readable_implements_text` as well as the command
body.

**Scope is `explain` and `html` only.** `ledger` and `analyze` stay for the third
slice; #943's measurement table is their starting point, so that slice needs no
re-survey.

## Output equivalence

Compared before and after in full, not field by field:

- `explain` — **byte-for-byte identical**.
- `html` — differs only in `verification.cost`'s `elapsed_s` and
  `solver.check_elapsed_s`. Those are wall-clock measurements of the run that
  produced them; there is no value they could be compared against, which is why
  they are excluded rather than "they may vary".

`html_parity_timing_exclusions_are_present_in_both_reports` keeps that exclusion
from going dead: it asserts both independently rendered reports actually contain
those two keys, so the exclusion fails if either key disappears. An exclusion of a
key that is no longer emitted weakens nothing while reading as deliberate.

## Controls

Two independent families, so neither platform coverage nor determinism rests on the
other:

- `rust/fslc/tests/issue_932_check_snapshot.rs` — FIFO controls
  (`explain_reads_one_fifo_snapshot`, `html_reads_one_fifo_snapshot`) that fail if a
  second source is opened. Unix-gated by necessity; a `#[cfg(not(unix))]` marker test
  keeps a passing non-Unix run from being mistaken for their evidence.
- `main.rs` `exit_status_tests` — deterministic controls with **no** `#[cfg(unix)]`,
  so Windows carries the same guarantee.

Calibration: the `explain` entry re-read mutation failed `explain`'s FIFO detector
with a second open while all three sibling controls, including `html`'s, stayed
green — the locality that makes it a detector for that route rather than for the
shared renderer. Restore proven by SHA-256 `05bf08…f8c9e` with an empty `git diff`.
The FIFO controls were run twice in one session after restore (4/4 both times),
since their verdict touches the filesystem.

## Two things that went wrong, recorded because the third slice will hit them

**A calibration mutation landed on a shared path.** The first `html` mutation made
both `html` and `explain` react, so it could not be cited as either route's
detector; it was replaced with an entry-only mutation. `analyze` shares paths
between its plain and `--ai-review` modes, so the third slice is more exposed to
this, not less.

**Two out-of-scope edits survived that switch.** `run_replay` was left calling
`load_model_from_source(path, source)` with no `source` in scope — it would not
compile — and `run_scenarios_mode_from_source` had been reverted to a path read,
which would have **regressed already-shipped `scenarios` behaviour**. Proving the
mutated site's revert by hash did not cover either, because both sat elsewhere in
the same file. Walking every `@@` header and naming which scope item it belongs to
is what found them; the second one would otherwise have shipped.

## Verification

Each gate's exit status was read from its log, not inferred from launching it. The
first round returned `fmt exit=1` (`main.rs:16926`) and `clippy exit=101`
(`needless_borrow` ×2 at `8545:60` and `9034:60`) — caught before committing, which
is the concrete form of the known failure where focused tests pass and workspace
clippy is skipped.

Re-measured after rebasing onto `93439c5`, because the pre-rebase run measured a
different commit:

| gate | exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets --locked -- -D warnings` | 0 |
| `cargo test -p fslc-rust --locked` | 0 (143 suites) |

`cargo test --workspace --locked` returned 0 before the rebase; the rebase only
dropped the commit that `#943` had squashed, so the workspace result is carried
forward rather than re-run.

`rust/fslc/tests/issue_868_result_option_verdict_census.rs` is updated for the
renamed helpers and their new lines.

Fragment: `changelog.d/932-explain-html-single-snapshot.fixed.md`.

Authorship note for review: this branch was produced under my orchestration, so
please read it as an authored change rather than an independently reviewed one.