### PR TITLE
feat(mutate): add opt-in --oracle-attribution for oracle redundancy visibility

### DIFF
--- a/changelog.d/848-oracle-attribution.added.md
+++ b/changelog.d/848-oracle-attribution.added.md
@@ -1,0 +1,3 @@
+Add opt-in `--oracle-attribution` to `fslc mutate`, exposing per-mutant `killers`
+arrays and `by_obligation` sole/shared counts keyed by oracle display names while
+leaving default output unchanged.

--- a/docs/DESIGN-mutate.md
+++ b/docs/DESIGN-mutate.md
@@ -8,7 +8,8 @@ existence check. This productizes mutation as a repeatable non-triviality check.
 
 ## 1. CLI
 
-`fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
+`fslc mutate <f> [--depth K=8] [--by-requirement] [--oracle-attribution]
+[--max-mutants N=200]
 [--from mutants.jsonl]`. Output
 `result:"mutated"`, **exit 0 always** (a generator in the same family as scenarios/testgen;
 survivors are review data, not failures. `--fail-on-survivors` is future work).
@@ -149,9 +150,24 @@ can only demonstrate its work by **catching a behavior mutation**. Hence the cor
 mechanization is reversed: the kill oracle records each mutant's killer → aggregate by the
 `killed_by` requirement tag. **A requirement that killed no behavior mutation = an empty
 formalization**, warned as `empty_formalization`. v1 records the first-killer and explicitly
-labels this "lower observation bound" (sole-killer redundancy analysis is future work).
-Acceptance and forbidden kills are attributed through explicit requirement annotations on the
+labels this "lower observation bound". Acceptance and forbidden kills are attributed through explicit requirement annotations on the
 failed trace declaration; their AC/FB case IDs remain unique scenario identities, not requirements.
+
+## 4b. `--oracle-attribution` (opt-in full killer projection)
+
+Default `mutate` output is unchanged: `killed_by` remains the first-killer lower
+observation bound and `kill_rate` remains mutant union coverage. With
+`--oracle-attribution`, each killed mutant additionally carries a `killers` array
+listing every oracle display name that rejected it (invariant, reachable, ensures
+action name, `_bounds_*`, acceptance, forbidden, refinement, …), evaluated
+independently so the set is order-independent. The envelope also adds
+`by_obligation` keyed by those same oracle display names with `kills_any`,
+`sole_kills`, and `shared_kills` counts, plus `attribution:{mode:"all_killers",
+order_independent:true}`. These fields are **observed lower bounds** within the
+chosen mutant set and depth — not obligation completeness, not spec correctness,
+and not an assurance-class upgrade. The flag is explicit because full attribution
+is more expensive than first-killer recording; when the flag is off, nothing is
+fabricated (no empty `killers` arrays on the default path).
 
 ## 5. Output / ripple
 
@@ -162,6 +178,14 @@ failed trace declaration; their AC/FB case IDs remain unique scenario identities
  "mutants":[{"op","loc","target","status","killed_by","requirement","source"}],
  "by_requirement":{"REQ-7":{"kills":0,"warning":"empty_formalization"}},
  "notes":["mutant cap 200 reached: 37 dropped"]}
+```
+
+With `--oracle-attribution` only:
+
+```json
+{"mutants":[{"status":"killed","killed_by":"Funded","killers":["Funded","deposit"],…}],
+ "by_obligation":{"deposit":{"kills_any":1,"sole_kills":0,"shared_kills":1}},
+ "attribution":{"mode":"all_killers","order_independent":true}}
 ```
 
 New `src/fslc/mutate.py`. Deterministic enumeration + `--max-mutants` truncation is made

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -791,7 +791,7 @@ fslc diff      <old> <new> [--depth K] [--mapping map.fsl]
 fslc diff      --git BASE..HEAD [spec.fsl] [--depth K]
                                                  # revision-consistent tree materialization; omit spec for all changed .fsl
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
-fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]
+fslc mutate    <file.fsl> [--by-requirement] [--oracle-attribution] [--max-mutants N]
                [--from mutants.jsonl]             # built-in + external spec mutation (§15)
 fslc explain   <file.fsl> [--depth K] [--readable] # JSON by default; readable text review view (§15)
 fslc analyze   <file-or-dir>... [--projection tsg|action_state_graph|action_dependency_graph|code_audit|impact_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--code FILE_OR_DIR] [--focus NODE] [--profile ai-review] [--export tag-review] [--format json|dot|mermaid]  # structural/tag/code review (§15)
@@ -2717,7 +2717,10 @@ DESIGN-*.md があります)。
   拡張)。要件ごとのキル数とこの警告は、選択されたミュータント集合と深さの中で
   観測された下界です。acceptance と forbidden の kill は、失敗した trace 宣言の
   明示的な requirement annotation を使います。AC/FB case ID は暗黙の requirement
