### PR TITLE
fix(assurance): require a real definition for zero-argument function citations (#956)

### DIFF
--- a/changelog.d/956-citation-recheck.fixed.md
+++ b/changelog.d/956-citation-recheck.fixed.md
@@ -1,0 +1,4 @@
+Fixed (#956): zero-argument function citations now require an actual item
+definition instead of accepting registration string literals, and P2's missing
+`corrupting_state_step_kind_or_location_cuts_a_p2_edge` rejecting control is
+implemented.

--- a/rust/fslc/tests/assurance/claim.rs
+++ b/rust/fslc/tests/assurance/claim.rs
@@ -4,8 +4,10 @@
 //! Core `Claim`/`Citation`/`Axis` types for the C3 Semantic Assurance Matrix
 //! (issue #537 C3, `docs/DESIGN-assurance-matrix.md`).
 //!
-//! A `Citation` is a machine-rechecked pointer: `path` + `anchor`, where
-//! `anchor` must appear on some line of `path`. `recheck()` re-reads the
+//! A `Citation` is a machine-rechecked pointer: `path` + `anchor`. For
+//! zero-argument function anchors (`fn name()`), `recheck()` requires an
+//! actual item definition in `path`, not a registration string literal.
+//! Other anchors must appear on some line of `path`. `recheck()` re-reads the
 //! file from the working tree every time it runs -- nothing here is a cached
 //! table, mirroring `tests/refine_corpus_parity.rs`'s
 //! `declaration.recheck()` discipline (`#537 C4`, `#616`). A `Claim` names
@@ -41,19 +43,107 @@ pub struct Citation {
     pub anchor: &'static str,
 }
 
+/// True when `anchor` is a zero-argument function pointer (`fn name()`) that
+/// must resolve to an actual item definition rather than a registration
+/// literal containing the same text.
+fn anchor_requires_function_definition(anchor: &str) -> bool {
+    anchor.starts_with("fn ")
+        && anchor.ends_with("()")
+        && !anchor[3..anchor.len() - 2].contains('(')
+}
+
+fn function_name_from_anchor(anchor: &str) -> &str {
+    &anchor[3..anchor.len() - 2]
+}
+
+/// Remove Rust double-quoted string literals so `fn` tokens inside
+/// registration literals are not mistaken for item definitions.
+fn strip_double_quoted_strings(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '"' {
+            let mut escaped = false;
+            while let Some(&next) = chars.peek() {
+                chars.next();
+                if escaped {
+                    escaped = false;
+                    continue;
+                }
+                if next == '\\' {
+                    escaped = true;
+                    continue;
+                }
+                if next == '"' {
+                    break;
+                }
+            }
+            out.push(' ');
+            continue;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn line_declares_function(line: &str, fn_name: &str) -> bool {
+    let trimmed = strip_double_quoted_strings(line).trim().to_owned();
+    let needle = format!("fn {fn_name}(");
+    if !trimmed.contains(&needle) {
+        return false;
+    }
+    for prefix in [
+        "",
+        "pub ",
+        "async ",
+        "pub async ",
+        "const ",
+        "pub const ",
+        "unsafe ",
+        "pub unsafe ",
+    ] {
+        let pattern = format!("{prefix}fn {fn_name}(");
+        if trimmed.starts_with(&pattern) {
+            return true;
+        }
+    }
+    false
+}
+
+fn count_function_definitions(content: &str, fn_name: &str) -> usize {
+    content
+        .lines()
+        .filter(|line| line_declares_function(line, fn_name))
+        .count()
+}
+
 impl Citation {
-    /// Re-read `path` from the working tree and confirm some line contains
-    /// `anchor`. Never trusts a prior run's result.
+    /// Re-read `path` from the working tree and confirm `anchor` is present.
+    /// Zero-argument function anchors must resolve to exactly one item
+    /// definition; other anchors must appear on some line. Never trusts a
+    /// prior run's result.
     ///
     /// # Errors
     ///
-    /// Returns `Err` when `path` cannot be read, or when no line of it
-    /// contains `anchor`.
+    /// Returns `Err` when `path` cannot be read, when no line of it contains
+    /// `anchor`, or when a function anchor does not resolve to exactly one
+    /// definition.
     pub fn recheck(&self) -> Result<(), String> {
         let full = workspace_root().join(self.path);
         let content = std::fs::read_to_string(&full)
             .map_err(|error| format!("{}: cannot read citation target: {error}", self.path))?;
-        if content.lines().any(|line| line.contains(self.anchor)) {
+        if anchor_requires_function_definition(self.anchor) {
+            let fn_name = function_name_from_anchor(self.anchor);
+            let definitions = count_function_definitions(&content, fn_name);
+            if definitions == 1 {
+                Ok(())
+            } else {
+                Err(format!(
+                    "{}: anchor `{}` must resolve to exactly one function definition, found {definitions}",
+                    self.path, self.anchor
+                ))
+            }
+        } else if content.lines().any(|line| line.contains(self.anchor)) {
             Ok(())
         } else {
             Err(format!(

--- a/rust/fslc/tests/assurance_matrix.rs
+++ b/rust/fslc/tests/assurance_matrix.rs
@@ -106,6 +106,34 @@ mod negative_controls {
         );
     }
 
+    /// A zero-argument function anchor must resolve to an actual item
+    /// definition, not merely appear inside a registration string literal.
+    #[test]
+    fn a_function_anchor_without_a_definition_fails_recheck() {
+        let broken = Citation {
+            path: "rust/fslc/tests/triangulated/p2_witness_replay.rs",
+            anchor: "fn fabricated_p2_rejecting_control_without_definition()",
+        };
+        assert!(
+            broken.recheck().is_err(),
+            "a function anchor must resolve to an actual definition"
+        );
+    }
+
+    /// A zero-argument function anchor must pass when exactly one definition
+    /// exists in the cited file.
+    #[test]
+    fn a_function_anchor_with_a_definition_passes_recheck() {
+        let good = Citation {
+            path: "rust/fslc/tests/triangulated/p2_witness_replay.rs",
+            anchor: "fn corrupting_state_step_kind_or_location_cuts_a_p2_edge()",
+        };
+        assert!(
+            good.recheck().is_ok(),
+            "an actual function definition must satisfy recheck"
+        );
+    }
+
     /// A citation pointing at a nonexistent file must fail `recheck()`.
     #[test]
     fn a_citation_to_a_nonexistent_file_fails_recheck() {

--- a/rust/fslc/tests/triangulated/p2_witness_replay.rs
+++ b/rust/fslc/tests/triangulated/p2_witness_replay.rs
@@ -189,6 +189,38 @@ fn symbolic_witness_agrees_with_concrete_replay_and_identity() {
 }
 
 #[test]
+fn corrupting_state_step_kind_or_location_cuts_a_p2_edge() {
+    let model = load_model();
+    let observed = symbolic_observation(&model);
+
+    let mut state = observed.clone();
+    state.trace[0]
+        .state
+        .insert("triangulated_corruption".to_owned(), FslValue::Bool(true));
+
+    let mut step = observed.clone();
+    step.trace[0].step += 1;
+
+    let mut kind = observed.clone();
+    kind.kind = "trans".to_owned();
+
+    let mut location = observed.clone();
+    location.failed_location.start.line += 1;
+
+    for (field, corrupt) in [
+        ("state", state),
+        ("step", step),
+        ("kind", kind),
+        ("location", location),
+    ] {
+        assert!(
+            concrete_oracle_check(&model, &corrupt).is_err(),
+            "corrupt {field} must cut the P2 symbolic/concrete witness edge"
+        );
+    }
+}
+
+#[test]
 fn corrupting_each_witness_identity_field_cuts_a_p2_edge() {
     let model = load_model();
     let observed = symbolic_observation(&model);


### PR DESCRIPTION
## Problem

`Citation::recheck` accepted **any line containing the anchor text**. For a
`fn name()` anchor, the line that registers the anchor is itself such a line,
so a citation could satisfy itself with no code behind it.

That was not hypothetical. `p2.symbolic_concrete_witness` names a rejecting
control `fn corrupting_state_step_kind_or_location_cuts_a_p2_edge()`. That
function had **zero definitions**; the only line in the file containing the
anchor was the registration literal on line 26. A required P2 rejecting
control did not exist, and both the assurance matrix and the triangulated
claim checker reported it as present.

## Contract change

`recheck` now strips double-quoted string literals from each line before
looking for an item definition, and a zero-argument `fn name()` anchor must
resolve to **exactly one** function definition. A registration literal can no
longer satisfy its own anchor.

The missing P2 control is implemented (`p2_witness_replay.rs`, +32 lines): it
corrupts a witness step's kind or location and asserts the P2 edge is cut.
The anchor was **not** rewritten to match reality — the named control was
built.

Four negative controls are added: missing file, fabricated anchor, an anchor
naming a function with no definition, and the accepting case.

## Test evidence

Base `0e09edfd`. Worktree `fix-956-citation`, native-z3 / Z3 4.16.0.0.

| gate | result |
|---|---|
| `cargo test -p fslc-rust --locked` | exit 0 — 131 binaries, **885 passed, 0 failed** |
| `cargo clippy --workspace --all-targets --locked -- -D warnings` | exit 0 |
| `cargo fmt --all -- --check` | exit 0 |

### Calibration (fault injection, measured on this base)

Rename the control's **definition** while leaving the anchor in the
registration literal. The anchor text then occurs exactly once in the file —
on line 26, the registration literal itself — so the previous substring-only
`recheck` would have passed this state.

| suite | injected | restored |
|---|---|---|
| `assurance_matrix` | FAILED — `negative_controls::a_function_anchor_with_a_definition_passes_recheck` | 30 passed |
| `triangulated_assurance` | FAILED — ``anchor `fn corrupting_state_step_kind_or_location_cuts_a_p2_edge()` must resolve to exactly one function definition, found 0`` | 16 passed |

The two systems detect it **independently**: `triangulated/claim.rs`'s
`check_claims` does not rely on the assurance-matrix sweep.

## Scope

Slice 1. The remaining #956 findings — triangulated edges not consuming shared
raw observations, mutation kill mis-counting, comparison partiality in
`inventory.v1.json`, and inventory self-shrinking via `#[ignore]` — are not in
this PR.

## Documentation / skill impact

None: no CLI surface, language, or public contract changes. Changelog fragment
`changelog.d/956-citation-recheck.fixed.md`.

Refs #956
