### PR TITLE
fix(domain): retire #796 CLI suppression (#798 slice 2)

### DIFF
--- a/changelog.d/798-domain-suppression-retired.changed.md
+++ b/changelog.d/798-domain-suppression-retired.changed.md
@@ -1,0 +1,4 @@
+Changed (#798, slice 2): retired the #796 CLI post-validation on `domain
+analyze` and `domain expand` now that scope-aware AST normalization makes the
+renderer agree with direct lowering; rejecting controls in
+`issue_796_domain_command_validation` still pass without the guard.

--- a/docs/DESIGN-domain.md
+++ b/docs/DESIGN-domain.md
@@ -515,10 +515,9 @@ tests, or external evidence.
 by `check_domain` to validate renderability; only its hard-finding envelope
 includes the generated `kernel_source`). At command entry, `domain analyze`
 and `domain expand` read one source `String`, parse their `DomainSpec`
-projection from it with `parse_domain_document_from_source`, and pass that same
-string to `load_kernel_model_from_source` to construct the checked Kernel. An
-atomic replacement of the path therefore cannot make either command validate a
-different source version before returning success (#796).
+projection from it with `parse_domain_document_from_source`, and render from
+that same in-memory snapshot. An atomic replacement of the path therefore
+cannot make either command project a different source version (#808).
 `domain generate`, `domain replay`, `domain testgen`, and `domain check` extend
 the same single-snapshot contract to checked-kernel scaffolding, Monitor replay,
 generic/adapter test generation, and edition post-processing respectively (#808).
@@ -526,12 +525,11 @@ generic/adapter test generation, and edition post-processing respectively (#808)
 `public_kernel_contract` for the full domain corpus and requires them to match
 except on source spans (#664). Building that gate found the two
 implementations already disagree: `Context::default` (`domain.rs`) still has
-legacy surface paths, while `Context::normalize` now composes scope-aware AST
-for kernel rendering (#798 slice 1 / design option B). #690 fixed the known
+legacy surface paths, while `Context::normalize` composes scope-aware AST
+for kernel rendering (#798 / design option B). #690 fixed the known
 `can(...)` precedence false green by parenthesizing each joined piece. #798
-slice 2 will retire the remaining legacy string path and #796 CLI suppression.
-#796 validates the CLI source before returning its renderer output; slice 1
-makes the renderer agree with `lower_domain` for the formerly pinned fixtures.
+slice 1 closed the pinned renderer divergences; slice 2 retired the #796 CLI
+post-validation that had masked remaining divergence at the command boundary.
 `domain_render_agreement.rs`'s `KNOWN_DIVERGENT_DOMAIN_FIXTURES` is empty after
 slice 1. #691 (a separate root cause --
 `Context::default` had a catch-all arm reachable for every container type,

--- a/rust/fsl-core/tests/domain_render_agreement.rs
+++ b/rust/fsl-core/tests/domain_render_agreement.rs
@@ -228,7 +228,8 @@ struct KnownDivergence {
 /// **#798** <https://github.com/ymm-oss/fsl/issues/798> slice 1 closed the
 /// two pinned symptoms below by replacing `Context::normalize`'s
 /// `str::replace` pipeline with scope-aware AST composition (design option
-/// B). Slice 2 retires the legacy string path and #796 CLI suppression.
+/// B). Slice 2 retired the #796 CLI post-validation that had masked renderer
+/// divergence at the command boundary.
 ///
 /// Historical record of the resolved divergences (fixtures moved to
 /// [`VALID_DOMAIN_FIXTURES`] / [`SEMANTICALLY_INVALID_DOMAIN_FIXTURES`]):

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -6983,18 +6983,6 @@ fn domain_scaffold_inputs_from_source(
     Ok((contract, fsl_tools::domain_scaffold_metadata(domain)))
 }
 
-/// Validate a domain command's source through the checked Kernel path shared
-/// by `check`, `verify`, and `domain generate`.
-///
-/// `domain analyze` and `domain expand` still consume their specialized
-/// projections below, but must never return success for a document direct
-/// lowering rejects (#796).
-fn validate_domain_command_input(path: &Path, source: &str) -> Result<(), (Value, i32)> {
-    load_kernel_model_from_source(path, source)
-        .map(|_| ())
-        .map_err(|error| (spec_load_error_output(&error), 2))
-}
-
 fn snake_case(value: &str) -> String {
     let characters = value.chars().collect::<Vec<_>>();
     let mut output = String::new();
@@ -7063,15 +7051,12 @@ fn run_domain_check(
 
 fn run_domain_analyze(path: &Path) -> (Value, i32) {
     match read_domain_command_input(path) {
-        // Preserve #726's renderer-side fail-closed guard and its established
-        // diagnostics first. A successful raw-`DomainSpec` projection must
-        // then also clear the checked direct-lowering path before it can be
-        // returned (#796).
-        Ok((source, domain)) => match fsl_tools::analyze_domain(&domain) {
-            Ok(result) => match validate_domain_command_input(path, &source) {
-                Ok(()) => wrap_specialized(result),
-                Err(error) => error,
-            },
+        // #726's renderer-side fail-closed guard; #798 slice 1 made the
+        // specialized projection agree with direct lowering, so the former
+        // #796 post-validation against `load_kernel_model_from_source` is
+        // no longer required at this boundary.
+        Ok((_source, domain)) => match fsl_tools::analyze_domain(&domain) {
+            Ok(result) => wrap_specialized(result),
             Err(error) => (domain_projection_error_output(path, &error), 2),
         },
         Err(error) => (spec_load_error_output(&error), 2),
@@ -7079,7 +7064,7 @@ fn run_domain_analyze(path: &Path) -> (Value, i32) {
 }
 
 fn run_domain_expand(path: &Path, output_path: Option<&Path>) -> (Value, i32) {
-    let (input_source, domain) = match read_domain_command_input(path) {
+    let (_input_source, domain) = match read_domain_command_input(path) {
         Ok(input) => input,
         Err(error) => return (spec_load_error_output(&error), 2),
     };
@@ -7087,9 +7072,6 @@ fn run_domain_expand(path: &Path, output_path: Option<&Path>) -> (Value, i32) {
         Ok(source) => source,
         Err(error) => return (domain_projection_error_output(path, &error), 2),
     };
-    if let Err(error) = validate_domain_command_input(path, &input_source) {
-        return error;
-    }
     if let Some(output_path) = output_path
         && let Err(error) = std::fs::write(output_path, &source)
     {
@@ -16955,9 +16937,9 @@ fn core_error_output(error: &fsl_core::CoreError) -> Value {
 
 /// Render a domain projection failure from the renderer path.
 ///
-/// #798 slice 1 rejects unknown symbols during rendering. Those diagnostics
-/// must match `check`'s file-qualified envelope (#796). Other renderer
-/// failures keep the historical `at line:column` message shape established by
+/// #798 rejects unknown symbols during rendering. Those diagnostics must match
+/// `check`'s file-qualified envelope. Other renderer failures keep the
+/// historical `at line:column` message shape established by
 /// `domain_origin_diagnostics`.
 fn domain_projection_error_output(path: &Path, error: &fsl_core::CoreError) -> Value {
     if error.message.starts_with("unknown domain symbol") {
@@ -17183,14 +17165,13 @@ spec InitTraceability {
         }
     }
 
-    /// Deterministic TOCTOU control for #796. The first read captures an
-    /// authored-invalid domain, then an atomic rename replaces the path with
-    /// a valid document. Validation must reject the captured snapshot even
-    /// though the path now contains a valid document. After #798 slice 1 the
-    /// specialized projections also fail closed on the same unknown symbols
-    /// as `check`, rather than rendering a false-green kernel.
+    /// Deterministic TOCTOU control for domain projection commands. The first
+    /// read captures an authored-invalid domain, then an atomic rename replaces
+    /// the path with a valid document. The specialized projections must reject
+    /// the captured in-memory `DomainSpec` even though the path now contains a
+    /// valid document.
     #[test]
-    fn domain_projection_validation_uses_the_original_source_snapshot() {
+    fn domain_projection_uses_the_original_source_snapshot() {
         let directory =
             std::env::temp_dir().join(format!("fslc-domain-snapshot-{}", std::process::id()));
         std::fs::create_dir_all(&directory).expect("create temporary fixture directory");
@@ -17218,10 +17199,7 @@ spec InitTraceability {
             fsl_tools::domain_kernel_source(&domain).is_err(),
             "the specialized expansion must reject the same unknown symbols as check"
         );
-        assert!(
-            validate_domain_command_input(&path, &source).is_err(),
-            "validation must use the initially-read invalid source, not its valid replacement"
-        );
+        let _ = source;
 
         std::fs::remove_dir_all(&directory).expect("remove temporary fixture directory");
     }

--- a/rust/fslc/tests/issue_796_domain_command_validation.rs
+++ b/rust/fslc/tests/issue_796_domain_command_validation.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Ryoichi Izumita
 
-//! Cross-command validation controls for #796.
+//! Cross-command validation controls for domain projection commands.
 //!
 //! `domain analyze` projects the domain AST and `domain expand` renders
 //! generated Kernel text, but neither may accept a source document that typed
-//! domain lowering rejects. In particular, renderer string normalization can
-//! leave an unknown authored identifier unchanged and previously produced a
-//! Kernel source that `fslc check` rejected. Both commands must instead return
-//! the same located semantic diagnostic as `check`.
+//! domain lowering rejects. #798 slice 1 made the renderer agree with direct
+//! lowering; slice 2 retired the #796 post-validation that previously masked
+//! renderer divergence at the CLI boundary.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -121,8 +120,8 @@ fn assert_rejected_like_check(fixture: &str) {
 
 /// Rejecting control: before #796 both commands returned exit 0 for this
 /// unknown state reference, while `check` rejected it at the authored
-/// expression. Keeping all three envelopes aligned prevents either command
-/// from again producing a false-green analysis or an invalid Kernel export.
+/// expression. After #798 slice 2 the renderer rejects directly; the former
+/// #796 `load_kernel_model_from_source` guard is no longer needed.
 #[test]
 fn domain_analyze_and_expand_reject_unknown_names_like_check() {
     assert_rejected_like_check(
@@ -155,11 +154,9 @@ fn domain_expand_rejection_does_not_write_output() {
     std::fs::remove_file(&output_path).expect("remove sentinel");
 }
 
-/// #798 is the sibling generated-name case: direct lowering rejects authored
-/// use of a generated enum member, but the renderer still leaves that already
-/// qualified text unchanged. Before #796 the CLI emitted that falsely valid
-/// Kernel; shared lowering validation now rejects it before either command
-/// emits a success envelope.
+/// #798 generated-name case: direct lowering rejects authored use of a
+/// generated enum member. Slice 1 made path B reject it during rendering;
+/// slice 2 retired the #796 CLI guard that previously masked the divergence.
 #[test]
 fn domain_analyze_and_expand_reject_generated_kernel_names_like_check() {
     assert_rejected_like_check(
@@ -185,11 +182,10 @@ fn domain_analyze_and_expand_still_accept_valid_domain_specs() {
     );
 }
 
-/// Deterministic external TOCTOU control for both #796 commands. A FIFO
-/// observes filesystem reads directly: the fixed implementation reads it
-/// once, so the first authored-invalid source must produce exit 2. Restoring
-/// `validate_domain_command_input` to `load_kernel_model(path)` performs the
-/// second read, receives the valid source, and makes this test fail.
+/// Deterministic external TOCTOU control for both domain projection commands.
+/// A FIFO observes filesystem reads directly: the fixed implementation reads it
+/// once, so the first authored-invalid source must produce exit 2. A second
+/// read of the replacement inode would make this test fail.
 ///
 /// This control is Unix-only because Windows has no FIFO equivalent. The
 /// non-Unix test below deliberately names that absence, so a Windows green


### PR DESCRIPTION
## Summary

Closes #798 (slice 2). Retires the #796 post-validation (`validate_domain_command_input` / `load_kernel_model_from_source`) on `domain analyze` and `domain expand` success paths. Slice 1's scope-aware AST normalize already makes path B agree with `lower_domain`; the renderer now rejects directly.

- **Acceptance:** `ai_internal_name_misuse.fsl` — `check` exit 2, `domain expand` exit 2 (no false green).
- **Negative control:** temporarily passthrough unknown symbols in `resolve_render_name` → `domain expand` exit 0 without the guard (proves renderer, not CLI, is the fix).
- `domain_render_agreement`: 13/13; `issue_796_domain_command_validation`: 5/5; `fslc-rust`: 147 suites exit 0.

**Legacy `str::replace`:** `Context::normalize` pipeline removed in slice 1. `replace_identifier` remains only in `saga_condition` (saga event-flag substitution — separate surface, not the #798 normalize path).

## Test plan

- [x] `cargo test -p fsl-core --test domain_render_agreement`
- [x] `cargo test -p fslc-rust --test issue_796_domain_command_validation`
- [x] `cargo test -p fslc-rust` (147 suites)
- [x] `cargo test -p fsl-core`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] CLI acceptance on `ai_internal_name_misuse.fsl`
- [ ] `check-merge-readiness.sh automation` — host `python3` is 3.9.6 (f-string SyntaxError in unrelated workflow test); Rust gates green


Made with [Cursor](https://cursor.com)