-  ではなく、trace case ID は宣言種別ごとに一意です。→
+  ではなく、trace case ID は宣言種別ごとに一意です。`--oracle-attribution`
+  (opt-in) はミュータントごとの `killers` 配列と、oracle 表示名をキーにした
+  `by_obligation` の sole/shared 集計を追加します。既定出力は変わらず、これらの
+  カウントは観測された下界であり、完全性や正しさの尺度ではありません。→
   [`DESIGN-mutate.md`](DESIGN-mutate.md)
 - **`fslc explain --readable`** — 骨格の列挙(状態、action の誰が/いつ/何を変える
   か、検証の境界、公平性、KPI の射影、branch の lowering、合成された refinement

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -818,7 +818,7 @@ fslc diff      <old> <new> [--depth K] [--mapping map.fsl]
 fslc diff      --git BASE..HEAD [spec.fsl] [--depth K]
                                                  # revision-consistent tree materialization; omit spec for all changed .fsl
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
-fslc mutate    <file.fsl> [--by-requirement] [--max-mutants N]
+fslc mutate    <file.fsl> [--by-requirement] [--oracle-attribution] [--max-mutants N]
                [--from mutants.jsonl]             # built-in + external spec mutation (§15)
 fslc explain   <file.fsl> [--depth K] [--readable] # JSON by default; readable text review view (§15)
 fslc analyze   <file-or-dir>... [--projection tsg|action_state_graph|action_dependency_graph|code_audit|impact_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--code FILE_OR_DIR] [--focus NODE] [--profile ai-review] [--export tag-review] [--format json|dot|mermaid]  # structural/tag/code review (§15)
@@ -2779,7 +2779,10 @@ DESIGN-*.md).
   lower bounds within the chosen mutant set and depth. Acceptance and forbidden
   kills use explicit requirement annotations on the failed trace declaration;
   AC/FB case IDs are not implicit requirements. Trace case IDs are unique
-  within each declaration kind.
+  within each declaration kind. `--oracle-attribution` (opt-in) adds per-mutant
+  `killers` arrays and `by_obligation` sole/shared counts keyed by oracle display
+  names; default output is unchanged and these counts are observed lower bounds,
+  not completeness or correctness measures.
   → [`DESIGN-mutate.md`](DESIGN-mutate.md)
 - **`fslc explain --readable`** — a text view over skeleton enumeration (state,
   action who/when/what-changes, verification bounds, fairness, KPI projections,

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -898,7 +898,7 @@ fslc diff      &lt;old&gt; &lt;new&gt; [--depth K] [--mapping map.fsl]
 fslc diff      --git BASE..HEAD [spec.fsl] [--depth K]
                                                  # revision-consistent tree materialization; omit spec for all changed .fsl
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
-fslc mutate    &lt;file.fsl&gt; [--by-requirement] [--max-mutants N]
+fslc mutate    &lt;file.fsl&gt; [--by-requirement] [--oracle-attribution] [--max-mutants N]
                [--from mutants.jsonl]             # built-in + external spec mutation (§15)
 fslc explain   &lt;file.fsl&gt; [--depth K] [--readable] # JSON by default; readable text review view (§15)
 fslc analyze   &lt;file-or-dir&gt;... [--projection tsg|action_state_graph|action_dependency_graph|code_audit|impact_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--code FILE_OR_DIR] [--focus NODE] [--profile ai-review] [--export tag-review] [--format json|dot|mermaid]  # structural/tag/code review (§15)
@@ -2749,7 +2749,10 @@ DESIGN-*.md).</p>
   lower bounds within the chosen mutant set and depth. Acceptance and forbidden
   kills use explicit requirement annotations on the failed trace declaration;
   AC/FB case IDs are not implicit requirements. Trace case IDs are unique
-  within each declaration kind.
+  within each declaration kind. <code>--oracle-attribution</code> (opt-in) adds per-mutant
+  <code>killers</code> arrays and <code>by_obligation</code> sole/shared counts keyed by oracle display
+  names; default output is unchanged and these counts are observed lower bounds,
+  not completeness or correctness measures.
   → <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-mutate.md"><code>DESIGN-mutate.md</code></a>
 - <strong><code>fslc explain --readable</code></strong> — a text view over skeleton enumeration (state,
   action who/when/what-changes, verification bounds, fairness, KPI projections,

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -872,7 +872,7 @@ fslc diff      &lt;old&gt; &lt;new&gt; [--depth K] [--mapping map.fsl]
 fslc diff      --git BASE..HEAD [spec.fsl] [--depth K]
                                                  # revision-consistent tree materialization; omit spec for all changed .fsl
 fslc chain     [fsl-project.toml] [--keep-going] # manifest-driven cross-layer report (§10)
-fslc mutate    &lt;file.fsl&gt; [--by-requirement] [--max-mutants N]
+fslc mutate    &lt;file.fsl&gt; [--by-requirement] [--oracle-attribution] [--max-mutants N]
                [--from mutants.jsonl]             # built-in + external spec mutation (§15)
 fslc explain   &lt;file.fsl&gt; [--depth K] [--readable] # JSON by default; readable text review view (§15)
 fslc analyze   &lt;file-or-dir&gt;... [--projection tsg|action_state_graph|action_dependency_graph|code_audit|impact_graph|requirement_property_graph|property_state_graph|refinement_graph|traceability_graph] [--code FILE_OR_DIR] [--focus NODE] [--profile ai-review] [--export tag-review] [--format json|dot|mermaid]  # structural/tag/code review (§15)
@@ -2688,7 +2688,10 @@ DESIGN-*.md があります)。</p>
   拡張)。要件ごとのキル数とこの警告は、選択されたミュータント集合と深さの中で
   観測された下界です。acceptance と forbidden の kill は、失敗した trace 宣言の
   明示的な requirement annotation を使います。AC/FB case ID は暗黙の requirement
