### PR TITLE
required(#761): extend the CI validator inventory to tools/check_rust_*.py

### DIFF
--- a/.github/ci-validator-inventory.json
+++ b/.github/ci-validator-inventory.json
@@ -557,6 +557,86 @@
       "exempt_reason": "frozen-python-compatibility",
       "path": "tests/test_version.py",
       "tier": "exempt"
+    },
+    {
+      "exempt_reason": "manual-developer-run",
+      "path": "tools/check_rust_ast_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "pending-native-migration",
+      "path": "tools/check_rust_bfs_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "pending-native-migration",
+      "path": "tools/check_rust_bmc_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "manual-developer-run",
+      "path": "tools/check_rust_cli_snapshot.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "frozen-python-compatibility",
+      "path": "tools/check_rust_corpus_cli_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "frozen-python-compatibility",
+      "path": "tools/check_rust_dialect_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "manual-developer-run",
+      "path": "tools/check_rust_grammar_fuzz.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "frozen-python-compatibility",
+      "path": "tools/check_rust_induction_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "manual-developer-run",
+      "path": "tools/check_rust_kernel_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "frozen-python-compatibility",
+      "path": "tools/check_rust_leadsto_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "frozen-python-compatibility",
+      "path": "tools/check_rust_phase2_commands.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "parked-pending-unrelated-work",
+      "path": "tools/check_rust_phase3_commands.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "frozen-python-compatibility",
+      "path": "tools/check_rust_refinement_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "frozen-python-compatibility",
+      "path": "tools/check_rust_replay_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "pending-native-migration",
+      "path": "tools/check_rust_scenarios_parity.py",
+      "tier": "exempt"
+    },
+    {
+      "exempt_reason": "manual-developer-run",
+      "path": "tools/check_rust_surface_parity.py",
+      "tier": "exempt"
     }
   ]
 }

--- a/.github/ci-validator-inventory.json
+++ b/.github/ci-validator-inventory.json
@@ -589,6 +589,11 @@
       "tier": "exempt"
     },
     {
+      "exempt_reason": "frozen-python-compatibility",
+      "path": "tools/check_rust_full_envelope.py",
+      "tier": "exempt"
+    },
+    {
       "exempt_reason": "manual-developer-run",
       "path": "tools/check_rust_grammar_fuzz.py",
       "tier": "exempt"

--- a/changelog.d/761-extend-validator-inventory-to-rust-harnesses.required.md
+++ b/changelog.d/761-extend-validator-inventory-to-rust-harnesses.required.md
@@ -7,14 +7,23 @@ record of why any were unwired). Three new `exempt_reason` values (plus the exis
 `frozen-python-compatibility`, reused) distinguish the actual reasons found in issue #761's
 classification table instead of collapsing them into one:
 `manual-developer-run` (5 self-declared "Optional developer-run" harnesses), `frozen-python-compatibility`
