### PR TITLE
Docs: synchronize language-feature checklists

### DIFF
--- a/.claude/agents/fsl-coupled-change-reviewer.md
+++ b/.claude/agents/fsl-coupled-change-reviewer.md
@@ -12,9 +12,11 @@ together. Inspect staged and unstaged changes; do not modify them.
 ## Coupling map
 
 1. Syntax or surface grammar in `rust/fsl-syntax` requires the corresponding lowering/model work,
-   regression cases, `docs/LANGUAGE.md`, `skills/fsl/references/`, an accepted `docs/DESIGN-*.md`, and
-   a new `changelog.d/<id>-<slug>.<category>.md` fragment (see `changelog.d/README.md`) -- not a direct
-   `CHANGELOG.md` edit, which is aggregated from fragments only at release time.
+   regression cases, `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, `skills/fsl/references/`, an accepted
+   `docs/DESIGN-*.md`, and a new `changelog.d/<id>-<slug>.<category>.md` fragment (see
+   `changelog.d/README.md`) -- not a direct `CHANGELOG.md` edit, which is aggregated from fragments only
+   at release time. A new declaration, binder, or reference form additionally requires
+   `rust/fsl-lsp/src/index.rs` and a targeted role/scope test.
 2. Typed semantics in `rust/fsl-core` or symbolic behavior in `rust/fsl-verifier` requires matching
    `rust/fsl-runtime` behavior when concretely evaluable, plus agreement/false-negative evidence.
 3. Solver changes require the relevant backend tests and preservation of runtime solver independence.

--- a/.claude/skills/add-language-feature/SKILL.md
+++ b/.claude/skills/add-language-feature/SKILL.md
@@ -17,9 +17,11 @@ typed Kernel behavior, evaluator semantics, CLI/report behavior, or public Kerne
 - `rust/fsl-tools` or `rust/fslc`: report/command/envelope behavior when applicable.
 - `rust/fsl-wasm`: only when Worker-visible behavior or shared envelopes require it.
 - Focused positive, negative, and boundary regression evidence.
-- `docs/LANGUAGE.md`, `skills/fsl/references/`, relevant `docs/DESIGN-*.md`, docs map, and a new
-  `changelog.d/<id>-<slug>.<category>.md` fragment (see `changelog.d/README.md`) -- not a direct
-  `CHANGELOG.md` edit.
+- `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, `skills/fsl/references/`, relevant `docs/DESIGN-*.md`,
+  docs map, and a new `changelog.d/<id>-<slug>.<category>.md` fragment (see `changelog.d/README.md`)
+  -- not a direct `CHANGELOG.md` edit.
+- A new declaration, binder, or reference form: `rust/fsl-lsp/src/index.rs` and a targeted role/scope
+  test.
 - Schemas/conformance vectors when the public Kernel contract changes.
 
 Do not update `src/fslc` by default. Record the explicit compatibility or LSP contract before changing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,9 @@ inventory and explicitly optional Python surfaces.
 ## Guidelines for changes
 
 - **Language or semantics:** update Rust syntax/lowering, typed model, symbolic and concrete evaluation,