-  ではなく、trace case ID は宣言種別ごとに一意です。→
+  ではなく、trace case ID は宣言種別ごとに一意です。<code>--oracle-attribution</code>
+  (opt-in) はミュータントごとの <code>killers</code> 配列と、oracle 表示名をキーにした
+  <code>by_obligation</code> の sole/shared 集計を追加します。既定出力は変わらず、これらの
+  カウントは観測された下界であり、完全性や正しさの尺度ではありません。→
   <a href="https://github.com/ymm-oss/fsl/blob/main/docs/DESIGN-mutate.md"><code>DESIGN-mutate.md</code></a>
 - <strong><code>fslc explain --readable</code></strong> — 骨格の列挙(状態、action の誰が/いつ/何を変える
   か、検証の境界、公平性、KPI の射影、branch の lowering、合成された refinement

--- a/rust/fslc/cli-contract.json
+++ b/rust/fslc/cli-contract.json
@@ -1729,7 +1729,7 @@
           "mutate"
         ],
         "prog": "fslc mutate",
-        "help": "usage: fslc mutate [-h] [--depth DEPTH] [--by-requirement] [--max-mutants MAX_MUTANTS] [--from MUTANTS_FROM] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --depth DEPTH\n  --by-requirement\n  --max-mutants MAX_MUTANTS\n  --from MUTANTS_FROM   adjudicate external JSONL mutants in addition to the\n                        built-in catalog\n",
+        "help": "usage: fslc mutate [-h] [--depth DEPTH] [--by-requirement] [--oracle-attribution] [--max-mutants MAX_MUTANTS] [--from MUTANTS_FROM] file\n\npositional arguments:\n  file\n\noptions:\n  -h, --help            show this help message and exit\n  --depth DEPTH\n  --by-requirement\n  --oracle-attribution  emit full killer sets and per-oracle sole/shared counts\n                        keyed by oracle display names (opt-in; default output\n                        unchanged)\n  --max-mutants MAX_MUTANTS\n  --from MUTANTS_FROM   adjudicate external JSONL mutants in addition to the\n                        built-in catalog\n",
         "actions": [
           {
             "dest": "help",
@@ -1761,6 +1761,16 @@
             "required": false,
             "flags": [
               "--by-requirement"
+            ],
+            "nargs": 0,
+            "default": false,
+            "action": "store_true"
+          },
+          {
+            "dest": "oracle_attribution",
+            "required": false,
+            "flags": [
+              "--oracle-attribution"
             ],
             "nargs": 0,
             "default": false,

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -1211,6 +1211,7 @@ fn command() -> Result<(Value, i32), String> {
             let mut readable = false;
             let mut max_mutants = DEFAULT_MAX_MUTANTS;
             let mut by_requirement = false;
+            let mut oracle_attribution = false;
             let mut typescript_only = false;
             let mut external_mutants = None;
             while let Some(option) = args.next() {
@@ -1231,6 +1232,7 @@ fn command() -> Result<(Value, i32), String> {
                             .map_err(|_| "--max-mutants must be an integer".to_owned())?;
                     }
                     "--by-requirement" => by_requirement = true,
+                    "--oracle-attribution" => oracle_attribution = true,
                     "--from" => {
                         external_mutants = Some(PathBuf::from(
                             args.next()
@@ -1248,6 +1250,7 @@ fn command() -> Result<(Value, i32), String> {
                     depth,
                     max_mutants,
                     by_requirement,
+                    oracle_attribution,
                     external_mutants.as_deref(),
                 ),
                 "typestate" => run_typestate(&path),
@@ -9820,6 +9823,248 @@ fn mutation_oracle_for_model(model: KernelModel, depth: usize) -> MutationOracle
     mutation_model_oracle(model, depth)
 }
 
+fn clear_action_ensures(model: &mut KernelModel) {
+    for action in &mut model.actions {
+        action.ensures.clear();
+        action.ensure_spans.clear();
+    }
+}
+
+fn isolate_model_for_invariant(model: &KernelModel, name: &str) -> KernelModel {
+    let mut isolated = model.clone();
+    isolated.invariants = isolated
+        .invariants
+        .iter()
+        .filter(|property| property.name == name)
+        .cloned()
+        .collect();
+    isolated.transitions.clear();
+    isolated.reachables.clear();
+    isolated.leadstos.clear();
+    clear_action_ensures(&mut isolated);
+    isolated
+}
+
+fn isolate_model_for_reachable(model: &KernelModel, name: &str) -> KernelModel {
+    let mut isolated = model.clone();
+    isolated.reachables = isolated
+        .reachables
+        .iter()
+        .filter(|property| property.name == name)
+        .cloned()
+        .collect();
+    isolated.invariants.clear();
+    isolated.transitions.clear();
+    isolated.leadstos.clear();
+    clear_action_ensures(&mut isolated);
+    isolated
+}
+
+fn isolate_model_for_transition(model: &KernelModel, name: &str) -> KernelModel {
+    let mut isolated = model.clone();
+    isolated.transitions = isolated
+        .transitions
+        .iter()
+        .filter(|property| property.name == name)
+        .cloned()
+        .collect();
+    isolated.invariants.clear();
+    isolated.reachables.clear();
+    isolated.leadstos.clear();
+    clear_action_ensures(&mut isolated);
+    isolated
+}
+
+fn isolate_model_for_leadsto(model: &KernelModel, name: &str) -> KernelModel {
+    let mut isolated = model.clone();
+    isolated.leadstos = isolated
+        .leadstos
+        .iter()
+        .filter(|property| property.name == name)
+        .cloned()
+        .collect();
+    isolated.invariants.clear();
+    isolated.transitions.clear();
+    isolated.reachables.clear();
+    clear_action_ensures(&mut isolated);
+    isolated
+}
+
+fn isolate_model_for_ensures(model: &KernelModel, action_name: &str) -> KernelModel {
+    let mut isolated = model.clone();
+    isolated.invariants.clear();
+    isolated.transitions.clear();
+    isolated.reachables.clear();
+    isolated.leadstos.clear();
+    for action in &mut isolated.actions {
+        if action.name != action_name {
+            action.ensures.clear();
+            action.ensure_spans.clear();
+        }
+    }
+    isolated
+}
+
+fn isolated_oracle_kills(model: KernelModel, depth: usize, expected: &str) -> bool {
+    let outcome = mutation_model_oracle(model, depth);
+    !outcome.clean && outcome.killed_by.as_deref() == Some(expected)
+}
+
+fn boundary_oracle_killers(model: &KernelModel, depth: usize) -> Vec<String> {
+    if let Ok(fsl_runtime::BoundaryProbe {
+        finding: Some((violation, _)),
+        ..
+    }) = fsl_runtime::find_boundary_violation(model, depth, fsl_runtime::CONCRETE_PROBE_BUDGET)
+    {
+        return vec![violation.name.clone()];
+    }
+    let mut automatic = model.clone();
+    automatic.invariants.clear();
+    automatic.transitions.clear();
+    automatic.reachables.clear();
+    automatic.leadstos.clear();
+    let outcome = mutation_model_oracle(automatic, depth);
+    if outcome.clean {
+        Vec::new()
+    } else {
+        outcome.killed_by.into_iter().collect()
+    }
+}
+
+fn collect_oracle_killers(
+    model: &KernelModel,
+    depth: usize,
+    source: &str,
+    base: &Path,
+    bounds_override: Option<&str>,
+) -> Vec<String> {
+    let mut killers = std::collections::BTreeSet::new();
+    if let Some(name) = bounds_override {
+        killers.insert(name.to_owned());
+    }
+    for name in boundary_oracle_killers(model, depth) {
+        killers.insert(name);
+    }
+    for property in &model.invariants {
+        let label = display(&property.name);
+        if isolated_oracle_kills(
+            isolate_model_for_invariant(model, &property.name),
+            depth,
+            &label,
+        ) {
+            killers.insert(label);
+        }
+    }
+    for property in &model.reachables {
+        let label = display(&property.name);
+        if isolated_oracle_kills(
+            isolate_model_for_reachable(model, &property.name),
+            depth,
+            &label,
+        ) {
+            killers.insert(label);
+        }
+    }
+    for property in &model.transitions {
+        let label = display(&property.name);
+        if isolated_oracle_kills(
+            isolate_model_for_transition(model, &property.name),
+            depth,
+            &label,
+        ) {
+            killers.insert(label);
+        }
+    }
+    for property in &model.leadstos {
+        let label = display(&property.name);
+        if isolated_oracle_kills(
+            isolate_model_for_leadsto(model, &property.name),
+            depth,
+            &label,
+        ) {
+            killers.insert(label);
+        }
+    }
+    for action in &model.actions {
+        if action.ensures.is_empty() {
+            continue;
+        }
+        let label = display(&action.name);
+        if isolated_oracle_kills(
+            isolate_model_for_ensures(model, &action.name),
+            depth,
+            &label,
+        ) {
+            killers.insert(label);
+        }
+    }
+    if mutation_oracle_for_model(model.clone(), depth).clean {
+        let mut outcome = MutationOracle {
+            clean: true,
+            killed_by: None,
+            killer_requirements: Vec::new(),
+        };
+        if apply_requirement_mutation_oracle(source, model, &mut outcome).is_ok()
+            && !outcome.clean
+            && let Some(killer) = outcome.killed_by
+        {
+            killers.insert(killer);
+        } else {
+            outcome = MutationOracle {
+                clean: true,
+                killed_by: None,
+                killer_requirements: Vec::new(),
+            };
+            if apply_implements_mutation_oracle(source, base, model, depth, &mut outcome).is_ok()
+                && !outcome.clean
+                && let Some(killer) = outcome.killed_by
+            {
+                killers.insert(killer);
+            }
+        }
+    }
+    killers.into_iter().collect()
+}
+
+fn aggregate_by_obligation(mutants: &[Value]) -> Map<String, Value> {
+    let mut stats = std::collections::BTreeMap::<String, (u64, u64, u64)>::new();
+    for mutant in mutants {
+        if mutant.get("status").and_then(Value::as_str) != Some("killed") {
+            continue;
+        }
+        let Some(killers) = mutant.get("killers").and_then(Value::as_array) else {
+            continue;
+        };
+        let names = killers.iter().filter_map(Value::as_str).collect::<Vec<_>>();
+        if names.is_empty() {
+            continue;
+        }
+        let shared = names.len() > 1;
+        for name in names {
+            let entry = stats.entry(name.to_owned()).or_insert((0, 0, 0));
+            entry.0 += 1;
+            if shared {
+                entry.2 += 1;
+            } else {
+                entry.1 += 1;
+            }
+        }
+    }
+    stats
+        .into_iter()
+        .map(|(name, (kills_any, sole_kills, shared_kills))| {
+            (
+                name,
+                json!({
+                    "kills_any": kills_any,
+                    "sole_kills": sole_kills,
+                    "shared_kills": shared_kills,
+                }),
+            )
+        })
+        .collect()
+}
+
 fn requirement_trace_failure_requirements(
     source: &str,
     failure: &Value,
@@ -10457,6 +10702,7 @@ fn run_mutate(
     depth: usize,
     max_mutants: usize,
     by_requirement: bool,
+    oracle_attribution: bool,
     external_mutants: Option<&Path>,
 ) -> (Value, i32) {
     // Capture one root-spec snapshot up front (#808): the baseline verify, the
@@ -10668,6 +10914,26 @@ fn run_mutate(
                 json!("action dead at baseline — survival expected"),
             );
         }
+        if oracle_attribution
+            && status == "killed"
+            && let Ok(kernel) = fsl_core::lower_direct_spec(mutated_spec.clone())
+            && let Ok(mutated_model) = fsl_core::build_model(kernel)
+        {
+            let bounds_override = if outcome
+                .killed_by
+                .as_deref()
+                .is_some_and(|killer| killer.starts_with("_bounds_"))
+            {
+                outcome.killed_by.as_deref()
+            } else {
+                None
+            };
+            let killers =
+                collect_oracle_killers(&mutated_model, depth, &source, base, bounds_override);
+            if let Value::Object(public) = &mut public {
+                public.insert("killers".to_owned(), json!(killers));
+            }
+        }
         for requirement in outcome.killer_requirements {
             if let Some(Value::Object(entry)) = by_req.get_mut(&requirement) {
                 let kills = entry
@@ -10763,12 +11029,28 @@ fn run_mutate(
                         entry.insert("kills".to_owned(), json!(kills + 1));
                     }
                 }
-                public_mutants.push(external_mutant_public(
+                let mut public = external_mutant_public(
                     &candidate,
                     "killed",
                     outcome.killed_by.as_deref(),
                     None,
-                ));
+                );
+                if oracle_attribution {
+                    let killers = collect_oracle_killers(
+                        &mutated_model,
+                        depth,
+                        mutated_source,
+                        base,
+                        outcome
+                            .killed_by
+                            .as_deref()
+                            .filter(|killer| killer.starts_with("_bounds_")),
+                    );
+                    if let Value::Object(public) = &mut public {
+                        public.insert("killers".to_owned(), json!(killers));
+                    }
+                }
+                public_mutants.push(public);
             }
         }
     }
@@ -10800,6 +11082,12 @@ fn run_mutate(
                 .to_owned(),
         );
     }
+    if oracle_attribution {
+        notes.push(
+            "oracle-attribution kills_any, sole_kills, and shared_kills are observed lower bounds within this mutant set and depth; they are not obligation completeness or spec correctness measures"
+                .to_owned(),
+        );
+    }
     let mut output = envelope();
     output.insert("result".to_owned(), json!("mutated"));
     output.insert("spec".to_owned(), json!(model.name));
@@ -10808,6 +11096,16 @@ fn run_mutate(
     output.insert("mutants".to_owned(), Value::Array(public_mutants.clone()));
     output.insert("summary".to_owned(), mutation_summary(&public_mutants));
     output.insert("by_requirement".to_owned(), Value::Object(by_req));
+    if oracle_attribution {
+        output.insert(
+            "by_obligation".to_owned(),
+            Value::Object(aggregate_by_obligation(&public_mutants)),
+        );
+        output.insert(
+            "attribution".to_owned(),
+            json!({"mode":"all_killers","order_independent":true}),
+        );
+    }
     output.insert("notes".to_owned(), json!(notes));
     if let Some(kernel_source) = domain_kernel_source {
         output.insert("kernel_source".to_owned(), json!(kernel_source));

--- a/rust/fslc/tests/fixtures/issue_848_bank_drop_ensures.fsl
+++ b/rust/fslc/tests/fixtures/issue_848_bank_drop_ensures.fsl
@@ -1,0 +1,16 @@
+spec BankAccount {
+  type Amount = 0..3
+  state { balance: Int }
+  init { balance = 0 }
+  action deposit(a: Amount) {
+    requires a > 0
+    balance = balance + a
+  }
+  action withdraw(a: Amount) {
+    requires a > 0
+    requires balance >= a
+    balance = balance - a
+  }
+  invariant NonNegative { balance >= 0 }
+  reachable Funded { balance >= 2 }
+}

--- a/rust/fslc/tests/fixtures/issue_848_bank_healthy.fsl
+++ b/rust/fslc/tests/fixtures/issue_848_bank_healthy.fsl
@@ -1,0 +1,17 @@
+spec BankAccount {
+  type Amount = 0..3
+  state { balance: Int }
+  init { balance = 0 }
+  action deposit(a: Amount) {
+    requires a > 0
+    balance = balance + a
+    ensures balance == old(balance) + a
+  }
+  action withdraw(a: Amount) {
+    requires a > 0
+    requires balance >= a
+    balance = balance - a
+  }
+  invariant NonNegative { balance >= 0 }
+  reachable Funded { balance >= 2 }
+}

--- a/rust/fslc/tests/fixtures/issue_848_bank_healthy_default.stdout.json
+++ b/rust/fslc/tests/fixtures/issue_848_bank_healthy_default.stdout.json
@@ -1,0 +1,252 @@
+{
+  "fsl": "1.0",
+  "result": "mutated",
+  "spec": "BankAccount",
+  "depth": 8,
+  "baseline": "verified",
+  "mutants": [
+    {
+      "op": "type_bound_lo_minus1",
+      "loc": null,
+      "target": "type Amount lo",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "type_bound_lo_plus1",
+      "loc": null,
+      "target": "type Amount lo",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "type_bound_hi_minus1",
+      "loc": null,
+      "target": "type Amount hi",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "type_bound_hi_plus1",
+      "loc": null,
+      "target": "type Amount hi",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "assignment_remove",
+      "loc": {
+        "line": 4,
+        "column": 10
+      },
+      "target": "init assignment",
+      "status": "killed",
+      "killed_by": "NonNegative",
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "integer_literal_minus1",
+      "loc": {
+        "line": 4,
+        "column": 10
+      },
+      "target": "init assignment",
+      "status": "killed",
+      "killed_by": "NonNegative",
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "integer_literal_plus1",
+      "loc": {
+        "line": 4,
+        "column": 10
+      },
+      "target": "init assignment",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "requires_remove",
+      "loc": {
+        "line": 6,
+        "column": 5
+      },
+      "target": "deposit requires #1",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "requires_negate",
+      "loc": {
+        "line": 6,
+        "column": 5
+      },
+      "target": "deposit requires #1",
+      "status": "killed",
+      "killed_by": "Funded",
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "integer_literal_minus1",
+      "loc": {
+        "line": 6,
+        "column": 5
+      },
+      "target": "deposit requires #1",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "integer_literal_plus1",
+      "loc": {
+        "line": 6,
+        "column": 5
+      },
+      "target": "deposit requires #1",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "assignment_remove",
+      "loc": {
+        "line": 7,
+        "column": 5
+      },
+      "target": "deposit assignment",
+      "status": "killed",
+      "killed_by": "deposit",
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "requires_remove",
+      "loc": {
+        "line": 11,
+        "column": 5
+      },
+      "target": "withdraw requires #1",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "requires_negate",
+      "loc": {
+        "line": 11,
+        "column": 5
+      },
+      "target": "withdraw requires #1",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "integer_literal_minus1",
+      "loc": {
+        "line": 11,
+        "column": 5
+      },
+      "target": "withdraw requires #1",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "integer_literal_plus1",
+      "loc": {
+        "line": 11,
+        "column": 5
+      },
+      "target": "withdraw requires #1",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "requires_remove",
+      "loc": {
+        "line": 12,
+        "column": 5
+      },
+      "target": "withdraw requires #2",
+      "status": "killed",
+      "killed_by": "NonNegative",
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "requires_negate",
+      "loc": {
+        "line": 12,
+        "column": 5
+      },
+      "target": "withdraw requires #2",
+      "status": "killed",
+      "killed_by": "NonNegative",
+      "requirement": null,
+      "source": "builtin"
+    },
+    {
+      "op": "assignment_remove",
+      "loc": {
+        "line": 13,
+        "column": 5
+      },
+      "target": "withdraw assignment",
+      "status": "survived",
+      "killed_by": null,
+      "requirement": null,
+      "source": "builtin"
+    }
+  ],
+  "summary": {
+    "total": 19,
+    "killed": 6,
+    "survived": 13,
+    "invalid": 0,
+    "kill_rate": 0.3158,
+    "by_source": {
+      "builtin": {
+        "total": 19,
+        "killed": 6,
+        "survived": 13,
+        "invalid": 0,
+        "kill_rate": 0.3158
+      },
+      "external": {
+        "total": 0,
+        "killed": 0,
+        "survived": 0,
+        "invalid": 0,
+        "kill_rate": null
+      }
+    }
+  },
+  "by_requirement": {},
+  "notes": [
+    "possible equivalent mutants should be reviewed manually; survivors are a review queue, not a hard failure"
+  ]
+}

--- a/rust/fslc/tests/issue_848_oracle_attribution.rs
+++ b/rust/fslc/tests/issue_848_oracle_attribution.rs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Oracle-attribution controls for issue #848.
+//!
+//! Default `fslc mutate` output must remain byte-identical to the pre-change
+//! contract; `--oracle-attribution` is the only surface that exposes full killer
+//! sets and per-oracle sole/shared counts keyed by oracle display names.
+
+use std::process::Command;
+
+fn workspace_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn run_cli(args: &[&str]) -> (serde_json::Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn run_cli_stdout(args: &[&str]) -> (Vec<u8>, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    (
+        output.stdout,
+        output.status.code().expect("native exit status"),
+    )
+}
+
+const BANK_HEALTHY: &str = "rust/fslc/tests/fixtures/issue_848_bank_healthy.fsl";
+const BANK_DROP: &str = "rust/fslc/tests/fixtures/issue_848_bank_drop_ensures.fsl";
+
+fn deposit_assignment_mutant(output: &serde_json::Value) -> &serde_json::Value {
+    output["mutants"]
+        .as_array()
+        .expect("mutants")
+        .iter()
+        .find(|mutant| {
+            mutant["op"] == "assignment_remove"
+                && mutant["target"]
+                    .as_str()
+                    .is_some_and(|target| target.contains("deposit assignment"))
+        })
+        .expect("deposit assignment_remove mutant")
+}
+
+/// Calibration: default stdout must not gain attribution fields (opt-in only).
+#[test]
+fn mutate_default_stdout_is_byte_identical_to_baseline_fixture() {
+    let (stdout, status) = run_cli_stdout(&["mutate", BANK_HEALTHY, "--depth", "8"]);
+    assert_eq!(status, 0);
+    let golden = include_bytes!("fixtures/issue_848_bank_healthy_default.stdout.json");
+    assert_eq!(
+        stdout.as_slice(),
+        golden.as_slice(),
+        "default mutate stdout changed; opt-in fields must not alter the default envelope"
+    );
+}
+
+/// Negative control (pre-attribution semantics): without the flag, redundancy is invisible.
+#[test]
+fn mutate_without_oracle_attribution_omits_killers_and_by_obligation() {
+    let (output, status) = run_cli(&["mutate", BANK_HEALTHY, "--depth", "8"]);
+    assert_eq!(status, 0, "{output}");
+    assert!(output.get("by_obligation").is_none(), "{output}");
+    assert!(output.get("attribution").is_none(), "{output}");
+    let mutant = deposit_assignment_mutant(&output);
+    assert_eq!(mutant["status"], "killed", "{mutant}");
+    assert_eq!(mutant["killed_by"], "deposit", "{mutant}");
+    assert!(mutant.get("killers").is_none(), "{mutant}");
+}
+
+/// Positive control: redundant killers are visible when the flag is set.
+#[test]
+fn mutate_oracle_attribution_reports_shared_killers_for_deposit_assignment() {
+    let (healthy, status) = run_cli(&[
+        "mutate",
+        BANK_HEALTHY,
+        "--depth",
+        "8",
+        "--oracle-attribution",
+    ]);
+    assert_eq!(status, 0, "{healthy}");
+    let mutant = deposit_assignment_mutant(&healthy);
+    assert_eq!(mutant["killed_by"], "deposit", "{mutant}");
+    let killers = mutant["killers"].as_array().expect("killers");
+    assert_eq!(killers.len(), 2, "{mutant}");
+    assert!(killers.iter().any(|killer| killer == "deposit"), "{mutant}");
+    assert!(killers.iter().any(|killer| killer == "Funded"), "{mutant}");
+    let deposit = &healthy["by_obligation"]["deposit"];
+    assert_eq!(deposit["kills_any"], 1, "{healthy}");
+    assert_eq!(deposit["sole_kills"], 0, "{healthy}");
+    assert_eq!(deposit["shared_kills"], 1, "{healthy}");
+    assert_eq!(
+        healthy["attribution"],
+        serde_json::json!({"mode": "all_killers", "order_independent": true})
+    );
+}
+
+/// Redundancy phenomenon on the implementation version: union kill-rate is preserved while
+/// first-killer attribution shifts and the dropped ensures oracle disappears from killers.
+#[test]
+fn mutate_oracle_attribution_detects_ensures_redundancy_across_healthy_and_drop_specs() {
+    let (healthy, healthy_status) = run_cli(&[
+        "mutate",
+        BANK_HEALTHY,
+        "--depth",
+        "8",
+        "--oracle-attribution",
+    ]);
+    let (dropped, dropped_status) =
+        run_cli(&["mutate", BANK_DROP, "--depth", "8", "--oracle-attribution"]);
+    assert_eq!(healthy_status, 0, "{healthy}");
+    assert_eq!(dropped_status, 0, "{dropped}");
+    assert_eq!(
+        healthy["summary"]["kill_rate"], dropped["summary"]["kill_rate"],
+        "union kill-rate must stay equal across healthy and drop_ensures"
+    );
+    assert_eq!(
+        healthy["summary"]["killed"], dropped["summary"]["killed"],
+        "{healthy} vs {dropped}"
+    );
+    assert_eq!(
+        healthy["summary"]["total"], dropped["summary"]["total"],
+        "{healthy} vs {dropped}"
+    );
+    let healthy_mutant = deposit_assignment_mutant(&healthy);
+    let dropped_mutant = deposit_assignment_mutant(&dropped);
+    assert_eq!(healthy_mutant["status"], "killed", "{healthy_mutant}");
+    assert_eq!(dropped_mutant["status"], "killed", "{dropped_mutant}");
+    assert_eq!(healthy_mutant["killed_by"], "deposit", "{healthy_mutant}");
+    assert_eq!(dropped_mutant["killed_by"], "Funded", "{dropped_mutant}");
+    let healthy_killers = healthy_mutant["killers"]
+        .as_array()
+        .expect("healthy killers");
+    let dropped_killers = dropped_mutant["killers"]
+        .as_array()
+        .expect("dropped killers");
+    assert!(
+        healthy_killers.iter().any(|killer| killer == "deposit"),
+        "{healthy_mutant}"
+    );
+    assert!(
+        !dropped_killers.iter().any(|killer| killer == "deposit"),
+        "{dropped_mutant}"
+    );
+    assert!(
+        dropped_killers.iter().any(|killer| killer == "Funded"),
+        "{dropped_mutant}"
+    );
+    assert!(
+        dropped["by_obligation"].get("deposit").is_none(),
+        "dropped ensures must remove the deposit oracle from aggregation: {dropped}"
+    );
+}
+
+/// Sole-killer control: when only one oracle rejects a mutant, `shared_kills` stay zero.
+#[test]
+fn mutate_oracle_attribution_counts_sole_kills_without_shared_kills() {
+    let (dropped, status) = run_cli(&["mutate", BANK_DROP, "--depth", "8", "--oracle-attribution"]);
+    assert_eq!(status, 0, "{dropped}");
+    let funded = &dropped["by_obligation"]["Funded"];
+    assert!(
+        funded["sole_kills"].as_u64().unwrap_or(0) >= 1,
+        "Funded must have at least one sole kill after ensures removal: {dropped}"
+    );
+    assert_eq!(funded["shared_kills"], 0, "{dropped}");
+}

--- a/skills/fsl/references/commands.md
+++ b/skills/fsl/references/commands.md
@@ -98,7 +98,7 @@ fslc verify <f> [--depth K=8] [--engine bmc|induction|explicit|auto] [--k N=1]
 fslc sweep <f> --instances NAME=LO..HI --depth LO..HI [--property Name]
                                                      # grid of verify runs; JSON sweep.results/minimal_counterexample
 fslc explain <f> [--depth K=8] [--readable]    # JSON by default; --readable emits a text review view
-fslc mutate <f> [--depth K=8] [--by-requirement] [--max-mutants N=200]
+fslc mutate <f> [--depth K=8] [--by-requirement] [--oracle-attribution] [--max-mutants N=200]
               [--from mutants.jsonl]
 fslc scenarios <f> [--depth K]                  # reach_* / cover_* / respond_* / deadlock_terminal
 fslc replay <f> --trace <events.json>           # conformant | nonconformant
@@ -467,7 +467,10 @@ substituted default — only an *absent* `depth`/`refine_depth` key defaults.
   and warns on zero kills as `empty_formalization` (a lower bound observed for
   this mutant set and depth). Trace attribution uses explicit requirement
   annotations; AC/FB case IDs are not implicit requirements and are unique
-  within each declaration kind.
+  within each declaration kind. `--oracle-attribution` (opt-in) adds per-mutant
+  `killers` arrays and `by_obligation` sole/shared counts keyed by oracle display
+  names; default output is unchanged and these counts are observed lower bounds,
+  not completeness or correctness measures.
   `--from` appends external JSONL mutants. Each line supplies either full
   `mutated_spec` source (`spec` alias accepted) or an exact
   `replace:{target,replacement,occurrence?}` instruction. Valid records use the


### PR DESCRIPTION
## Summary

- Add `--oracle-attribution` to `fslc mutate`: per-mutant `killers` arrays and top-level `by_obligation` (`kills_any` / `sole_kills` / `shared_kills`) keyed by oracle display names, plus `attribution: {mode: all_killers, order_independent: true}`.
- Default `mutate` output is unchanged (byte-identical stdout on the bank calibration fixture); `killed_by` remains first-killer and `kill_rate` remains union coverage.
- Detects ensures-oracle redundancy on implementation-version fixtures: healthy vs `drop_ensures` bank specs share `kill_rate` 0.3158 (6/19) while deposit `assignment_remove` shifts first killer `deposit` → `Funded` and drops `deposit` from `killers` when ensures is removed.

## Test plan

- [x] `cargo test -p fslc-rust --test issue_848_oracle_attribution` — negative/positive controls, byte-identical default stdout
- [x] `cargo test -p fslc-rust --locked` (exit=0)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (exit=0)
- [x] `cargo fmt --all -- --check` (exit=0)
- [ ] `./tools/check-merge-readiness.sh automation` (exit=2 — pre-existing `tests/test_post_merge_reporter_workflow.py` SyntaxError on `origin/main`, unrelated to this diff)

Closes #848.

Made with [Cursor](https://cursor.com)