### PR TITLE
fix(ai)!: fail closed on invalid ai_component across check, compat, and replay (#800)

### DIFF
--- a/changelog.d/800-ai-fail-closed.changed.md
+++ b/changelog.d/800-ai-fail-closed.changed.md
@@ -1,0 +1,5 @@
+Changed (#800)!: `fslc ai check`, `fslc ai compat`, and `fslc ai replay` now
+reject invalid `ai_component` declarations (undeclared authority tools and
+unknown `check hard` rule names, plus checked project parsing for `ai replay`)
+with exit 2 instead of returning `ai_project_analyzed`,
+`compat_profile_generated`, or `replay_conformant` on false greens.

--- a/docs/DESIGN-ai-hard.md
+++ b/docs/DESIGN-ai-hard.md
@@ -142,6 +142,15 @@ successful recursive `agent` checks return `agent_analyzed` with
 `formal_result: "not_run"`; successful replay returns `replay_conformant` with
 `formal_result: "not_run"`.
 
+`fslc ai check`, `fslc ai compat`, and `fslc ai replay` must not emit those
+success results on an invalid `ai_component`, whether the component is supplied
+alone or embedded in an fsl-ai project. They share
+`fsl_core::validate_ai_component` (undeclared authority tools and unknown
+`check hard` rule names, exit 2). Project-level `fslc ai replay` parses with
+`parse_checked_ai_project` instead of a line scanner so parse failures cannot
+report `replay_conformant` (issue #800). `fslc ai drift` / `eval` / `regress`
+remain tracked separately.
+
 ## Recursive Agent Composition
 
 `agent` is the recursively composable fsl-ai structure. A nested agent is not a

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -2562,7 +2562,13 @@ fslc ai compat examples/ai/support_answer_quality.fsl --environment prod
 そして `fslc ai compat` は、1 つの `ai_component`、またはプロジェクトが
 宣言するすべての `ai_component` について有限の `dbsystem artifact`
 ケイパビリティプロファイルを出力し、AI ではない入力や `ai_component` を
-1 つも宣言しない AI プロジェクトは拒否します（exit 2）。これらはすべて
+1 つも宣言しない AI プロジェクトは拒否します（exit 2）。`fslc ai check`、
+`fslc ai compat`、`fslc ai replay` が成功 verdict を返す前に、入力内のすべての
+`ai_component`（単体でもプロジェクト内でも）について、単体 `ai_component` に対する
+`fslc verify` と同じ意味制約（`authority` が参照する未宣言 tool、未知の
+`check hard { rule ... }` 名）を検査します（exit 2、`kind:"semantics"`）。
+`fslc ai replay` のプロジェクト入力は `fslc ai check` と同じ checked パーサを使うため、
+壊れたプロジェクト構文は `replay_conformant` になりません。これらはすべて
 `formal_result:"not_run"` を使います。既知のエビデンス節文法
 （`min_samples`、`ci_lower`、`ci_upper`、点推定、`observed`、`drift`）の
 いずれにも一致しない `require` 節は、`fslc ai check` と `fslc check` の

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -2624,7 +2624,14 @@ declared `observed`/`drift` requirements over runtime telemetry
 (`observed_supported` / `observed_mismatch`); and `fslc ai compat` emits a
 finite `dbsystem artifact` capability profile for one `ai_component` or every
 `ai_component` a project declares, rejecting non-AI input and an AI project
-with no `ai_component` at all (exit 2). All of these use
+with no `ai_component` at all (exit 2). Before `fslc ai check`, `fslc ai
+compat`, or `fslc ai replay` may emit a success verdict, every `ai_component`
+in the input -- standalone or embedded in a project -- is checked for the same
+semantic constraints as `fslc verify` on a lone component: undeclared tools
+referenced in `authority`, and unknown `check hard { rule ... }` names (exit
+2, `kind:"semantics"`). `fslc ai replay` on a project file uses the same
+checked project parser as `fslc ai check`, so malformed project syntax cannot
+report `replay_conformant`. All of these use
 `formal_result:"not_run"`. A `require` clause matching none of the known
 evidence-clause grammars (`min_samples`, `ci_lower`, `ci_upper`, a point
 estimate, `observed`, `drift`) is a spec error (exit 2) at `check` time, in

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -2611,7 +2611,14 @@ declared <code>observed</code>/<code>drift</code> requirements over runtime tele
 (<code>observed_supported</code> / <code>observed_mismatch</code>); and <code>fslc ai compat</code> emits a
 finite <code>dbsystem artifact</code> capability profile for one <code>ai_component</code> or every
 <code>ai_component</code> a project declares, rejecting non-AI input and an AI project
-with no <code>ai_component</code> at all (exit 2). All of these use
+with no <code>ai_component</code> at all (exit 2). Before <code>fslc ai check</code>, <code>fslc ai
+compat</code>, or <code>fslc ai replay</code> may emit a success verdict, every <code>ai_component</code>
+in the input -- standalone or embedded in a project -- is checked for the same
+semantic constraints as <code>fslc verify</code> on a lone component: undeclared tools
+referenced in <code>authority</code>, and unknown <code>check hard { rule ... }</code> names (exit
+2, <code>kind:"semantics"</code>). <code>fslc ai replay</code> on a project file uses the same
+checked project parser as <code>fslc ai check</code>, so malformed project syntax cannot
+report <code>replay_conformant</code>. All of these use
 <code>formal_result:"not_run"</code>. A <code>require</code> clause matching none of the known
 evidence-clause grammars (<code>min_samples</code>, <code>ci_lower</code>, <code>ci_upper</code>, a point
 estimate, <code>observed</code>, <code>drift</code>) is a spec error (exit 2) at <code>check</code> time, in

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -2550,7 +2550,13 @@ fslc ai compat examples/ai/support_answer_quality.fsl --environment prod
 そして <code>fslc ai compat</code> は、1 つの <code>ai_component</code>、またはプロジェクトが
 宣言するすべての <code>ai_component</code> について有限の <code>dbsystem artifact</code>
 ケイパビリティプロファイルを出力し、AI ではない入力や <code>ai_component</code> を
-1 つも宣言しない AI プロジェクトは拒否します（exit 2）。これらはすべて
+1 つも宣言しない AI プロジェクトは拒否します（exit 2）。<code>fslc ai check</code>、
+<code>fslc ai compat</code>、<code>fslc ai replay</code> が成功 verdict を返す前に、入力内のすべての
+<code>ai_component</code>（単体でもプロジェクト内でも）について、単体 <code>ai_component</code> に対する
+<code>fslc verify</code> と同じ意味制約（<code>authority</code> が参照する未宣言 tool、未知の
+<code>check hard { rule ... }</code> 名）を検査します（exit 2、<code>kind:"semantics"</code>）。
+<code>fslc ai replay</code> のプロジェクト入力は <code>fslc ai check</code> と同じ checked パーサを使うため、
+壊れたプロジェクト構文は <code>replay_conformant</code> になりません。これらはすべて
 <code>formal_result:"not_run"</code> を使います。既知のエビデンス節文法
 （<code>min_samples</code>、<code>ci_lower</code>、<code>ci_upper</code>、点推定、<code>observed</code>、<code>drift</code>）の
 いずれにも一致しない <code>require</code> 節は、<code>fslc ai check</code> と <code>fslc check</code> の

--- a/rust/fsl-core/src/dialect.rs
+++ b/rust/fsl-core/src/dialect.rs
@@ -2638,6 +2638,49 @@ fn ai_span(loc: fsl_syntax::AiLoc) -> fsl_syntax::Span {
     }
 }
 
+/// Semantic validation shared by every `fslc ai` entry point that can emit a
+/// success verdict for an `ai_component` document, whether the component is
+/// supplied alone or as part of an fsl-ai project (issue #800).
+///
+/// # Errors
+///
+/// Returns [`CoreError`] when authority references an undeclared tool, a
+/// `check hard { rule ... }` clause names an unknown rule, or a fallback
+/// reason is duplicated.
+pub fn validate_ai_component(component: &fsl_syntax::AiComponent) -> Result<(), CoreError> {
+    let mut reasons = BTreeSet::new();
+    for fallback in &component.fallback {
+        if !reasons.insert(&fallback.reason) {
+            return Err(CoreError::unlocated(format!(
+                "duplicate fallback reason '{}'",
+                fallback.reason
+            )));
+        }
+    }
+    let tools = component
+        .tools
+        .iter()
+        .map(|tool| tool.name.as_str())
+        .collect::<BTreeSet<_>>();
+    for rule in component
+        .authority
+        .may_suggest
+        .iter()
+        .chain(&component.authority.may_execute)
+        .chain(&component.authority.requires_human_approval)
+        .chain(&component.authority.forbidden)
+    {
+        if !tools.contains(rule.name.as_str()) {
+            return Err(CoreError::unlocated(format!(
+                "unknown tool '{}' in authority block",
+                rule.name
+            )));
+        }
+    }
+    ai_rule_set(component)?;
+    Ok(())
+}
+
 /// Validate and resolve `check hard { rule ...; }`, defaulting to all five
 /// rules when the block is omitted (`docs/LANGUAGE.md` §13.6).
 ///

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -55,6 +55,7 @@ pub use dialect::{
     RequirementsTraceStep, ai_approval_invariant_name, ai_forbidden_invariant_name, ai_tool_sets,
     governance_contract, lower_ai_component, lower_business, lower_db, lower_domain,
     lower_governance, lower_requirements, requirements_has_implements, requirements_trace_contract,
+    validate_ai_component,
 };
 pub use domain::{DomainDefault, domain_kernel_source, domain_type_default};
 pub use domain_lowering::{domain_effect_owns_event, event_flag, state_name};

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6083,30 +6083,7 @@ fn validate_specialized_document_from_source(path: &Path, source: &str) -> Resul
             fsl_tools::validate_db(&system).map_err(|error| error.to_string())
         }
         fsl_syntax::SurfaceDocument::AiComponent(component) => {
-            let mut reasons = std::collections::BTreeSet::new();
-            for fallback in &component.fallback {
-                if !reasons.insert(&fallback.reason) {
-                    return Err(format!("duplicate fallback reason '{}'", fallback.reason));
-                }
-            }
-            let tools = component
-                .tools
-                .iter()
-                .map(|tool| tool.name.as_str())
-                .collect::<std::collections::BTreeSet<_>>();
-            for rule in component
-                .authority
-                .may_suggest
-                .iter()
-                .chain(&component.authority.may_execute)
-                .chain(&component.authority.requires_human_approval)
-                .chain(&component.authority.forbidden)
-            {
-                if !tools.contains(rule.name.as_str()) {
-                    return Err(format!("unknown tool '{}' in authority block", rule.name));
-                }
-            }
-            Ok(())
+            fsl_core::validate_ai_component(&component).map_err(|error| error.to_string())
         }
         _ => Ok(()),
     }
