### PR TITLE
docs(testgen): conformance layer-selection norm (#643, slice 1)

### DIFF
--- a/changelog.d/643-testgen-layer-selection.documented.md
+++ b/changelog.d/643-testgen-layer-selection.documented.md
@@ -1,0 +1,5 @@
+Documented (#643): conformance-test layer-selection norm — generate from the
+implementation's layer granularity; reuse upper-layer `forbidden` negatives only,
+not upper positive scenarios (forward-simulation rationale and
+`examples/refinement_chain` example in `docs/LANGUAGE.md` §12 and
+`skills/fsl/references/impl.md` §9).

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -1638,6 +1638,19 @@ fslc scenarios specs/order_system.fsl
 を生成する → 実装を `Adapter` に結線する → テストを実行する**。`Monitor` は
 ランダムウォークテストのオラクルとして使われます。
 
+**層の選び方:** コンフォーマンステストは、検査対象の実装と**同じ粒度の層**の spec
+から生成する。上位層から流用してよいのは **`forbidden`(負例)シナリオだけ**である。
+負例トレースは精緻化(refinement)のあとも健全だが、上位層の**正例**
+(`acceptance`、`cover`、ランダムウォークの witness)を下位実装のテストにそのまま使うと、
+正当に精緻化された実装を誤って落としうる。refinement は抽象モデルを下位が再現できるか
+を見る**前向きシミュレーション**であり、抽象側の正例トレースをすべて下位で再生できる
+ことを要求する**逆向き再生**ではないからである。**例:**
+`examples/refinement_chain/top.fsl` では初期 `TOpen` からすぐ `finish` できるが、
+`mid.fsl` では `MOpen → MReview` のあとでなければ `finish` できない。`ChainTop` の
+正例 `finish` トレースを `ChainMid` 実装のテストに使ってはならない。詳細は
+`docs/DESIGN-layers.md` を参照(refinement 連鎖の末端は design 層への testgen/replay;
+requirements の `acceptance` は**その層**の scenarios/testgen へ流れる)。
+
 `testgen` は、言語非依存のシナリオ収集コア(`scenarios`)をターゲットごとの
 エミッタから分離しているので、同じシナリオが複数のハーネスへレンダリングされます。
 ネイティブ実装では、6 つのエミッタすべてが、Public Kernel v1、シナリオ JSON、

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1689,6 +1689,18 @@ Recommended workflow: **`verify` / `prove` the spec → generate the scaffold wi
 `testgen` → wire the implementation into the `Adapter` → run the tests**. `Monitor`
 is used as an oracle in random-walk testing.
 
+**Layer selection:** generate conformance tests from the spec at the **same layer
+granularity as the implementation** you are checking. From an **upper** layer you
+may reuse **`forbidden` (negative) scenarios only** — forbidden traces remain
+sound under refinement, but upper-layer **positive** scenarios (`acceptance`,
+`cover`, random-walk witnesses) can falsely fail a legitimately refined
+implementation because refinement is forward simulation, not backward replay of
+every abstract positive trace. **Example:** `examples/refinement_chain/top.fsl`
+lets `finish` from initial `TOpen`; `mid.fsl` requires `MOpen → MReview` first —
+a `ChainTop` positive `finish` trace must not be used as a `ChainMid`
+implementation test. See `docs/DESIGN-layers.md` (refinement chain → design-layer
+testgen/replay; requirements `acceptance` → that layer's scenarios/testgen).
+
 `testgen` separates a language-independent scenario-collection core (`scenarios`)
 from per-target emitters, so the same scenarios render to multiple harnesses. In
 the native implementation all six emitters consume one validated adapter built

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -1712,6 +1712,17 @@ implementation (see <code>DESIGN-bridge.md</code>).</p>
 <p>Recommended workflow: <strong><code>verify</code> / <code>prove</code> the spec → generate the scaffold with
 <code>testgen</code> → wire the implementation into the <code>Adapter</code> → run the tests</strong>. <code>Monitor</code>
 is used as an oracle in random-walk testing.</p>
+<p><strong>Layer selection:</strong> generate conformance tests from the spec at the <strong>same layer
+granularity as the implementation</strong> you are checking. From an <strong>upper</strong> layer you
+may reuse <strong><code>forbidden</code> (negative) scenarios only</strong> — forbidden traces remain
+sound under refinement, but upper-layer <strong>positive</strong> scenarios (<code>acceptance</code>,
+<code>cover</code>, random-walk witnesses) can falsely fail a legitimately refined
+implementation because refinement is forward simulation, not backward replay of
+every abstract positive trace. <strong>Example:</strong> <code>examples/refinement_chain/top.fsl</code>
+lets <code>finish</code> from initial <code>TOpen</code>; <code>mid.fsl</code> requires <code>MOpen → MReview</code> first —
+a <code>ChainTop</code> positive <code>finish</code> trace must not be used as a <code>ChainMid</code>
+implementation test. See <code>docs/DESIGN-layers.md</code> (refinement chain → design-layer
+testgen/replay; requirements <code>acceptance</code> → that layer's scenarios/testgen).</p>
 <p><code>testgen</code> separates a language-independent scenario-collection core (<code>scenarios</code>)
 from per-target emitters, so the same scenarios render to multiple harnesses. In
 the native implementation all six emitters consume one validated adapter built

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -1662,6 +1662,18 @@ fslc scenarios specs/order_system.fsl
 <p>推奨ワークフロー: <strong>spec を <code>verify</code> / <code>prove</code> する → <code>testgen</code> でスキャフォールド
 を生成する → 実装を <code>Adapter</code> に結線する → テストを実行する</strong>。<code>Monitor</code> は
 ランダムウォークテストのオラクルとして使われます。</p>
+<p><strong>層の選び方:</strong> コンフォーマンステストは、検査対象の実装と<strong>同じ粒度の層</strong>の spec
+から生成する。上位層から流用してよいのは <strong><code>forbidden</code>(負例)シナリオだけ</strong>である。
+負例トレースは精緻化(refinement)のあとも健全だが、上位層の<strong>正例</strong>
+(<code>acceptance</code>、<code>cover</code>、ランダムウォークの witness)を下位実装のテストにそのまま使うと、
+正当に精緻化された実装を誤って落としうる。refinement は抽象モデルを下位が再現できるか
+を見る<strong>前向きシミュレーション</strong>であり、抽象側の正例トレースをすべて下位で再生できる
+ことを要求する<strong>逆向き再生</strong>ではないからである。<strong>例:</strong>
+<code>examples/refinement_chain/top.fsl</code> では初期 <code>TOpen</code> からすぐ <code>finish</code> できるが、
+<code>mid.fsl</code> では <code>MOpen → MReview</code> のあとでなければ <code>finish</code> できない。<code>ChainTop</code> の
+正例 <code>finish</code> トレースを <code>ChainMid</code> 実装のテストに使ってはならない。詳細は
+<code>docs/DESIGN-layers.md</code> を参照(refinement 連鎖の末端は design 層への testgen/replay;
+requirements の <code>acceptance</code> は<strong>その層</strong>の scenarios/testgen へ流れる)。</p>
 <p><code>testgen</code> は、言語非依存のシナリオ収集コア(<code>scenarios</code>)をターゲットごとの
 エミッタから分離しているので、同じシナリオが複数のハーネスへレンダリングされます。
 ネイティブ実装では、6 つのエミッタすべてが、Public Kernel v1、シナリオ JSON、

--- a/skills/fsl-delivery/SKILL.md
+++ b/skills/fsl-delivery/SKILL.md
@@ -78,6 +78,12 @@ rules in this skill.
    - design refines requirements with an explicit mapping (`fslc refine`)
    - implementation conforms through generated tests or event-log replay
    - gate the whole chain at once with `fslc chain` when a manifest exists
+   - **testgen layer selection:** run `fslc testgen` on the spec at the **same
+     layer granularity as the implementation** (design `spec` for design-aligned
+     code). From upper layers, reuse **`forbidden` negatives only** — they stay
+     sound under refinement; upper **positive** scenarios can falsely fail a
+     sound refinement (see `../fsl/references/impl.md` §9 and
+     `examples/refinement_chain/{top,mid}.fsl`).
 6. Report proof categories separately. Never collapse "model is verified",
    "design refines requirements", and "implementation conforms" into one claim.
 

--- a/skills/fsl/references/impl.md
+++ b/skills/fsl/references/impl.md
@@ -1,5 +1,37 @@
 ## 9. Implementation connection (the testgen Adapter contract)
 
+### Layer selection for conformance tests
+
+Generate implementation-conformance tests from the spec at the **same layer
+granularity as the implementation** you are checking. `fslc testgen` against a
+design-layer `spec` checks the design model; against a `requirements` spec it
+checks the requirements model — pick the layer that matches what the Adapter
+projects.
+
+From an **upper** layer you may reuse **`forbidden` (negative) scenarios only**.
+Forbidden traces are sound under refinement: if the upper model must reject a
+sequence, a faithful lower layer must reject it too. Do **not** reuse upper-layer
+**positive** scenarios (`acceptance`, `cover`, random-walk witnesses) as
+implementation tests for a lower-layer implementation. Refinement is forward
+simulation (`fslc refine` asks whether the implementation model can simulate the
+abstract one), not backward simulation of every abstract positive trace. A
+legitimately refined lower layer may add intermediate states or guards that make
+an upper-layer positive trace unrealizable without violating the refinement
+contract.
+
+**Example:** In `examples/refinement_chain/top.fsl`, `ChainTop` starts in `TOpen`
+with `finish` enabled immediately (`fair action finish` requires only
+`st[c] == TOpen`). In `examples/refinement_chain/mid.fsl`, `ChainMid` requires
+`MOpen → MReview` before `finish` (`finish` requires `st[c] == MReview`). Running
+`ChainTop`'s positive `finish` trace against a `ChainMid` implementation falsely
+fails a sound refinement — the implementation correctly requires the review step
+the abstract top layer omitted.
+
+This matches `docs/DESIGN-layers.md`: the refinement chain ends with
+implementation conforming to the **design** layer via testgen/replay (§1); the
+requirements layer's `acceptance` flows into scenarios/testgen for **that layer's**
+conformance anchor (§5), not as a substitute for design-layer positive tests.
+
 Wire the generated file's `Adapter` to the implementation:
 - `reset()`: bring the implementation to the same initial state as init
 - `step(action, params)`: execute one action (in composition, `"alias.action"` names


### PR DESCRIPTION
## Summary

- **Slice 1 (docs-only):** documents the conformance-test layer-selection norm from #643 — generate from the implementation's layer granularity; reuse upper-layer `forbidden` negatives only, not upper positive scenarios (forward-simulation rationale + `examples/refinement_chain/{top,mid}.fsl` example).
- Updates `docs/LANGUAGE.md` §12, `skills/fsl/references/impl.md` §9, and `skills/fsl-delivery/SKILL.md`; aligns with `docs/DESIGN-layers.md` §1/§5.
- **Out of scope (later slices):** `--via-mapping`, unconditional requirements warning comments, auto-negative testgen default, and `test-plan.v1` (#844) — each touches CLI/emitter/snapshot contracts.

## Test plan

- [x] `git diff origin/main --stat` — docs + skills + changelog fragment only (no `rust/`, no `tests/snapshots/`)
- [x] Cited paths/lines verified with `sed` (`top.fsl` 2–7, `mid.fsl` 2–8, `DESIGN-layers.md` 33–38 / 232–235)
- [x] `BASE_SHA=… HEAD_SHA=… ./tools/aggregate_changelog.sh check-pr` — PASS
- [ ] `./tools/check-merge-readiness.sh automation` — local run blocked by Python 3.9 f-string in `tests/test_post_merge_reporter_workflow.py` (CI uses newer Python)

Closes #643 (docs slice only; follow-up issues/PRs expected for remaining proposals).


Made with [Cursor](https://cursor.com)