-(reused; the 7 F1-F7 parity harnesses, whose precise pipeline stage remains `docs/RUST-PORTING.md`'s
+(reused; the 8 F1-F8 parity harnesses, whose precise pipeline stage remains `docs/RUST-PORTING.md`'s
 record, not this inventory's), `parked-pending-unrelated-work` (1 harness blocked on an unrelated,
 currently-parked feature), and `pending-native-migration` (3 harnesses blocked on a tracked,
 not-yet-complete migration). This tool establishes only that a classification was recorded, not that
 it is correct; `docs/DESIGN-ci-validator-inventory.md` states that guarantee boundary explicitly. The
-16 harnesses discovered today were seeded via explicit `--exempt path:reason` pairs matched to #761's
+17 harnesses in the inventory were seeded via explicit `--exempt path:reason` pairs matched to #761's
 own classification table, not via the filename-pattern default (`default_exempt_reason`), which was
 not relied on here. That default is reached both via `--bootstrap` for a genuinely new module and,
 pre-existing and unrelated to this change, via an ordinary `generate` for a module whose `wiring`/
 `prior` tier falls through every more specific branch (for example a previously `required` module
 that is no longer wired anywhere) -- confirmed directly, not merely inferred from the source.
+
+16 of the 17 were seeded in one `--bootstrap --exempt` call against a clean prior. `full_envelope`
+was classified separately, one commit later in review: an earlier version of this pull request also
+deleted `tools/check_rust_full_envelope.py`, reasoning that its `_diff`/`_normalize` helpers had no
+other consumers after #913; independent review found that answers "is the helper still used," not "is
+the comparison it performs still needed," and that `test-browser.mjs`'s native-vs-WASM parity is a
+different edge that does not observe the frozen Python side either -- so it was restored, classified
+`frozen-python-compatibility` like the other seven F-numbered harnesses, and its retirement decision
+moved to a dedicated follow-up issue (#988) instead of being bundled with this change.

--- a/changelog.d/761-extend-validator-inventory-to-rust-harnesses.required.md
+++ b/changelog.d/761-extend-validator-inventory-to-rust-harnesses.required.md
@@ -1,0 +1,20 @@
+Required (#761): `tools/check_ci_validator_inventory.py` now discovers and requires classification for
+`tools/check_rust_*.py` in addition to `tests/test_*.py`, reserved as future scope by slice 1
+(`docs/DESIGN-ci-validator-inventory.md`, "Scope boundaries"). A new, unclassified harness now fails
+`check` closed with `untracked validator module`, exactly as an unclassified `tests/test_*.py` module
+already did -- the shape #761 itself demonstrated is otherwise possible (17 harnesses existed with no
+record of why any were unwired). Three new `exempt_reason` values (plus the existing
+`frozen-python-compatibility`, reused) distinguish the actual reasons found in issue #761's
+classification table instead of collapsing them into one:
+`manual-developer-run` (5 self-declared "Optional developer-run" harnesses), `frozen-python-compatibility`
+(reused; the 7 F1-F7 parity harnesses, whose precise pipeline stage remains `docs/RUST-PORTING.md`'s
+record, not this inventory's), `parked-pending-unrelated-work` (1 harness blocked on an unrelated,
+currently-parked feature), and `pending-native-migration` (3 harnesses blocked on a tracked,
+not-yet-complete migration). This tool establishes only that a classification was recorded, not that
+it is correct; `docs/DESIGN-ci-validator-inventory.md` states that guarantee boundary explicitly. The
+16 harnesses discovered today were seeded via explicit `--exempt path:reason` pairs matched to #761's
+own classification table, not via the filename-pattern default (`default_exempt_reason`), which was
+not relied on here. That default is reached both via `--bootstrap` for a genuinely new module and,
+pre-existing and unrelated to this change, via an ordinary `generate` for a module whose `wiring`/
+`prior` tier falls through every more specific branch (for example a previously `required` module
+that is no longer wired anywhere) -- confirmed directly, not merely inferred from the source.

--- a/docs/DESIGN-bfs-bmc-native-migration.md
+++ b/docs/DESIGN-bfs-bmc-native-migration.md
@@ -321,7 +321,7 @@ The safe removal sequence is:
    (`rust/fslc/tests/liveness_witness_replay.rs:124-147,167-242`). Do **not** delete
    `fsl-replay-actions` merely because BFS/BMC/scenarios are gone: the retained
    Python consumer still imports its path and executes it
-   (`tools/check_rust_leadsto_parity.py:22,70-100,148-155`). Remove the binary in
+   (`tools/check_rust_leadsto_parity.py:28,76-105,154-161`). Remove the binary in
    the cleanup that deletes that consumer, or after deliberately migrating the
    retained consumer to a production replay surface. This is a hard dependency,
    not optional cleanup.

--- a/docs/DESIGN-ci-validator-inventory.md
+++ b/docs/DESIGN-ci-validator-inventory.md
@@ -3,7 +3,22 @@
 Accepted decision for issue #962 slice 1: record every `tests/test_*.py`
 validator module in a machine-generated inventory and fail closed when a new
 module appears without required-gate wiring or an explicit exempt
-classification.
+classification. Extended by issue #761 stage 2 to `tools/check_rust_*.py`
+(reserved as future scope by slice 1's own "Scope boundaries" section below).
+
+## Guarantee boundary
+
+This tool establishes that a validator module's tier and exempt reason were
+**recorded**, not that the recorded reason is **correct**. `--exempt
+path:reason` costs one command and satisfies `generate`'s guard completely;
+that is intentional, not a gap -- the property this check protects is "no
+validator module accumulates silently, unclassified" (the root problem
+#761's 17 unwired `tools/check_rust_*.py` harnesses demonstrated: nobody had
+recorded why any of them were unwired). Whether a recorded reason accurately
+describes a specific module -- the F1-F7 precondition analysis, native-owner
+cross-referencing, and retirement readiness for the parity harnesses -- is
+`docs/RUST-PORTING.md`'s job, a human-maintained document this tool does not
+read and cannot verify.
 
 ## Problem
 
@@ -35,18 +50,42 @@ from required-gate resolution.
 Declared `exempt_reason` values:
 
 - `frozen-python-compatibility` — frozen Python reference/product tests kept
-  outside required gates (`docs/DESIGN-rust-integration.md`).
+  outside required gates (`docs/DESIGN-rust-integration.md`). Also covers the
+  7 `tools/check_rust_*.py` parity harnesses whose disposition in
+  `docs/RUST-PORTING.md` is F1, F2, F3, F4, F5, F6, or F7 (`corpus_cli_parity`,
+  `dialect_parity`, `induction_parity`, `leadsto_parity`, `phase2_commands`,
+  `refinement_parity`, `replay_parity`) — each still fundamentally compares
+  against the frozen Python reference; the precise stage each is at within
+  that F1-F7 pipeline (precondition unmet, native owner pending review, or
+  explicitly retained) is recorded in `RUST-PORTING.md`'s own table, not
+  re-encoded here (see "Guarantee boundary" above).
 - `hook-local` — agent hook contract tests with timing or local-environment
   dependencies (`tests/test_hook_enforcement.py`; see
   `docs/DESIGN-hooks-enforcement.md`).
+- `manual-developer-run` (#761 stage 2) — a `tools/check_rust_*.py` harness
+  whose own docstring declares it "Optional developer-run", run only for an
+  intentional change to a named frozen-Python projection
+  (`ast_parity`, `cli_snapshot`, `grammar_fuzz`, `kernel_parity`,
+  `surface_parity`). Distinct from `frozen-python-compatibility`: the reason
+  these are unwired is a declared process boundary, not (only) that the
+  property is frozen-reference-scoped -- `surface_parity` in particular does
+  not import the frozen Python package at all.
+- `parked-pending-unrelated-work` (#761 stage 2) — `phase3_commands`,
+  blocked on an unowned native `ai compare` contract while AI work is
+  currently parked; unrelated to Python-compatibility retirement.
+- `pending-native-migration` (#761 stage 2) — `bfs_parity`, `bmc_parity`,
+  `scenarios_parity`, blocked on the not-yet-complete native BFS/BMC
+  migration (`docs/DESIGN-bfs-bmc-native-migration.md`), a tracked multi-PR
+  sequence rather than a single harness's own precondition.
 
 Unwired validators are not defects by default. Only `required` rows must be
 reachable from the scanned entrypoints.
 
 ## Controls
 
-1. **Inventory completeness** — every tracked `tests/test_*.py` module must
-   appear in the committed inventory; new modules fail `check` until classified.
+1. **Inventory completeness** — every tracked `tests/test_*.py` and
+   `tools/check_rust_*.py` module must appear in the committed inventory;
+   new modules fail `check` until classified.
 2. **Required wiring** — `tier: required` rows must match live wiring
    discovered from the scanned entrypoints.
 3. **Exempt anti-reward** — a module wired into a required entrypoint cannot
@@ -74,12 +113,29 @@ Calibration evidence:
   `untracked validator module`.
 - Wire it into `tools/check-merge-readiness.sh` and run `generate` → the module
   becomes `tier: required` and `check` passes.
+- Add a new unwired `tools/check_rust_*.py` module → `check` fails with
+  `untracked validator module` (#761 stage 2, same execution path as the
+  `tests/` case above). Measured directly against this repository, not only a
+  fixture: `check` on the unmodified tree exits 0 (123 validator modules);
+  adding an unclassified `tools/check_rust_probe_injected.py` and re-running
+  the identical command exits 1, naming that exact path; removing it restores
+  exit 0. Classify it via `generate --exempt
+  tools/check_rust_probe_injected.py:<reason>` (one of the four declared
+  reasons above) or wire it into a required entrypoint to clear the finding.
 
 ## Scope boundaries
 
-- Slice 1 does **not** wire the existing 98 unwired frozen-Python modules.
-- `tools/check_rust_*.py` harness disposition and orphan binaries are issue
-  #761 (stages 2–3), not this inventory.
+- Slice 1 does **not** wire the existing 98 unwired frozen-Python
+  `tests/test_*.py` modules.
+- **#761 stage 2 (this change)**: `tools/check_rust_*.py` discovery and
+  classification are now in scope for this inventory, using the 4 declared
+  reasons above. The *disposition* of each harness -- whether it should
+  eventually be wired, retired, or stay exempt, and why -- remains
+  `docs/RUST-PORTING.md`'s authority; this inventory only records that a
+  classification exists, per the guarantee boundary above. Orphan binaries
+  (`fsl-parse-expr`, `fsl-parse-kernel`, `fsl-parse-surface`, `fsl-bfs`,
+  `fsl-bmc`, `fsl-replay-actions`) are #761 stage 3, still not this
+  inventory's concern.
 - `tests/test_hook_enforcement.py` remains exempt (`hook-local`); its timing-
   dependent cargo-lock serialization test is not promoted to a required gate.
 
@@ -88,3 +144,5 @@ Calibration evidence:
 - `docs/DESIGN-ci.md` — required pre-merge contexts and automation contracts
 - `docs/DESIGN-hooks-enforcement.md` — hook-local exempt boundary
 - `docs/DESIGN-rust-integration.md` — frozen Python compatibility boundary
+- `docs/RUST-PORTING.md` — the 16-harness `tools/check_rust_*.py` disposition
+  table this inventory's `exempt_reason` values summarize but do not replace

--- a/docs/DESIGN-ci-validator-inventory.md
+++ b/docs/DESIGN-ci-validator-inventory.md
@@ -15,7 +15,7 @@ that is intentional, not a gap -- the property this check protects is "no
 validator module accumulates silently, unclassified" (the root problem
 #761's 17 unwired `tools/check_rust_*.py` harnesses demonstrated: nobody had
 recorded why any of them were unwired). Whether a recorded reason accurately
-describes a specific module -- the F1-F7 precondition analysis, native-owner
+describes a specific module -- the F1-F8 precondition analysis, native-owner
 cross-referencing, and retirement readiness for the parity harnesses -- is
 `docs/RUST-PORTING.md`'s job, a human-maintained document this tool does not
 read and cannot verify.
@@ -51,12 +51,12 @@ Declared `exempt_reason` values:
 
 - `frozen-python-compatibility` — frozen Python reference/product tests kept
   outside required gates (`docs/DESIGN-rust-integration.md`). Also covers the
-  7 `tools/check_rust_*.py` parity harnesses whose disposition in
-  `docs/RUST-PORTING.md` is F1, F2, F3, F4, F5, F6, or F7 (`corpus_cli_parity`,
+  8 `tools/check_rust_*.py` parity harnesses whose disposition in
+  `docs/RUST-PORTING.md` is F1, F2, F3, F4, F5, F6, F7, or F8 (`corpus_cli_parity`,
   `dialect_parity`, `induction_parity`, `leadsto_parity`, `phase2_commands`,
-  `refinement_parity`, `replay_parity`) — each still fundamentally compares
-  against the frozen Python reference; the precise stage each is at within
-  that F1-F7 pipeline (precondition unmet, native owner pending review, or
+  `refinement_parity`, `replay_parity`, `full_envelope`) — each still fundamentally
+  compares against the frozen Python reference; the precise stage each is at within
+  that F1-F8 pipeline (precondition unmet, native owner pending review, or
   explicitly retained) is recorded in `RUST-PORTING.md`'s own table, not
   re-encoded here (see "Guarantee boundary" above).
 - `hook-local` — agent hook contract tests with timing or local-environment
@@ -116,7 +116,7 @@ Calibration evidence:
 - Add a new unwired `tools/check_rust_*.py` module → `check` fails with
   `untracked validator module` (#761 stage 2, same execution path as the
   `tests/` case above). Measured directly against this repository, not only a
-  fixture: `check` on the unmodified tree exits 0 (123 validator modules);
+  fixture: `check` on the unmodified tree exits 0 (124 validator modules);
   adding an unclassified `tools/check_rust_probe_injected.py` and re-running
   the identical command exits 1, naming that exact path; removing it restores
   exit 0. Classify it via `generate --exempt

--- a/docs/DESIGN-ci.md
+++ b/docs/DESIGN-ci.md
@@ -27,12 +27,17 @@ because they match that name. The five bounded frozen-Python compatibility check
 `RUST-PORTING.md` are developer-run only, triggered by an intentional change to their shared
 projection. They are outside merge readiness, the product gate, scheduled promotion, and release,
 and a manual pass cannot replace or waive native evidence. Native/Worker full-envelope comparison
-is owned by `rust/fsl-wasm/test-browser.mjs`; native semantic agreement is owned by the Rust
-agreement and replay suites. The Phase-3 Python comparison is separately parked until `ai compare`
-has a focused native contract test. #761's documentation phase deletes no harness:
-`check_rust_full_envelope.py` is deletion-ready only after its shared helpers move safely; seven
-parity harnesses remain because related native coverage does not yet detect their exact drift
-(F1–F7 in `RUST-PORTING.md`); and the BFS/BMC/scenarios trio remains pending native semantic migration.
+(native build vs. WASM build, not vs. the frozen Python side) is owned by
+`rust/fsl-wasm/test-browser.mjs`; native semantic agreement is owned by the Rust agreement and replay
+suites. The Phase-3 Python comparison is separately parked until `ai compare` has a focused native
+contract test. #761's documentation phase deletes no harness: eight parity harnesses remain deletion-
+deferred, for reasons recorded per-harness (F1–F8 in `RUST-PORTING.md`) rather than a blanket rule —
+some still lack matching native coverage, and two (F2, F4) have landed native coverage for part of
+what they check but retain a frozen-Python-vs-native comparison edge nothing native-only replaces.
+`check_rust_full_envelope.py` (F8) holds the only such edge for the *full* envelope, with no
+replacement edge identified yet, so retiring it needs a separate compatibility decision (#988); and
+the BFS/BMC/scenarios trio remains pending native semantic
+migration.
 
 ### Why the split falls here
 

--- a/docs/DESIGN-rust-integration.md
+++ b/docs/DESIGN-rust-integration.md
@@ -35,16 +35,20 @@ The removed `tests/test_rust_cli_contract.py` compared the evolving Rust CLI wit
 parser plus a large exception file. That made the frozen implementation a second authority. The
 native tests instead compare every live help path with the checked-in embedded contract and directly
 validate the published result/schema contracts. No parity utility is deleted under #761's
-documentation phase. `check_rust_full_envelope.py` is eligible for deletion because calibrated
-native/Worker parity owns its named drift, but it remains until its `_diff`/`_normalize` helpers move
-without breaking three retained consumers. Seven other utilities remain deletion-deferred because
-their exact native contract gaps (F1–F7) are recorded in `RUST-PORTING.md`.
+documentation phase. `check_rust_full_envelope.py`'s own `_diff`/`_normalize` helpers no longer block
+deletion (#913 moved them), but native/Worker parity in `test-browser.mjs` compares native against
+WASM, not against the frozen Python side, so it does not own this harness's drift and is not a
+substitute for it; retiring the harness needs a separate compatibility decision (#988). Eight
+utilities, `check_rust_full_envelope.py` included, remain deletion-deferred because their exact native
+contract gaps or comparison-edge replacement (F1–F8) are recorded in `RUST-PORTING.md`.
 `check_rust_phase3_commands.py` remains parked,
 outside every gate, until its
 unowned `ai compare` metric/delta projection receives a focused native contract test; AI work is
 currently parked. The five bounded manual utilities below are explicitly invoked compatibility
-evidence only; the seven F1–F7-deferred parity harnesses retain their existing detector role
-until the named native controls exist.
+evidence only; the eight F1–F8-deferred parity harnesses retain their existing detector role until
+each is individually reviewed and retired -- some (F2, F4) already have landed native coverage for
+part of what they check, but retirement is a separate, per-harness decision recorded in
+`RUST-PORTING.md`, not a blanket "once native exists" rule.
 
 That bounded manual suite is exactly `check_rust_ast_parity.py`,
 `check_rust_grammar_fuzz.py`, `check_rust_surface_parity.py`,

--- a/docs/RUST-PORTING.md
+++ b/docs/RUST-PORTING.md
@@ -170,14 +170,14 @@ The current 17-harness disposition is authoritative for maintenance work:
 | Disposition | Harnesses | Preconditions / scope |
 |---|---|---|
 | Manual compatibility (5) | `ast_parity`, `grammar_fuzz`, `surface_parity`, `kernel_parity`, `cli_snapshot` | Run only for an intentional change to the named frozen-Python projection; never product-gate evidence. |
-| F1 deletion deferred | `corpus_cli_parity` | Bind every corpus `verify` result class to its process exit and calibrate a rejecting mutation. |
-| F2 deletion deferred | `dialect_parity` | Add focused induction output contracts for the business, requirements, and governance paths. |
+| F1 deletion deferred | `corpus_cli_parity` | Native ownership landed: `rust/fslc/tests/corpus_check_sweep.rs`'s `verify_result_and_exit_status_never_contradict` / `verify_result_classes_map_to_exact_public_exit_codes` bind every corpus `verify` result class to its process exit, and `fault_operators/{unknown-result-to-success,failure-verdict-exits-zero}.patch` calibrate rejecting mutations against the same classifier (`fslc_rust::outcome`). #900 recorded this row as only partially closed; confirm the residual scope before retiring the script — this row is stale text, not a closed item. |
+| F2 deletion deferred | `dialect_parity` | Native ownership landed in #900: `rust/fslc/tests/dialect_induction_contract.rs::business_requirements_and_governance_pin_native_induction_contracts` already owns focused induction output contracts for the business, requirements, and governance paths. This row's own text was never updated when that test landed (measured 2026-09-04). Retiring `check_rust_dialect_parity.py` is a separate follow-up decision, not made here. |
 | F3 deletion deferred | `induction_parity` | Own the 16-case CLI stable fields/exits with explicit exclusions and negative controls. |
-| F4 deletion deferred | `leadsto_parity` | Add a native liveness-lasso replay matrix with isolated state/action/loop corruptions. |
+| F4 deletion deferred | `leadsto_parity` | Native ownership of a *native-only* corruption matrix landed in #903: `rust/fslc/tests/liveness_witness_replay.rs`'s `all_nine_case_by_corruption_cells_are_rejected_exactly` corrupts a Monitor-generated trace (state/action/loop, 9 cells) and confirms the native Monitor's own replay path rejects each exactly; a separate test in the same file checks BMC's safety/leadsTo verdicts, but nothing there cross-replays a BMC witness through Monitor. This row's earlier "add a matrix" wording overclaimed the remaining work for that half, but `check_rust_leadsto_parity.py` does two more things neither native test does: it diffs the frozen-Python `verify` envelope against the native one for the same three cases (`tools/check_rust_leadsto_parity.py:33-37,109-136`, `kind: "envelope"` failures), and cross-replays witnesses in both directions, Rust BMC to Python Monitor and Python BMC to Rust Monitor (`tools/check_rust_leadsto_parity.py:62-105,118-122`) — a second frozen-Python-vs-native comparison edge, structurally the same situation as F8/`full_envelope`. It also still imports and executes `fsl-replay-actions` via `check_rust_bmc_parity.DEFAULT_REPLAY_BIN` (import `tools/check_rust_leadsto_parity.py:28`; wired as the `--replay-bin` default and executed via `subprocess.run` at `:76-105,154-161`), so the binary and this harness retire together if the comparison edge is ever retired, not separately (see `DESIGN-bfs-bmc-native-migration.md` §5) — but that retirement is not established by the landed native matrix alone. |
 | F5 deletion deferred | `phase2_commands` | Assert `--keep-going` failure continuation and the human-readable `Layer` stderr table. |
 | F6 native-owned; harness retained | `refinement_parity` | `refine_corpus_parity` compares the complete observed stable projection, excludes only the solver-selected `impl_trace` witness with a stated reason, and rejects a dead exclusion. |
 | F7 deletion deferred | `replay_parity` | Add positive and rejecting native tests for the legacy unversioned `{ "events": [...] }` wrapper. |
-| Deletion-ready after helper move (1) | `full_envelope` | Native/Worker parity owns the detector; first move `_diff`/`_normalize` without breaking its three consumers. |
+| F8 deletion deferred | `full_envelope` | Holds the only frozen-Python-vs-native comparison edge for the full `check`/`verify` envelope; `rust/fsl-wasm/test-browser.mjs` compares native vs. WASM, a different edge, and is not a substitute (measured 2026-09-04: `check_rust_full_envelope.py` diffs `python_check` against `rust_check`, both driven from the same corpus case; `test-browser.mjs` diffs `nativeEnvelope` against `wasmEnvelope`, both native/WASM builds of the same Rust code — neither observes the frozen Python side). Its own `_diff`/`_normalize` helper move (#913) is already complete and does not by itself justify deletion; retiring the comparison edge itself is a separate compatibility decision, tracked in #988, not a cleanup. |
 | Parked (1) | `phase3_commands` | Add a focused native `ai compare` metric/delta contract; AI work is currently parked. |
 | Native migration phase (3) | `bfs_parity`, `bmc_parity`, `scenarios_parity` | Complete the native BFS/BMC/deadlock/reachability/action-coverage/witness matrix before deletion. |
 
@@ -206,8 +206,10 @@ PYTHONPATH=src python tools/check_rust_cli_snapshot.py
 # A nonzero result requires an explicit compatible-subset decision. Do not turn
 # native-only evolution into a broad allowlist or regenerate the snapshot to pass.
 
-# Deletion deferred: related native coverage does not yet own the exact detector.
-# F1-F7 above name the required native controls for these seven scripts.
+# Deletion deferred, for varying reasons named in F1-F8 above: some scripts still lack
+# matching native coverage; some (F2, F4) have landed native coverage but retiring the
+# script itself is a separate, not-yet-made decision; full_envelope (F8) holds a
+# frozen-Python-vs-native comparison edge no native/native check reproduces.
 PYTHONPATH=src python tools/check_rust_corpus_cli_parity.py --depth 3
 PYTHONPATH=src python tools/check_rust_dialect_parity.py
 PYTHONPATH=src python tools/check_rust_induction_parity.py
@@ -215,9 +217,6 @@ PYTHONPATH=src python tools/check_rust_leadsto_parity.py --depth 5
 PYTHONPATH=src python tools/check_rust_phase2_commands.py
 PYTHONPATH=src python tools/check_rust_refinement_parity.py
 PYTHONPATH=src python tools/check_rust_replay_parity.py
-
-# Native owner confirmed, but deletion waits for shared-helper extraction because
-# dialect, induction, and Phase-2 tools import `_diff`/`_normalize` from this module.
 PYTHONPATH=src python tools/check_rust_full_envelope.py --depth 5
 
 # Awaiting native semantic migration; not part of the bounded manual suite above.

--- a/rust/README.md
+++ b/rust/README.md
@@ -27,10 +27,14 @@ Current covered slice:
   SQL/Prisma import, AI hard-contract/stochastic evidence, domain structural
   checks/replay/scaffolds, and the report-tool command surface. The historical
   Phase-3 differential is parked, not a gate, and awaits a focused native
-  `ai compare` metric/delta contract before deletion. Seven other Python parity
-  harnesses also remain deletion-deferred pending the exact native controls in
-  `RUST-PORTING.md` F1–F7. The redundant full-envelope comparison is deletion-ready but
-  remains until its helpers move without breaking retained consumers.
+  `ai compare` metric/delta contract before deletion. Eight other Python parity
+  harnesses also remain deletion-deferred, for varying reasons, in
+  `RUST-PORTING.md` F1–F8. The full-envelope comparison (F8) is not redundant:
+  it is the only harness comparing the frozen Python side against native for
+  the *full* envelope (F2 and F4 separately do the same kind of comparison,
+  narrowed to their own dialect/case sets), and `test-browser.mjs`'s
+  native/WASM parity does not observe the frozen Python side either; retiring
+  it needs a separate compatibility decision (#988).
   Native tests cover
   typestate, full built-in/external mutation adjudication, invariant and
   reachable counterfactuals with source-backed blame, all five alternate

--- a/tests/test_ci_validator_inventory.py
+++ b/tests/test_ci_validator_inventory.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
 
-"""Reachability metatest for the CI validator inventory (issue #962)."""
+"""Reachability metatest for the CI validator inventory (issue #962; extended to
+tools/check_rust_*.py by issue #761 stage 2)."""
 
 from __future__ import annotations
 
@@ -43,6 +44,16 @@ def write_fixture_inventory(fixture: Path) -> None:
                 "tier": "exempt",
                 "exempt_reason": "frozen-python-compatibility",
             },
+            {
+                "path": "tools/check_rust_required.py",
+                "tier": "required",
+                "entrypoints": ["tools/check-merge-readiness.sh"],
+            },
+            {
+                "path": "tools/check_rust_exempt.py",
+                "tier": "exempt",
+                "exempt_reason": "manual-developer-run",
+            },
         ],
     }
     (fixture / ".github" / "ci-validator-inventory.json").write_text(
@@ -62,6 +73,7 @@ def bootstrap_fixture(tmp_path: Path) -> Path:
 set -euo pipefail
 check_automation() {
   python3 -m pytest tests/test_required.py -v
+  python3 tools/check_rust_required.py
 }
 case "${1:-all}" in
   automation) check_automation ;;
@@ -76,6 +88,8 @@ esac
     )
     (fixture / "tests" / "test_required.py").write_text("# required probe\n", encoding="utf-8")
     (fixture / "tests" / "test_exempt.py").write_text("# exempt probe\n", encoding="utf-8")
+    (fixture / "tools" / "check_rust_required.py").write_text("# required harness probe\n", encoding="utf-8")
+    (fixture / "tools" / "check_rust_exempt.py").write_text("# exempt harness probe\n", encoding="utf-8")
     write_fixture_inventory(fixture)
     subprocess.run(["git", "init"], cwd=fixture, check=True, capture_output=True, text=True)
     subprocess.run(["git", "add", "."], cwd=fixture, check=True, capture_output=True, text=True)
@@ -150,3 +164,132 @@ def test_inventory_calibration_wiring_detector(tmp_path: Path):
 
     wired = run_tool("check", cwd=fixture)
     assert wired.returncode == 0, wired.stderr or wired.stdout
+
+
+def test_inventory_rejects_untracked_rust_harness(tmp_path: Path):
+    # issue #761 stage 2: the tools/check_rust_*.py sibling of
+    # test_inventory_rejects_untracked_validator above, exercised through the
+    # real git-tracked-discovery path (git_tracked_rust_harness_modules), not
+    # a hand-built discovered= list.
+    fixture = bootstrap_fixture(tmp_path)
+    (fixture / "tools" / "check_rust_probe_untracked.py").write_text(
+        "# probe\n", encoding="utf-8"
+    )
+    subprocess.run(
+        ["git", "add", "tools/check_rust_probe_untracked.py"],
+        cwd=fixture,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result = run_tool("check", cwd=fixture)
+    assert result.returncode != 0
+    assert "untracked validator module" in result.stderr
+    assert "tools/check_rust_probe_untracked.py" in result.stderr
+
+
+def test_inventory_calibration_wiring_detector_for_rust_harness(tmp_path: Path):
+    fixture = bootstrap_fixture(tmp_path)
+    probe = fixture / "tools" / "check_rust_probe_wiring.py"
+    probe.write_text("# probe\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "tools/check_rust_probe_wiring.py"],
+        cwd=fixture,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    # No-fault/fault-side calibration on the same execution path: an
+    # unclassified new harness fails `check` (fault side) with the identical
+    # finding text the tests/test_*.py family produces above, then `generate`
+    # accepts an explicit --exempt classification (no-fault side) instead of
+    # requiring wiring, proving the two paths (wired-or-exempt) both work for
+    # this file family, not only the wired one.
+    unwired = run_tool("check", cwd=fixture)
+    assert unwired.returncode != 0
+    assert "untracked validator module" in unwired.stderr
+    assert "check_rust_probe_wiring.py" in unwired.stderr
+
+    generate_blocked = run_tool("generate", cwd=fixture)
+    assert generate_blocked.returncode != 0
+    assert "require explicit classification" in (generate_blocked.stderr or generate_blocked.stdout)
+
+    generate_bad_path = run_tool(
+        "generate", "--exempt", "tools/check_rust_probe_wiring.py",  # missing ":reason"
+        cwd=fixture,
+    )
+    assert generate_bad_path.returncode != 0
+
+    generated_exempt = run_tool(
+        "generate",
+        "--exempt",
+        "tools/check_rust_probe_wiring.py:pending-native-migration",
+        cwd=fixture,
+    )
+    assert generated_exempt.returncode == 0, generated_exempt.stderr or generated_exempt.stdout
+    inventory = json.loads(
+        (fixture / ".github" / "ci-validator-inventory.json").read_text(encoding="utf-8")
+    )
+    probe_entry = next(
+        entry
+        for entry in inventory["validators"]
+        if entry["path"] == "tools/check_rust_probe_wiring.py"
+    )
+    assert probe_entry["tier"] == "exempt"
+    assert probe_entry["exempt_reason"] == "pending-native-migration"
+    exempt_ok = run_tool("check", cwd=fixture)
+    assert exempt_ok.returncode == 0, exempt_ok.stderr or exempt_ok.stdout
+
+    # Now show the wired path also works, from the same starting inventory
+    # (re-add the probe as untracked-again by resetting its classification is
+    # unnecessary: wiring it makes `required` the correct tier regardless of
+    # the exempt row generate just wrote, matching build_entry's own
+    # wiring-takes-priority-over-prior rule).
+    merge_script = fixture / "tools" / "check-merge-readiness.sh"
+    merge_script.write_text(
+        merge_script.read_text(encoding="utf-8").replace(
+            "python3 tools/check_rust_required.py",
+            "python3 tools/check_rust_required.py\n  python3 tools/check_rust_probe_wiring.py",
+        ),
+        encoding="utf-8",
+    )
+    generated_required = run_tool("generate", cwd=fixture)
+    assert generated_required.returncode == 0, generated_required.stderr or generated_required.stdout
+    inventory = json.loads(
+        (fixture / ".github" / "ci-validator-inventory.json").read_text(encoding="utf-8")
+    )
+    probe_entry = next(
+        entry
+        for entry in inventory["validators"]
+        if entry["path"] == "tools/check_rust_probe_wiring.py"
+    )
+    assert probe_entry["tier"] == "required"
+    assert "tools/check-merge-readiness.sh" in probe_entry["entrypoints"]
+    wired = run_tool("check", cwd=fixture)
+    assert wired.returncode == 0, wired.stderr or wired.stdout
+
+
+def test_inventory_rejects_declared_reason_outside_the_closed_set(tmp_path: Path):
+    # Condition-4 boundary: --exempt cannot mint a brand-new reason string on
+    # the spot. Only EXEMPT_REASONS' declared values are accepted, so
+    # widening what a harness may claim requires editing this tool's source
+    # (reviewable), not a one-line data change.
+    fixture = bootstrap_fixture(tmp_path)
+    probe = fixture / "tools" / "check_rust_probe_reason.py"
+    probe.write_text("# probe\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "tools/check_rust_probe_reason.py"],
+        cwd=fixture,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result = run_tool(
+        "generate",
+        "--exempt",
+        "tools/check_rust_probe_reason.py:invented-on-the-spot",
+        cwd=fixture,
+    )
+    assert result.returncode != 0
+    assert "unknown exempt reason" in (result.stderr or result.stdout)

--- a/tools/check_ci_validator_inventory.py
+++ b/tools/check_ci_validator_inventory.py
@@ -16,7 +16,7 @@ once is the entire cost of satisfying `generate`'s guard, and that is
 intentional -- the property this check protects is "no validator module can
 accumulate silently, unclassified" (issue #761's own root problem: 17
 `tools/check_rust_*.py` harnesses existed with nobody having recorded why).
-Whether a recorded reason accurately describes the module -- the F1-F7
+Whether a recorded reason accurately describes the module -- the F1-F8
 precondition analysis, native-owner cross-referencing, and retirement
 readiness -- is `docs/RUST-PORTING.md`'s job, a human-maintained document
 this tool does not read and cannot verify.

--- a/tools/check_ci_validator_inventory.py
+++ b/tools/check_ci_validator_inventory.py
@@ -1,7 +1,39 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Ryoichi Izumita
-"""CI validator inventory: discover pytest modules and required-gate wiring."""
+"""CI validator inventory: discover validator modules and required-gate wiring.
+
+Scope, since issue #761 stage 2: `tests/test_*.py` pytest modules and
+`tools/check_rust_*.py` frozen-Python/Rust parity harnesses (the family
+`docs/DESIGN-ci-validator-inventory.md`'s "Scope boundaries" originally
+reserved as out of scope for slice 1).
+
+Guarantee boundary, load-bearing for why `--exempt path:reason` is an
+acceptable way to satisfy this check: this tool establishes only that a
+validator module's tier and reason were *recorded*, not that the recorded
+reason is *correct*. Passing `--exempt tools/check_rust_x.py:some-reason`
+once is the entire cost of satisfying `generate`'s guard, and that is
+intentional -- the property this check protects is "no validator module can
+accumulate silently, unclassified" (issue #761's own root problem: 17
+`tools/check_rust_*.py` harnesses existed with nobody having recorded why).
+Whether a recorded reason accurately describes the module -- the F1-F7
+precondition analysis, native-owner cross-referencing, and retirement
+readiness -- is `docs/RUST-PORTING.md`'s job, a human-maintained document
+this tool does not read and cannot verify.
+
+Wiring-detection scope, deliberate, shared by PYTEST_PATH and
+RUST_HARNESS_PATH alike: both regexes match a path preceded by whitespace,
+a quote, or `=`, including inside a `#` comment -- a commented-out mention
+is treated the same as a real invocation, and this was already true for
+`tests/test_*.py` before this file existed (verified: unchanged by this
+extension, not introduced by it). Neither regex has an
+`IMPORT_PATH`-style companion for a `from tools.check_rust_x import` form,
+because no `REQUIRED_GATE_ENTRYPOINTS` file currently wires a
+`tools/check_rust_*.py` harness that way (`tools/check-merge-readiness.sh`'s
+own inline `from tests.test_x import` pattern, which `IMPORT_PATH` exists
+to catch, has no `tools/check_rust_*.py` analogue today); add one only if
+and when such a wiring pattern is actually introduced, not speculatively.
+"""
 
 from __future__ import annotations
 
@@ -27,20 +59,34 @@ PYTEST_PATH = re.compile(
 IMPORT_PATH = re.compile(
     r"from\s+tests\.(test_[A-Za-z0-9_]+)\s+import"
 )
+RUST_HARNESS_PATH = re.compile(
+    r"(?:^|[\s\"'=])(tools/check_rust_[A-Za-z0-9_]+\.py)"
+)
 
 EXEMPT_REASONS = frozenset(
     {
         "frozen-python-compatibility",
         "hook-local",
+        # issue #761 stage 2: tools/check_rust_*.py-specific reasons. Each
+        # names a distinct cause a harness is unwired, matching #761's own
+        # classification table -- collapsing them into
+        # frozen-python-compatibility would lose that distinction (a
+        # `manual-developer-run` harness like `surface_parity` does not even
+        # import the frozen Python package; `parked-pending-unrelated-work`
+        # and `pending-native-migration` are blocked on work with no relation
+        # to Python compatibility at all).
+        "manual-developer-run",
+        "parked-pending-unrelated-work",
+        "pending-native-migration",
     }
 )
 
 HOOK_LOCAL_TESTS = frozenset({"tests/test_hook_enforcement.py"})
 
 
-def git_tracked_test_modules(root: Path) -> list[str]:
+def _git_tracked_py_modules(root: Path, scope_dir: str, name_prefix: str) -> list[str]:
     result = subprocess.run(
-        ["git", "ls-files", "-z", "--", "tests"],
+        ["git", "ls-files", "-z", "--", scope_dir],
         cwd=root,
         check=False,
         capture_output=True,
@@ -53,9 +99,21 @@ def git_tracked_test_modules(root: Path) -> list[str]:
     paths = [
         name
         for name in result.stdout.decode("utf-8").split("\0")
-        if name.startswith("tests/test_") and name.endswith(".py")
+        if name.startswith(name_prefix) and name.endswith(".py")
     ]
     return sorted(paths)
+
+
+def git_tracked_test_modules(root: Path) -> list[str]:
+    return _git_tracked_py_modules(root, "tests", "tests/test_")
+
+
+def git_tracked_rust_harness_modules(root: Path) -> list[str]:
+    return _git_tracked_py_modules(root, "tools", "tools/check_rust_")
+
+
+def git_tracked_validator_modules(root: Path) -> list[str]:
+    return sorted(git_tracked_test_modules(root) + git_tracked_rust_harness_modules(root))
 
 
 def read_entrypoint_text(root: Path, entrypoint: str) -> str:
@@ -63,7 +121,7 @@ def read_entrypoint_text(root: Path, entrypoint: str) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def wired_test_modules(root: Path) -> dict[str, list[str]]:
+def wired_validator_modules(root: Path) -> dict[str, list[str]]:
     wiring: dict[str, set[str]] = {}
     for entrypoint in REQUIRED_GATE_ENTRYPOINTS:
         text = read_entrypoint_text(root, entrypoint)
@@ -72,6 +130,8 @@ def wired_test_modules(root: Path) -> dict[str, list[str]]:
         for match in IMPORT_PATH.finditer(text):
             path = f"tests/{match.group(1)}.py"
             wiring.setdefault(path, set()).add(entrypoint)
+        for match in RUST_HARNESS_PATH.finditer(text):
+            wiring.setdefault(match.group(1), set()).add(entrypoint)
     return {
         path: sorted(entrypoints)
         for path, entrypoints in sorted(wiring.items())
@@ -88,6 +148,21 @@ def inventory_index(inventory: dict[str, Any]) -> dict[str, dict[str, Any]]:
 
 
 def default_exempt_reason(path: str) -> str:
+    # A deliberately conservative fallback. Reached via --bootstrap for a
+    # genuinely new path with no prior recorded reason and no explicit
+    # --exempt override; also reached, pre-existing and unrelated to issue
+    # #761's extension, via an ordinary (non-bootstrap) generate for a path
+    # whose wiring/prior tier falls through build_entry()'s more specific
+    # branches -- for example a previously `required` module that is no
+    # longer wired anywhere (confirmed directly: inventory_document(...,
+    # bootstrap=False) with such a prior still reaches this function). It
+    # does not attempt to distinguish manual-developer-run,
+    # parked-pending-unrelated-work, or pending-native-migration from
+    # frozen-python-compatibility for a tools/check_rust_*.py path: getting
+    # that distinction right needs the classification behind issue #761's
+    # table, which a caller is expected to supply via explicit --exempt
+    # pairs (see docs/DESIGN-ci-validator-inventory.md) rather than rely on
+    # this guess.
     if path in HOOK_LOCAL_TESTS:
         return "hook-local"
     return "frozen-python-compatibility"
@@ -244,14 +319,22 @@ def inventory_findings(
     return findings
 
 
+def _is_validator_path(path: str) -> bool:
+    if path.startswith("tests/test_") and path.endswith(".py"):
+        return True
+    return path.startswith("tools/check_rust_") and path.endswith(".py")
+
+
 def parse_exempt_pairs(pairs: list[str]) -> dict[str, str]:
     parsed: dict[str, str] = {}
     for pair in pairs:
         if ":" not in pair:
             raise ValueError(f"--exempt expects path:reason, got {pair!r}")
         path, reason = pair.split(":", 1)
-        if not path.startswith("tests/test_") or not path.endswith(".py"):
-            raise ValueError(f"--exempt path must be tests/test_*.py, got {path!r}")
+        if not _is_validator_path(path):
+            raise ValueError(
+                f"--exempt path must be tests/test_*.py or tools/check_rust_*.py, got {path!r}"
+            )
         parsed[path] = reason
     return parsed
 
@@ -418,15 +501,148 @@ def selftest(root: Path) -> int:
         print("selftest: FAIL: wired new validator must become required", file=sys.stderr)
         ok = False
 
+    # issue #761 stage 2: the same accepting/rejecting shape, for
+    # tools/check_rust_*.py instead of tests/test_*.py -- the failure/success
+    # side is calibrated on the identical execution path (inventory_findings
+    # / inventory_document), not a separate code path that could silently
+    # diverge from the tests/ behavior above.
+    rust_inventory = {
+        "schema_version": SCHEMA_VERSION,
+        "required_gate_entrypoints": list(REQUIRED_GATE_ENTRYPOINTS),
+        "validators": [
+            {
+                "path": "tools/check_rust_required.py",
+                "tier": "required",
+                "entrypoints": ["tools/check-merge-readiness.sh"],
+            },
+            {
+                "path": "tools/check_rust_exempt.py",
+                "tier": "exempt",
+                "exempt_reason": "manual-developer-run",
+            },
+        ],
+    }
+    run_case(
+        "complete inventory (rust harness)",
+        discovered=["tools/check_rust_required.py", "tools/check_rust_exempt.py"],
+        wiring={
+            "tools/check_rust_required.py": ["tools/check-merge-readiness.sh"],
+        },
+        inventory=rust_inventory,
+        expected_fragments=[],
+        should_pass=True,
+    )
+    run_case(
+        "untracked rust harness",
+        discovered=[
+            "tools/check_rust_required.py",
+            "tools/check_rust_exempt.py",
+            "tools/check_rust_new.py",
+        ],
+        wiring={
+            "tools/check_rust_required.py": ["tools/check-merge-readiness.sh"],
+        },
+        inventory=rust_inventory,
+        expected_fragments=["untracked validator module"],
+        should_pass=False,
+    )
+    run_case(
+        "exempt rust harness with unknown reason",
+        discovered=["tools/check_rust_required.py", "tools/check_rust_exempt.py"],
+        wiring={
+            "tools/check_rust_required.py": ["tools/check-merge-readiness.sh"],
+        },
+        inventory={
+            "schema_version": SCHEMA_VERSION,
+            "required_gate_entrypoints": list(REQUIRED_GATE_ENTRYPOINTS),
+            "validators": [
+                rust_inventory["validators"][0],
+                {
+                    "path": "tools/check_rust_exempt.py",
+                    "tier": "exempt",
+                    "exempt_reason": "not-a-declared-reason",
+                },
+            ],
+        },
+        expected_fragments=["unknown exempt_reason"],
+        should_pass=False,
+    )
+
+    try:
+        inventory_document(
+            fixture_root,
+            discovered=[
+                "tools/check_rust_required.py",
+                "tools/check_rust_exempt.py",
+                "tools/check_rust_new.py",
+            ],
+            wiring={
+                "tools/check_rust_required.py": ["tools/check-merge-readiness.sh"],
+            },
+            prior=inventory_index(rust_inventory),
+            bootstrap=False,
+        )
+        print(
+            "selftest: FAIL: generate must reject new unwired rust harnesses without classification",
+            file=sys.stderr,
+        )
+        ok = False
+    except RuntimeError as error:
+        if "new validator module(s) require explicit classification" not in str(error):
+            print(f"selftest: FAIL: unexpected generate error (rust harness): {error}", file=sys.stderr)
+            ok = False
+
+    generated_exempt = inventory_document(
+        fixture_root,
+        discovered=[
+            "tools/check_rust_required.py",
+            "tools/check_rust_exempt.py",
+            "tools/check_rust_new.py",
+        ],
+        wiring={
+            "tools/check_rust_required.py": ["tools/check-merge-readiness.sh"],
+        },
+        prior=inventory_index(rust_inventory),
+        new_exempt={"tools/check_rust_new.py": "pending-native-migration"},
+        bootstrap=False,
+    )
+    generated_exempt_index = inventory_index(generated_exempt)
+    new_entry = generated_exempt_index["tools/check_rust_new.py"]
+    if new_entry["tier"] != "exempt" or new_entry["exempt_reason"] != "pending-native-migration":
+        print(
+            f"selftest: FAIL: --exempt classification did not stick for a rust harness: {new_entry!r}",
+            file=sys.stderr,
+        )
+        ok = False
+
+    generated_rust = inventory_document(
+        fixture_root,
+        discovered=[
+            "tools/check_rust_required.py",
+            "tools/check_rust_exempt.py",
+            "tools/check_rust_new.py",
+        ],
+        wiring={
+            "tools/check_rust_required.py": ["tools/check-merge-readiness.sh"],
+            "tools/check_rust_new.py": ["tools/check-merge-readiness.sh"],
+        },
+        prior=inventory_index(rust_inventory),
+        bootstrap=False,
+    )
+    generated_rust_index = inventory_index(generated_rust)
+    if generated_rust_index["tools/check_rust_new.py"]["tier"] != "required":
+        print("selftest: FAIL: wired new rust harness must become required", file=sys.stderr)
+        ok = False
+
     if ok:
-        print("selftest: PASS: inventory_accepting=1 inventory_rejecting=5")
+        print("selftest: PASS: inventory_accepting=2 inventory_rejecting=7")
         return 0
     return 1
 
 
 def check(root: Path) -> int:
-    discovered = git_tracked_test_modules(root)
-    wiring = wired_test_modules(root)
+    discovered = git_tracked_validator_modules(root)
+    wiring = wired_validator_modules(root)
     inventory = load_inventory(root)
     findings = inventory_findings(
         root,
@@ -452,8 +668,8 @@ def generate(
     bootstrap: bool,
     exempt_pairs: list[str],
 ) -> int:
-    discovered = git_tracked_test_modules(root)
-    wiring = wired_test_modules(root)
+    discovered = git_tracked_validator_modules(root)
+    wiring = wired_validator_modules(root)
     prior = None
     inventory_path = root / INVENTORY_PATH
     if inventory_path.is_file():

--- a/tools/check_rust_corpus_cli_parity.py
+++ b/tools/check_rust_corpus_cli_parity.py
@@ -3,9 +3,15 @@
 
 """Compare stable Python/Rust CLI verdicts across the complete FSL corpus.
 
-Deletion deferred (F1): no native corpus control binds every
-``verify`` envelope result class to its process exit. Deletion requires that
-native control plus a rejecting mutation.
+Deletion deferred (docs/RUST-PORTING.md F1). ``rust/fslc/tests/
+corpus_check_sweep.rs``'s ``verify_result_and_exit_status_never_contradict``
+now binds every corpus ``verify`` result class to its process exit, with
+rejecting mutations calibrated in ``fault_operators/{unknown-result-to-
+success,failure-verdict-exits-zero}.patch``; #900 recorded this row as only
+partially closed, and this script did not track the residual scope down
+before this comment was last touched. Confirm that scope before retiring
+this script -- do not treat the native test landing as sufficient on its
+own.
 """
 from __future__ import annotations
 

--- a/tools/check_rust_dialect_parity.py
+++ b/tools/check_rust_dialect_parity.py
@@ -3,9 +3,12 @@
 
 """Compare native and Python business/requirements/governance envelopes.
 
-Deletion deferred (F2): dialect dispatch is covered, but there is no focused
-native induction output contract for all three paths. Deletion requires those
-native induction cases.
+Deletion deferred (docs/RUST-PORTING.md F2). ``rust/fslc/tests/
+dialect_induction_contract.rs``'s
+``business_requirements_and_governance_pin_native_induction_contracts`` (#900)
+now owns focused native induction output contracts for the business,
+requirements, and governance paths -- retiring this script is a separate
+follow-up decision, not made by that test landing alone.
 """
 from __future__ import annotations
 

--- a/tools/check_rust_full_envelope.py
+++ b/tools/check_rust_full_envelope.py
@@ -3,9 +3,18 @@
 
 """Compare Python and Rust CLI envelopes with a narrow reviewed allowlist.
 
-Disposition: calibrated native/Worker parity owns this
-detector, so deletion is permitted once its shared ``_diff``/``_normalize``
-helpers move without breaking the retained dialect/induction/Phase-2 tools.
+Disposition (docs/RUST-PORTING.md F8): deletion deferred. This is the only
+harness that compares the frozen Python envelope against the native one for
+the *full* ``check``/``verify`` envelope (``leadsto_parity`` and
+``dialect_parity`` separately do the same kind of comparison, narrowed to
+their own dialect/case sets). ``rust/fsl-wasm/test-browser.mjs``'s
+native/Worker parity compares native against WASM and does not observe the
+frozen Python side, so it does not own this detector and is not a substitute
+for it. The shared ``_diff``/
+``_normalize`` helpers moving to ``rust_parity_util.py`` (#913) removed the
+only reason this script's *deletion* was ever blocked on another consumer,
+but that does not make retiring the comparison edge itself safe -- that is a
+separate compatibility decision, tracked in #988.
 """
 from __future__ import annotations
 

--- a/tools/check_rust_leadsto_parity.py
+++ b/tools/check_rust_leadsto_parity.py
@@ -3,10 +3,16 @@
 
 """Compare bounded leadsTo decisions and cross-replay liveness witnesses.
 
-Deletion remains deferred (F4). Candidate native owner
-``rust/fslc/tests/liveness_witness_replay.rs`` covers the three legacy cases
-with an exact 3x3 state/action/loop corruption matrix; harness retirement still
-requires review of that evidence.
+Deletion remains deferred (docs/RUST-PORTING.md F4). ``rust/fslc/tests/
+liveness_witness_replay.rs`` (#903) owns a native-only 3x3 state/action/loop
+corruption matrix -- a Monitor-generated trace, corrupted, rejected by the
+native Monitor's own replay path; it also separately checks BMC's safety/
+leadsTo verdicts, but does not cross-replay a BMC witness through Monitor.
+This script does two more things neither of those cover: it diffs the frozen
+Python `verify` envelope against the native one for the same three cases,
+and cross-replays witnesses in both directions (Rust BMC -> Python Monitor
+and Python BMC -> Rust Monitor). Landing the native corruption matrix alone
+does not retire this script.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Problem

Issue #761: all 17 `tools/check_rust_*.py` harnesses are wired into no CI runner, and five
dedicated binaries exist only for them.

## What this PR does

Classified all 17 harnesses (checkpointed with the fsl lead before any code change) and extended
the existing CI validator inventory (issue #962's mechanism) to require a recorded classification
for every one of them, closing the gap that let 17 unclassified scripts accumulate in the first
place. **None of the 17 are retired by this PR.**

An earlier version of this PR also retired `tools/check_rust_full_envelope.py`. Independent review
found that decision unsound (see "Reverted" below); it is now restored and classified `exempt`
instead.

### Commit 1 (`931af8be`) — Extended the CI validator inventory to `tools/check_rust_*.py`

`tools/check_ci_validator_inventory.py` (issue #962's fail-closed mechanism for `tests/test_*.py`)
now also discovers and requires classification for `tools/check_rust_*.py`. A new, unclassified
harness now fails `check` closed with `untracked validator module`, exactly like an unclassified
`tests/test_*.py` module — preventing the shape #761 itself demonstrated.

**Guarantee boundary** (stated in the tool's docstring, `docs/DESIGN-ci-validator-inventory.md`,
and the commit message): this tool establishes that a classification was *recorded*, not that it
is *correct*. Whether a reason accurately describes a harness remains `docs/RUST-PORTING.md`'s job.

Four `exempt_reason` values distinguish the real reasons in #761's classification table instead of
collapsing them into one: `manual-developer-run` (5), `frozen-python-compatibility` (8, including
`full_envelope` — see below), `parked-pending-unrelated-work` (1, `phase3_commands`), and
`pending-native-migration` (3, `bfs_parity`/`bmc_parity`/`scenarios_parity`). 107 tests + 17 Rust
harnesses = 124 total validator modules (9 required, 115 exempt).

### Commit 2 (`e025788a`) — Reverted the `full_envelope` retirement and corrected its own stale rows

**What was wrong.** This PR originally deleted `tools/check_rust_full_envelope.py` as
"deletion-ready," reasoning that its `_diff`/`_normalize` helpers had no other consumers after
#913. Independent review found the deletion's justification compared the wrong edge:
`check_rust_full_envelope.py` diffs the frozen Python `check`/`verify` envelope against the native
one (`python_check` vs. `rust_check`) — the only harness that does so for the *full* envelope. The
claimed replacement, `rust/fsl-wasm/test-browser.mjs`, diffs `nativeEnvelope` against
`wasmEnvelope` — both native/WASM builds of the same Rust code, never touching the frozen Python
side. If the shared Rust emitter ever drifted from frozen Python, native and Worker would still
agree with each other and stay green; only the deleted harness could have caught it. Only the
harness's *helper* had no other consumers — a different question than whether the comparison edge
itself was still needed.

**Fix.** Dropped the retirement commit from this branch (restoring `check_rust_full_envelope.py`
unchanged) and reclassified it in `docs/RUST-PORTING.md`'s disposition table as F8, grouped with
the F1-F7 deletion-deferred frozen-Python parity harnesses, with the comparison-edge evidence
recorded in the row. Retiring the comparison edge is now a separate, explicit compatibility
decision, filed as #988 (issue only, not implemented here) — `AGENTS.md` designates `src/fslc/` a
frozen compatibility reference, so retiring a comparison edge against it needs an explicit
accept/reject, not bundled cleanup.

**Same defect class, found twice more in the same review.** F1 and F2's table rows were stale
(native ownership already landed in #900, but the rows still read as open asks); F4's row asked to
"add a native liveness-lasso replay matrix" that had already landed in #903 — but that native
matrix only covers Monitor-self-consistency, not the frozen-Python-vs-native envelope comparison
and bidirectional witness cross-replay `check_rust_leadsto_parity.py` also performs, so an earlier
fix draft's claim that the shared `fsl-replay-actions` binary was F4's *only* remaining blocker
repeated the exact same mistake as `full_envelope`, one level up. All three rows (F1, F2, F4) were
corrected with direct citations; **none of the three scripts are retired here** — landed native
coverage and "ready to retire" are different judgments, and this PR does not make the second one
for any harness beyond restoring `full_envelope`'s prior status.

## Not done here, deliberately

None of the 17 harnesses are retired by this PR. F1/F2/F5 still lack matching native coverage for
part of what they check; F3/F4/F7/F8 have landed native coverage for part of what they check but
retain a frozen-Python comparison edge (F4, F8) or unclosed residual scope (F1, per #900) that
native landing alone does not resolve; F6 has a matching native owner and was explicitly retained.
Full table and reasoning posted to #761; F8's retirement decision is #988.

## Test evidence

- `python3 tools/check_ci_validator_inventory.py selftest` → PASS (inventory_accepting=2
  inventory_rejecting=7).
- `python3 tools/check_ci_validator_inventory.py check` → PASS, 124 validator modules (107 + 17).
- `python3 -m pytest tests/test_ci_validator_inventory.py -v` → 7 passed.
- `python3 tools/check-design-citation-headings.py check` → 75 citations, 0 findings.
- `python3 tools/check_spdx_headers.py changed` → PASS.
- No `cargo` command was run anywhere in this task.

Independent review (Sol, `cursor-agent gpt-5.6-sol-medium --mode ask`):
- Commit 1: 6 viewpoints, 6 rounds to zero findings (see commit 1's message for the full history).
- Commit 2: 5 rounds to zero findings. R1: 1 blocker (restored `full_envelope.py`'s own docstring
  still asserted the disproven premise) / 1 major (F4's first draft repeated the `full_envelope`
  mistake) / 1 minor (a stale F1-F7 mention). R2: 1 blocker (this PR's own new "the only harness"
  language was itself an unscoped overclaim) / 2 major (the native matrix was mischaracterized as
  "BMC vs. Monitor"; F1/F2's own script docstrings still carried the pre-#900 premise) / 1 minor
  (citation ranges). R3-R4: citation drift caught after each docstring edit shifted line numbers
  (own file, then a third file's matching citation). R5: zero findings.

Refs #896, #900, #903, #906, #907, #913, #962, #988. Closes part of #761 (harnesses remain
classified but none retired; the inventory mechanism now prevents any *future* unclassified
harness from recurring silently — see the issue comment for the full disposition and two corrected
facts about the issue's own body: `fsl-bfs` has an independent production consumer, and a sixth
binary `fsl-parse-surface` exists beyond the five originally named).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
