### PR TITLE
feat(nix): add Nix flake and Devbox support for source-build installation

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,60 @@
+name: Nix flake
+
+# Validates the flake (flake.nix). For most nixify targets Nix is a side
+# concern and the full build can take 10+ minutes, so this workflow runs
+# only on manual dispatch, on published releases, or when flake-relevant
+# files change on a PR.
+#
+# Steps, in order of what they catch:
+#   1. nix flake check --all-systems  — every system's outputs evaluate
+#      (including darwin on an ubuntu runner).
+#   2. nix build .#default            — the from-source build (vendored Z3
+#      + Rust workspace) actually realises for the runner's system.
+#   3. nix run .#default -- --version — the built binary actually execs.
+#      This is the only step that catches the `let ... in rec` shadowing
+#      class of bug (passes flake check, fails nix run). Do NOT drop it.
+
+on:
+  workflow_dispatch: {}
+  release:
+    types: [published]
+  pull_request:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "**/*.nix"
+      - ".github/workflows/nix.yml"
+      - "rust/Cargo.lock"
+      - "rust/Cargo.toml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab602fd15196c2084a2eea5ff2d25 # v22
+
+      - name: nix flake check --all-systems
+        run: nix flake check --all-systems --no-build
+
+      - name: nix build .#default
+        run: nix build .#default --print-build-logs
+
+      - name: nix run .#default -- --version
+        if: github.event_name != 'pull_request'
+        run: nix run .#default -- --version

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ docs/index.bleve/
 # Relational Design plugin local trace/session state — working scratch for the
 # design process, not a repo deliverable (the decisions land in docs/DESIGN-*.md)
 .relational-design/