@@ -6317,6 +6294,30 @@ fn wrap_specialized(result: Value) -> (Value, i32) {
     (output, status)
 }
 
+fn reject_invalid_ai_components(components: &[fsl_syntax::AiComponent]) -> Option<(Value, i32)> {
+    for component in components {
+        if let Err(error) = fsl_core::validate_ai_component(component) {
+            return Some((core_error_output(&error), 2));
+        }
+    }
+    None
+}
+
+fn ai_project_parse_failure(
+    error: &fslc_rust::frontend_output::AiProjectParseError,
+) -> (Value, i32) {
+    let mut output = error_output("parse", &error.message);
+    if let Some(object) = output.as_object_mut() {
+        if let Some((line, column)) = error.position {
+            object.insert("loc".to_owned(), json!({"line": line, "column": column}));
+        }
+        if let Some(code) = error.diagnostic_code {
+            object.insert("diagnostic_code".to_owned(), json!(code));
+        }
+    }
+    (output, 2)
+}
+
 fn run_ai_check(path: &Path, depth: usize, deadlock: &str, engine: &str) -> (Value, i32) {
     let source = match std::fs::read_to_string(path) {
         Ok(source) => source,
@@ -6393,6 +6394,16 @@ fn run_ai_replay(path: &Path, logs: &Path, selected_component: Option<&str>) -> 
         Err(error) => return (error_output("io", &error.to_string()), 2),
     };
     if fslc_rust::frontend_output::is_ai_project(&source) {
+        let project = match fslc_rust::frontend_output::parse_checked_ai_project(
+            &source,
+            &ai_project_name(path),
+        ) {
+            Ok(project) => project,
+            Err(error) => return ai_project_parse_failure(&error),
+        };
+        if let Some(failure) = reject_invalid_ai_components(&project.components) {
+            return failure;
+        }
         let summary = ai_project_summary(&source);
         if selected_component.is_some_and(|selected| selected != summary.component) {
             return (
@@ -6437,6 +6448,9 @@ fn run_ai_replay(path: &Path, logs: &Path, selected_component: Option<&str>) -> 
         }
         Err(error) => return (spec_load_error_output(&error), 2),
     };
+    if let Some(failure) = reject_invalid_ai_components(std::slice::from_ref(&component)) {
+        return failure;
+    }
     if selected_component.is_some_and(|selected| selected != component.name) {
         return (
             semantic_error_output(&format!(
@@ -6526,19 +6540,11 @@ fn run_ai_project_check(source: &str, path: &Path) -> (Value, i32) {
         &ai_project_name(path),
     ) {
         Ok(project) => project,
-        Err(error) => {
-            let mut output = error_output("parse", &error.message);
-            if let Some(object) = output.as_object_mut() {
-                if let Some((line, column)) = error.position {
-                    object.insert("loc".to_owned(), json!({"line": line, "column": column}));
-                }
-                if let Some(code) = error.diagnostic_code {
-                    object.insert("diagnostic_code".to_owned(), json!(code));
-                }
-            }
-            return (output, 2);
-        }
+        Err(error) => return ai_project_parse_failure(&error),
     };
+    if let Some(failure) = reject_invalid_ai_components(&project.components) {
+        return failure;
+    }
     // Field set and order mirror the frozen reference's `analyze_ai_project`
     // (`src/fslc/ai_project.py`). Native previously omitted `dialect`,
     // `ai_project`, `datasets`, `evaluators`, `failure_modes`, and
@@ -6806,6 +6812,9 @@ fn run_ai_compat(path: &Path, environment: Option<&str>) -> (Value, i32) {
                 Err(error) => return (spec_load_error_output(&error), 2),
             }
         };
+    if let Some(failure) = reject_invalid_ai_components(&components) {
+        return failure;
+    }
     if components.is_empty() {
         return (
             semantic_error_output(

--- a/rust/fslc/tests/error_envelope_parity.rs
+++ b/rust/fslc/tests/error_envelope_parity.rs
@@ -1051,26 +1051,8 @@ const CAUSAL_NAME_WITH_DIAGNOSTIC: Expectation = Expectation::Json(JsonExpectati
     message: MessageExpectation::OmitsInput,
     ..SEMANTIC_JSON
 });
-/// #800 tracks these product false negatives. They are pinned to detect drift,
-/// not to endorse accepting invalid component declarations.
-const AI_PROJECT_CHECK_FALSE_GREEN: Expectation = Expectation::Json(JsonExpectation {
-    result: ExpectedField::Exact("ai_project_analyzed"),
-    kind: ExpectedField::Absent,
-    location: LocationShape::Absent,
-    diagnostic: Diagnostic::None,
-    exit: 0,
-    dialect: ExpectedField::Exact("fsl-ai-project.v0"),
-    message: MessageExpectation::Absent,
-});
-const AI_COMPAT_FALSE_GREEN: Expectation = Expectation::Json(JsonExpectation {
-    result: ExpectedField::Exact("compat_profile_generated"),
-    kind: ExpectedField::Absent,
-    location: LocationShape::Absent,
-    diagnostic: Diagnostic::None,
-    exit: 0,
-    dialect: ExpectedField::Absent,
-    message: MessageExpectation::Absent,
-});
+/// #800 tracks these product false negatives for commands outside the
+/// `check`/`compat`/`replay` fix in this change.
 const AI_DRIFT_FALSE_GREEN: Expectation = Expectation::Json(JsonExpectation {
     result: ExpectedField::Exact("observed_supported"),
     kind: ExpectedField::Absent,
@@ -1090,15 +1072,6 @@ const AI_EVAL_FALSE_GREEN: Expectation = Expectation::Json(JsonExpectation {
     message: MessageExpectation::Absent,
 });
 const AI_REGRESS_FALSE_GREEN: Expectation = AI_EVAL_FALSE_GREEN;
-const AI_REPLAY_FALSE_GREEN: Expectation = Expectation::Json(JsonExpectation {
-    result: ExpectedField::Exact("replay_conformant"),
-    kind: ExpectedField::Absent,
-    location: LocationShape::Absent,
-    diagnostic: Diagnostic::None,
-    exit: 0,
-    dialect: ExpectedField::Exact("fsl-ai-hard.v0"),
-    message: MessageExpectation::Absent,
-});
 /// Unlike the similarly shaped #800 observations, these are valid project
 /// documents. #694 tracks the command-specific Markdown handling difference.
 const AI_DRIFT_LITERATE_PROJECT: Expectation = Expectation::Json(JsonExpectation {
@@ -1583,49 +1556,6 @@ const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
     ),
     pin!(
         shape: InputShape::Project;
-        FailureClass::Parse,
-        "ai replay",
-        PARSE_AI_PROJECT_FIXTURE,
-        AI_REPLAY_FALSE_GREEN,
-        "#800"
-    ),
-    // #800 tracks these product false negatives. They are not accepted
-    // behavior: the affected command/input-shape pairs report success
-    // without validating the malformed component declaration.
-    pin!(
-        shape: InputShape::Component;
-        FailureClass::Guard,
-        "ai compat",
-        AI_GUARD_FIXTURE,
-        AI_COMPAT_FALSE_GREEN,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Component;
-        FailureClass::Name,
-        "ai compat",
-        AI_NAME_FIXTURE,
-        AI_COMPAT_FALSE_GREEN,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Guard,
-        "ai compat",
-        AI_PROJECT_GUARD_FIXTURE,
-        AI_COMPAT_FALSE_GREEN,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Name,
-        "ai compat",
-        AI_PROJECT_NAME_FIXTURE,
-        AI_COMPAT_FALSE_GREEN,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Project;
         FailureClass::Guard,
         "ai drift",
         AI_PROJECT_GUARD_FIXTURE,
@@ -1670,54 +1600,6 @@ const KNOWN_ASYMMETRIES: &[KnownAsymmetry] = &[
         "ai regress",
         AI_PROJECT_NAME_FIXTURE,
         AI_REGRESS_FALSE_GREEN,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Component;
-        FailureClass::Guard,
-        "ai replay",
-        AI_GUARD_FIXTURE,
-        AI_REPLAY_FALSE_GREEN,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Component;
-        FailureClass::Name,
-        "ai replay",
-        AI_NAME_FIXTURE,
-        AI_REPLAY_FALSE_GREEN,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Guard,
-        "ai replay",
-        AI_PROJECT_GUARD_FIXTURE,
-        AI_REPLAY_FALSE_GREEN,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Name,
-        "ai replay",
-        AI_PROJECT_NAME_FIXTURE,
-        AI_REPLAY_FALSE_GREEN,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Guard,
-        "ai check",
-        AI_PROJECT_GUARD_FIXTURE,
-        AI_PROJECT_CHECK_FALSE_GREEN,
-        "#800"
-    ),
-    pin!(
-        shape: InputShape::Project;
-        FailureClass::Name,
-        "ai check",
-        AI_PROJECT_NAME_FIXTURE,
-        AI_PROJECT_CHECK_FALSE_GREEN,
         "#800"
     ),
     pin!(

--- a/rust/fslc/tests/issue_800_ai_fail_closed.rs
+++ b/rust/fslc/tests/issue_800_ai_fail_closed.rs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression coverage for issue #800: `fslc ai check` / `ai compat` / `ai replay`
+//! must fail closed on invalid `ai_component` declarations instead of emitting
+//! success verdicts (`ai_project_analyzed`, `compat_profile_generated`,
+//! `replay_conformant`) with exit 0.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+const LOGS: &str = "rust/fslc/tests/fixtures/error_envelope_empty_records.json";
+const VALID_COMPONENT: &str = "examples/ai/refund_agent_tool_safety.fsl";
+const VALID_PROJECT: &str = "examples/ai/support_answer_quality.fsl";
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn run(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(workspace_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn assert_rejects_ai_semantics(args: &[&str]) {
+    let (value, status) = run(args);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error", "{value}");
+    assert_eq!(value["kind"], "semantics", "{value}");
+}
+
+fn assert_rejects_ai_parse(args: &[&str]) {
+    let (value, status) = run(args);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error", "{value}");
+    assert_eq!(value["kind"], "parse", "{value}");
+}
+
+// --- measured false greens: component + invalid hard rule -------------------
+
+#[test]
+fn ai_compat_rejects_a_component_with_an_unregistered_hard_rule() {
+    let path = fixture("error_envelope_ai_invalid_rule.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_semantics(&["ai", "compat", &path]);
+}
+
+#[test]
+fn ai_replay_rejects_a_component_with_an_unregistered_hard_rule() {
+    let path = fixture("error_envelope_ai_invalid_rule.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_semantics(&["ai", "replay", &path, "--logs", LOGS]);
+}
+
+#[test]
+fn ai_check_still_rejects_a_component_with_an_unregistered_hard_rule() {
+    let path = fixture("error_envelope_ai_invalid_rule.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_semantics(&["ai", "check", &path]);
+}
+
+// --- measured false greens: component + unknown authority tool --------------
+
+#[test]
+fn ai_compat_rejects_a_component_with_an_unknown_authority_tool() {
+    let path = fixture("error_envelope_ai_unknown_tool.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_semantics(&["ai", "compat", &path]);
+}
+
+#[test]
+fn ai_replay_rejects_a_component_with_an_unknown_authority_tool() {
+    let path = fixture("error_envelope_ai_unknown_tool.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_semantics(&["ai", "replay", &path, "--logs", LOGS]);
+}
+
+#[test]
+fn ai_check_still_rejects_a_component_with_an_unknown_authority_tool() {
+    let path = fixture("error_envelope_ai_unknown_tool.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_semantics(&["ai", "check", &path]);
+}
+
+// --- measured false greens: project + invalid hard rule ---------------------
+
+#[test]
+fn ai_check_rejects_a_project_with_an_unregistered_hard_rule() {
+    let path = fixture("error_envelope_ai_project_invalid_rule.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_semantics(&["ai", "check", &path]);
+}
+
+#[test]
+fn ai_compat_rejects_a_project_with_an_unregistered_hard_rule() {
+    let path = fixture("error_envelope_ai_project_invalid_rule.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_semantics(&["ai", "compat", &path]);
+}
+
+#[test]
+fn ai_replay_rejects_a_project_with_an_unregistered_hard_rule() {
+    let path = fixture("error_envelope_ai_project_invalid_rule.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_semantics(&["ai", "replay", &path, "--logs", LOGS]);
+}
+
+// --- measured false green: parse-broken project on replay only --------------
+
+#[test]
+fn ai_replay_rejects_a_parse_broken_ai_project() {
+    let path = fixture("error_envelope_broken_ai_project.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_parse(&["ai", "replay", &path, "--logs", LOGS]);
+}
+
+#[test]
+fn ai_check_and_compat_still_reject_a_parse_broken_ai_project() {
+    let path = fixture("error_envelope_broken_ai_project.fsl")
+        .display()
+        .to_string();
+    assert_rejects_ai_parse(&["ai", "check", &path]);
+    let (value, status) = run(&["ai", "compat", &path]);
+    assert_eq!(status, 2, "{value}");
+    assert_eq!(value["result"], "error", "{value}");
+    assert_ne!(
+        value["kind"], "parse",
+        "compat parse-kind asymmetry remains tracked separately"
+    );
+}
+
+// --- positive controls: valid inputs still succeed --------------------------
+
+#[test]
+fn valid_component_inputs_still_succeed_on_all_three_commands() {
+    let (check, check_status) = run(&["ai", "check", VALID_COMPONENT]);
+    assert_eq!(check_status, 0, "{check}");
+    assert_ne!(check["result"], "error", "{check}");
+
+    let (compat, compat_status) = run(&["ai", "compat", VALID_COMPONENT]);
+    assert_eq!(compat_status, 0, "{compat}");
+    assert_eq!(compat["result"], "compat_profile_generated", "{compat}");
+
+    let (replay, replay_status) = run(&["ai", "replay", VALID_COMPONENT, "--logs", LOGS]);
+    assert_eq!(replay_status, 0, "{replay}");
+    assert_eq!(replay["result"], "replay_conformant", "{replay}");
+}
+
+#[test]
+fn valid_project_inputs_still_succeed_on_all_three_commands() {
+    let (check, check_status) = run(&["ai", "check", VALID_PROJECT]);
+    assert_eq!(check_status, 0, "{check}");
+    assert_eq!(check["result"], "ai_project_analyzed", "{check}");
+
+    let (compat, compat_status) = run(&["ai", "compat", VALID_PROJECT]);
+    assert_eq!(compat_status, 0, "{compat}");
+    assert_eq!(compat["result"], "compat_profile_generated", "{compat}");
+
+    let (replay, replay_status) = run(&["ai", "replay", VALID_PROJECT, "--logs", LOGS]);
+    assert_eq!(replay_status, 0, "{replay}");
+    assert_eq!(replay["result"], "replay_conformant", "{replay}");
+}

--- a/skills/fsl/references/commands.md
+++ b/skills/fsl/references/commands.md
@@ -154,6 +154,7 @@ fslc db import <sql|schema.prisma> [--source auto|sql|prisma] [--name Name] [-o 
                                                         # SQL DDL / minimal Prisma -> dbsystem
 fslc ai check <f> [--depth K] [--engine bmc|induction]  # ai_component hard-contract findings
 fslc ai replay <f> --logs events.jsonl                  # AI runtime replay evidence, not proof
+                                                        # check/compat/replay fail closed on invalid ai_component (exit 2)
 fslc ai eval <f> [--records <path>] [--dataset <Name>] [--slice <Name>] [--property <Name>]
                                                         # Wilson-bound check over precomputed eval JSONL
 fslc ai regress <f> [--migration <Name>] --before-records <p> --after-records <p> [--dataset <Name>]

--- a/skills/fsl/references/syntax.md
+++ b/skills/fsl/references/syntax.md
@@ -458,7 +458,11 @@ the full `schemas/fslc/ai/statistical-result.v0.schema.json` field set
 (`observed_supported` / `observed_mismatch`), and `fslc ai compat` emits DB
 artifact capability profiles for one `ai_component` or every `ai_component` a
 project declares -- rejecting non-AI input and a project with no
-`ai_component` at all (exit 2) rather than an empty profile. These results
+`ai_component` at all (exit 2) rather than an empty profile. `fslc ai check`,
+`fslc ai compat`, and `fslc ai replay` share the same `ai_component` semantic
+gate (undeclared authority tools and unknown `check hard` rule names, exit 2)
+before any success verdict; project-level `fslc ai replay` uses the checked
+project parser rather than a line scanner. These results
 are never formal proof.
 
 Recursive fsl-ai `agent` composition is checked structurally by


### PR DESCRIPTION
## Summary
- Add `fsl_core::validate_ai_component` and call it from `fslc ai check` (project path), `ai compat`, and `ai replay` before any success verdict.
- `ai replay` on project files now uses `parse_checked_ai_project` instead of the line scanner, so parse-broken projects cannot return `replay_conformant`.
- Move eleven `#800` false-green pins out of `error_envelope_parity.rs` into the uniform matrix; add `issue_800_ai_fail_closed` calibration + positive controls.

## Breaking change
Invalid `ai_component` inputs that previously returned exit 0 with `ai_project_analyzed`, `compat_profile_generated`, or `replay_conformant` now exit 2 with `kind:"semantics"` (or `kind:"parse"` for broken project replay). Single-component `ai check` behavior is unchanged.

## Coupled surfaces
- `docs/LANGUAGE.md` / `docs/LANGUAGE.ja.md`, `docs/DESIGN-ai-hard.md`, `skills/fsl/references/{syntax,commands}.md`, `changelog.d/800-ai-fail-closed.changed.md`
- `cli-contract.json`: no CLI flag/help change (behavior-only contract)
- `rust/fsl-lsp`, `tests/dialect_registry.py`, new design doc: N/A (no new syntax/construct)

## Test plan
- [x] `cargo test -p fslc-rust --test issue_800_ai_fail_closed`
- [x] `cargo test -p fslc-rust --test error_envelope_parity`
- [x] `cargo test -p fslc-rust` (exit=0)
- [x] `cargo clippy --workspace --all-targets -D warnings` (exit=0)
- [x] `cargo fmt --check` (exit=0)
- [ ] `check-merge-readiness.sh automation` — blocked locally by system `python3` 3.9.6 (pytest collection needs 3.12+); use Homebrew 3.13 in CI

Closes #800 (phase C: check/compat/replay). `ai drift` / `eval` / `regress` pins remain for a follow-up.


Made with [Cursor](https://cursor.com)