-  regression cases, `docs/LANGUAGE.md`, `skills/fsl/references/`, an accepted design note, and a new
-  `changelog.d/` fragment (see `changelog.d/README.md`) together. A new dialect's top-level construct,
+  regression cases, `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, `skills/fsl/references/`, an accepted
+  design note, and a new `changelog.d/` fragment (see `changelog.d/README.md`) together. A new dialect's
+  top-level construct,
   and any new `examples/`/`specs/`
   directory it lands in, must also be registered in `tests/dialect_registry.py` (`DIALECTS`,
   `EVIDENCE_CONSTRUCTS`, or `MONITOR_EXCLUSIONS` with a reason) — the conformance harness
@@ -67,6 +68,8 @@ inventory and explicitly optional Python surfaces.
   to fail loudly on an unregistered construct instead of silently skipping it. That harness is a
   manual/reference check that no CI lane currently invokes (see the design doc's "Cost and CI
   wiring") — register the construct regardless of that gap.
+- **A new declaration, binder, or reference form:** also update `rust/fsl-lsp/src/index.rs` and a
+  targeted role/scope test.
 - **Public Kernel contract:** update schemas, Rust exporter/consumer paths, conformance vectors,
   agreement tests, `docs/DESIGN-kernel-contract.md`, language/reference docs, and a new
   `changelog.d/` fragment (see `changelog.d/README.md`) rather than editing `CHANGELOG.md` directly.

--- a/docs/DESIGN-coupled-change-metatest.md
+++ b/docs/DESIGN-coupled-change-metatest.md
@@ -1,4 +1,4 @@
-# FSL — coupled-change metatests (native LSP corpus/index + DESIGN-doc coverage)
+# FSL — coupled-change metatests (native LSP corpus/index + checklist presence + DESIGN-doc coverage)
 
 Motivation: issue #168. The repository rule that a language feature moves with
 its parser, model, runtime, documentation, and tests began as a human checklist.
@@ -6,11 +6,12 @@ The original Python metatest caught dialects and grammar productions that the
 Python LSP index silently omitted. Issue #310 moved the language server and its
 coverage gate to the authoritative Rust implementation.
 
-The coupled-change checks now have two owners:
+The coupled-change checks have two owners:
 
 - `rust/fsl-lsp/tests/corpus.rs` owns native LSP corpus and index coverage.
-- `tests/test_coupled_change_meta.py` retains compatibility checks for the
-  frozen Python reference and the DESIGN-document map.
+- `tests/test_coupled_change_meta.py` owns two native-to-frozen-Python
+  compatibility comparisons, two frozen-Python-sourced DESIGN-map checks, and
+  two language-neutral checks.
 
 ## 1. Native LSP corpus and index coverage
 
@@ -35,10 +36,20 @@ reference, rename, and semantic-token behavior. Server unit tests and
 `rust/fsl-lsp/tests/stdio.rs` cover request handling, unsaved buffers, workspace
 resolution, and the stdio lifecycle.
 
-## 2. DESIGN-doc coverage (dialect/feature ↔ docs/DESIGN-*.md)
+## 2. Language-feature checklist presence
 
-`tests/test_coupled_change_meta.py` keeps five tests whose inspected surfaces
-remain frozen-Python-owned or language-neutral:
+`test_language_feature_checklists_include_coupled_obligations` checks three
+authored checklists for the required Japanese language reference and conditional
+LSP index plus targeted role/scope-test obligations. It is a fail-closed,
+additive documentation-presence control: it reports each exact missing member
+and copy, but does not establish LSP semantics, translation freshness, or
+product verification.
+
+## 3. DESIGN-doc coverage (dialect/feature ↔ docs/DESIGN-*.md)
+
+The module's other five checks comprise two native-to-frozen-Python
+compatibility comparisons, two frozen-Python-sourced DESIGN-map checks, and one
+language-neutral check:
 
 1. **`test_retained_python_dialect_registry_matches_native_authority`** — the
    frozen Python dialect registry exactly matches the native dispatch registry.
@@ -54,7 +65,7 @@ remain frozen-Python-owned or language-neutral:
    compatibility CLI command maps to an existing design document or a reviewed
    waiver reason.
 
-These five Python tests run as required pre-merge repository/compatibility
+Together, these six Python tests run as required pre-merge repository/compatibility
 evidence through `tools/check-merge-readiness.sh automation` and the
 `merge readiness / automation contracts` job. They are not product evidence
 and are not invoked by the Rust-native `./tools/check-native-integration.sh`

--- a/tests/test_coupled_change_meta.py
+++ b/tests/test_coupled_change_meta.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Python compatibility and DESIGN-doc coupled-change metatests (issue #168).
+"""Python compatibility, checklist-presence, and DESIGN-doc coupled-change metatests (issue #168).
 
 The authoritative LSP corpus/index gate moved to `rust/fsl-lsp/tests/corpus.rs`.
-This module retains only the frozen Python compatibility checks and the
-DESIGN-doc map checks that still inspect Python-owned surfaces.
+This module retains frozen Python compatibility, language-neutral checklist-presence,
+and DESIGN-doc map checks that do not claim native LSP behavior.
 """
 from __future__ import annotations
 
@@ -20,6 +20,25 @@ from fslc.grammar import GRAMMAR
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
+LANGUAGE_FEATURE_CHECKLISTS = (
+    "CONTRIBUTING.md",
+    ".claude/skills/add-language-feature/SKILL.md",
+    ".claude/agents/fsl-coupled-change-reviewer.md",
+)
+LANGUAGE_FEATURE_CHECKLIST_MEMBERS = (
+    "docs/LANGUAGE.ja.md",
+    "rust/fsl-lsp/src/index.rs",
+    "targeted role/scope test",
+)
+
+
+def language_feature_checklist_missing_pairs():
+    return tuple(
+        (member, copy)
+        for copy in LANGUAGE_FEATURE_CHECKLISTS
+        for member in LANGUAGE_FEATURE_CHECKLIST_MEMBERS
+        if member not in " ".join((ROOT / copy).read_text(encoding="utf-8").split())
+    )
 
 
 def test_retained_python_dialect_registry_matches_native_authority():
@@ -40,6 +59,14 @@ def test_native_ai_project_block_gate_matches_retained_parser():
     assert block is not None
     native = set(re.findall(r'"([a-z_]+)"', block.group("body")))
     assert native == PROJECT_BLOCKS
+
+
+def test_language_feature_checklists_include_coupled_obligations():
+    missing_pairs = language_feature_checklist_missing_pairs()
+    assert not missing_pairs, ",".join(
+        f"missing={member},copy={copy}" for member, copy in missing_pairs
+    )
+
 
 # DESIGN-doc coverage
 


### PR DESCRIPTION
## Summary

- Synchronize the three language-feature checklists with the existing coupled-change authority in `AGENTS.md`.
- Make `docs/LANGUAGE.ja.md` unconditional for language changes, while keeping `rust/fsl-lsp/src/index.rs` and a targeted role/scope test conditional on a new declaration, binder, or reference form.
- Add a focused fail-closed metatest and document exactly what the six coupled-change checks establish.

## Changes

- Update `CONTRIBUTING.md`, `.claude/skills/add-language-feature/SKILL.md`, and `.claude/agents/fsl-coupled-change-reviewer.md` with the same obligations and condition boundary.
- Extend `tests/test_coupled_change_meta.py` with a deterministic missing-pair detector covering all three checklist copies.
- Update `docs/DESIGN-coupled-change-metatest.md` to describe two native-to-frozen-Python comparisons, two frozen-Python-sourced DESIGN-map checks, and two language-neutral checks.

## Contract interpretation

`AGENTS.md` is treated as the existing authority: a language feature moves with both canonical language references, and a new declaration, binder, or reference form additionally moves with the native LSP index and a targeted role/scope test. This PR synchronizes process documentation and its guard; it does not change language, CLI, API, schema, runtime, or LSP semantics.

User-authorized direct maintenance; no issue is resolved by this PR.

## Verification

- `python3 -m pytest tests/test_coupled_change_meta.py -q` — run twice, exit 0, 6 passed each time.
- `git diff --check f565aeb9c46daa28a927ecad79bfdb72e44b6bb7..599e2e88cc13b9a0d5b2d25888320b4c229847fc` — run twice, exit 0.
- `BASE_SHA=f565aeb9c46daa28a927ecad79bfdb72e44b6bb7 HEAD_SHA=599e2e88cc13b9a0d5b2d25888320b4c229847fc ./tools/check-merge-readiness.sh automation` — run twice, exit 0.
- Negative control: removing only `docs/LANGUAGE.ja.md` from the skill checklist produced the exact missing pair for that copy; restoring it returned `missing=[]` and the named baseline diff.
- Same-series Sol review reached zero findings in round 5; cross-series Claude review reached zero findings in round 3.

The merge-readiness command is bounded PR evidence, not product verification. The native product gate was not run because this PR changes no product semantics; the repository-required post-merge product gate remains applicable after integration.

## Risk / review notes

- No migration, persisted data, dependency, configuration, public contract, or generated snapshot changes.
- No changelog fragment: this is non-notable internal process-document synchronization with no product behavior change.
- The focused guard establishes checklist-member presence; it does not establish translation freshness, LSP behavior, or native product correctness.

## Adjacent comparison evidence

These records provide historical or compliant examples only; none owns this maintenance slice:

- https://github.com/ymm-oss/fsl/issues/168
- https://github.com/ymm-oss/fsl/pull/182
- https://github.com/ymm-oss/fsl/issues/504
- https://github.com/ymm-oss/fsl/issues/746
- https://github.com/ymm-oss/fsl/issues/786
- https://github.com/ymm-oss/fsl/pull/787
- https://github.com/ymm-oss/fsl/pull/894
- https://github.com/ymm-oss/fsl/pull/955