+
+# Nix build result symlinks
+/result
+/result-*
+# Devbox generated artifacts
+.devbox/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ integration. Use one of the other two routes only if it specifically fits you:
 
 - Just want the `fslc` binary, nothing else (no PATH setup, no skills)? [Download a single
   executable](#download-a-single-executable-instead).
+- Already use Nix? [Nix (Flakes)](#nix-flakes) builds `fslc` from source with Z3 bundled in.
 - Building `fslc` yourself, or need the frozen Python reference for compatibility work?
   [Developer setup](#developer-setup-building-from-source).
 
@@ -110,6 +111,62 @@ baseline (glibc 2.39 or newer).
 
 > This binary bundles Z3, so all features including `verify` work without a separately
 > installed solver. Normal operating-system runtime libraries still apply.
+
+### Nix (Flakes)
+
+The project provides optional Nix flake outputs for users who already use Nix. The flake builds `fslc` (and `fslc-lsp`) from source with Z3 bundled in.
+
+```bash
+# Latest source from default branch
+nix run github:ymm-oss/fsl
+
+# Specific release (uses the flake at that git tag)
+nix run github:ymm-oss/fsl/v4.4.1
+
+# Named outputs: #fslc, #source
+nix run github:ymm-oss/fsl#fslc
+nix run github:ymm-oss/fsl#source
+
+# Build / develop
+nix build github:ymm-oss/fsl
+nix develop github:ymm-oss/fsl
+```
+
+The flake exposes `packages.<system>.fslc` / `.default` / `.source`, `apps.<system>.fslc` / `.default`, `devShells.<system>.default`, and `overlays.default`.
+
+Update through the same Nix workflow you used to install. For profile installs, run `nix profile list` and then `nix profile upgrade <index-or-name>`. For flake inputs, run `nix flake update fsl` in your own flake and rebuild.
+
+### Devbox
+
+For a reproducible development environment (Rust toolchain + `cmake` for the bundled Z3 build), use [Devbox](https://www.jetify.com/devbox):
+
+```bash
+# Install Devbox first (if not already installed)
+curl -fsSL https://get.jetify.dev/devbox | bash
+
+# Initialize the environment
+devbox shell
+
+# Build the project (uses --manifest-path rust/Cargo.toml)
+devbox run build
+
+# Run the verifier on a spec
+devbox run check
+```
+
+Or install Devbox via Homebrew:
+
+```bash
+brew install jetify-com/devbox/devbox
+```
+
+> **Note for x86_64-darwin (Intel Mac) users:** Devbox currently uses
+> nixpkgs-unstable internally, which has dropped x86_64-darwin support.
+> Use the Nix flake dev shell instead:
+>
+> ```bash
+> nix develop --extra-experimental-features 'nix-command flakes'
+> ```
 
 ## Write your first spec with an AI agent
 

--- a/changelog.d/0000-nix-package-manager-install.added.md
+++ b/changelog.d/0000-nix-package-manager-install.added.md
@@ -1,0 +1,7 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+Nix flake support for installing `fslc` and `fslc-lsp` from source via
+`nix build .#fslc`, `nix run .#default -- --version`, or
+`nix profile install github:ymm-oss/fsl`. The flake uses crane for crate
+vendoring, builds vendored Z3 via CMake, and supports `x86_64-linux`,
+`aarch64-linux`, `x86_64-darwin`, and `aarch64-darwin`. A Devbox
+configuration and Nix CI workflow are included.

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.12.0/.schema/devbox.schema.json",
+  "packages": [
+    "rustc",
+    "cargo",
+    "rust-analyzer",
+    "clippy",
+    "rustfmt",
+    "cmake",
+    "pkg-config",
+    "python3",
+    "act"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to the FSL devbox environment!'"
+    ],
+    "scripts": {
+      "build": "cargo build --manifest-path rust/Cargo.toml --workspace --locked",
+      "test": "cargo test --manifest-path rust/Cargo.toml --workspace --locked",
+      "check": "cargo run --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc -- check specs/cart_v1.fsl",
+      "verify": "cargo run --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc -- verify specs/cart_v1.fsl --depth 8",
+      "fmt": "cargo fmt --manifest-path rust/Cargo.toml --all",
+      "fmt-check": "cargo fmt --manifest-path rust/Cargo.toml --all -- --check",
+      "clippy": "cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings",
+      "run": "cargo run --manifest-path rust/Cargo.toml -p fslc-rust --bin fslc --"
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,42 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "act": {
+      "resolved": "github:NixOS/nixpkgs/e8be7818e19ada32105a8af937a6a473b38167ca#act",
+      "source": "nixpkg"
+    },
+    "cargo": {
+      "resolved": "github:NixOS/nixpkgs/e8be7818e19ada32105a8af937a6a473b38167ca#cargo",
+      "source": "nixpkg"
+    },
+    "clippy": {
+      "resolved": "github:NixOS/nixpkgs/e8be7818e19ada32105a8af937a6a473b38167ca#clippy",
+      "source": "nixpkg"
+    },
+    "cmake": {
+      "resolved": "github:NixOS/nixpkgs/e8be7818e19ada32105a8af937a6a473b38167ca#cmake",
+      "source": "nixpkg"
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-08-29T00:50:12Z",
+      "resolved": "github:NixOS/nixpkgs/e8be7818e19ada32105a8af937a6a473b38167ca?lastModified=1787964612"
+    },
+    "pkg-config": {
+      "resolved": "github:NixOS/nixpkgs/e8be7818e19ada32105a8af937a6a473b38167ca#pkg-config",
+      "source": "nixpkg"
+    },
+    "python3": {
+      "plugin_version": "0.0.5",
+      "resolved": "github:NixOS/nixpkgs/e8be7818e19ada32105a8af937a6a473b38167ca#python3",
+      "source": "nixpkg"
+    },
+    "rust-analyzer": {
+      "resolved": "github:NixOS/nixpkgs/e8be7818e19ada32105a8af937a6a473b38167ca#rust-analyzer",
+      "source": "nixpkg"
+    },
+    "rustfmt": {
+      "resolved": "github:NixOS/nixpkgs/e8be7818e19ada32105a8af937a6a473b38167ca#rustfmt",
+      "source": "nixpkg"
+    }
+  }
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1787326676,
+        "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "692f7e9ef2ece8125b466f66f2af532b3edaed0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787964612,
+        "narHash": "sha256-0N9nghg3nwzX6b6qc77EzjR9cu/Z+UR66FlfsCqiURs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e8be7818e19ada32105a8af937a6a473b38167ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-darwin": {
+      "locked": {
+        "lastModified": 1787940818,
+        "narHash": "sha256-vFzVv78WlyEbTyV5BbrnicnV159wC0YPOcBe3QagyBI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f6107e546a5012172d93e79f1f7950da02ad798f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin": "nixpkgs-darwin"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,89 @@
+{
+  description = "FSL — AI-native formal specification language verifier (fslc)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # nixpkgs-unstable (26.11) has dropped x86_64-darwin support.
+    # Pin x86_64-darwin to the 26.05 stable branch, which still supports
+    # it and is compatible with crane (requires nixpkgs >= 26.05).
+    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+    flake-utils.url = "github:numtide/flake-utils";
+    # crane uses `cargo vendor` (cargo's own HTTP client with a proper
+    # User-Agent) rather than Nix fetchurl, which avoids crates.io 403
+    # rejections when downloading crate tarballs.
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-darwin, flake-utils, crane, ... }@inputs:
+    (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs =
+          if system == "x86_64-darwin"
+          then nixpkgs-darwin.legacyPackages.${system}
+          else nixpkgs.legacyPackages.${system};
+        craneLib = crane.mkLib pkgs;
+
+        fslc = craneLib.buildPackage {
+          pname = "fslc";
+          version = "4.4.1";
+          # The Cargo workspace lives under rust/; build from there so
+          # crane finds Cargo.toml and Cargo.lock at the source root.
+          # Use cleanSource (not crane's cleanCargoSource) because
+          # fsl-tools uses include_str! for non-Rust files (.css, .txt)
+          # that cleanCargoSource would filter out.
+          src = pkgs.lib.cleanSource ./rust;
+          # Build only the native CLI and LSP server; fsl-wasm targets
+          # wasm32-unknown-unknown and is not buildable on native targets.
+          cargoBuild = "cargo build --release -p fslc-rust -p fsl-lsp";
+          # The project's own CI runs the full test suite; keep the Nix
+          # build focused on producing installable binaries.
+          doCheck = false;
+          # The z3 crate uses the "vendored" feature, which builds Z3 from
+          # bundled source via cmake.
+          nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config pkgs.python3 ];
+          buildInputs =
+            pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];
+          meta = {
+            description = "AI-native formal specification language verifier with bundled Z3";
+            homepage = "https://github.com/ymm-oss/fsl";
+            license = pkgs.lib.licenses.asl20;
+            mainProgram = "fslc";
+          };
+        };
+      in
+      {
+        packages = {
+          # Users naturally try .#fslc, so expose it alongside default.
+          fslc = fslc;
+          default = fslc;
+          source = fslc;
+        };
+
+        apps = {
+          fslc = {
+            type = "app";
+            program = "${fslc}/bin/fslc";
+          };
+          default = {
+            type = "app";
+            program = "${fslc}/bin/fslc";
+          };
+        };
+
+        checks = {
+          build = fslc;
+        };
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config pkgs.python3 ];
+          buildInputs =
+            [ pkgs.rustc pkgs.cargo ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];
+        };
+      }
+    )) // {
+      overlays.default = final: prev: {
+        fslc = self.packages.${final.system}.fslc;
+      };
+    };
+}


### PR DESCRIPTION
## What

Adds a `flake.nix` so FSL can be installed and run directly from GitHub:

```bash
nix run github:ymm-oss/fsl
nix profile add github:ymm-oss/fsl
```

Adds a `devbox.json` for reproducible development environments:

```bash
devbox shell
devbox run build
```

## Why

Enables one-command install for users who already have Nix installed. The flake builds `fslc` (and `fslc-lsp`) from source with Z3 bundled in, with all inputs pinned in `flake.lock`.

## Changes

- **`flake.nix`**: Nix flake using [crane](https://github.com/ipetkov/crane) for crate vendoring. Outputs: `packages.fslc` / `.default` / `.source`, `apps.fslc` / `.default`, `overlays.default`, `devShells.default`, and `checks`. Builds the `fslc-rust` and `fsl-lsp` workspace members. Z3 is bundled via the `z3` crate's `vendored` feature; `cmake` and `python3` are in `nativeBuildInputs` for the vendored Z3 build.
- **`flake.lock`**: Reproducible lockfile (nixpkgs-unstable, nixpkgs-26.05-darwin, crane, flake-utils).
- **`devbox.json`**: Devbox configuration with Rust toolchain, `cmake`, `python3`, `rust-analyzer`, `clippy`, `rustfmt`, and `act`.
- **`devbox.lock`**: Devbox lockfile for reproducible environments.
- **`.gitignore`**: Added `/result`, `/result-*`, and `.devbox/`.
- **`.github/workflows/nix.yml`**: GitHub Actions CI — `nix flake check --all-systems --no-build`, `nix build .#default`, `nix run .#default -- --version`.
- **`README.md`**: Added "Nix (Flakes)" and "Devbox" install subsections.
- **`changelog.d/0000-nix-package-manager-install.added.md`**: Changelog fragment.

## Testing

Verified locally on `x86_64-darwin`:

```bash
nix flake check --all-systems --no-build   # all 4 systems evaluate
nix build .#fslc                            # succeeds
./result/bin/fslc --version                 # fslc 4.4.1
nix run .#default -- --version              # fslc 4.4.1
nix develop --command cargo --version       # cargo 1.95.0
```

`fslc-lsp` responds correctly to an LSP `initialize` request (hover, completion, definition, references, documentSymbol, codeAction, rename, semanticTokens capabilities).

## Design notes

- **Crane instead of `buildRustPackage`**: nixpkgs' `fetchurl`-based crate downloader doesn't send a User-Agent header, causing crates.io to return HTTP 403. Crane uses `cargo vendor` which sends proper headers.
- **`cleanSource` instead of `cleanCargoSource`**: `fsl-tools` uses `include_str!` for non-Rust files (`.css`, `.txt`) that `cleanCargoSource` would filter out.
- **`nixpkgs-26.05-darwin` pin for x86_64-darwin**: nixpkgs-unstable (26.11) dropped x86_64-darwin support; 26.05 is the last stable branch supporting it and is compatible with crane.
- **`python3` in `nativeBuildInputs`**: Z3's CMake build requires Python3.
- No breaking changes to existing build paths — additive only.

## Related

Resolves #957
