### PR TITLE
docs(assurance): align the classifier contract with what it accepts (#990)

### DIFF
--- a/changelog.d/990-assurance-classifier-doc-parity.documented.md
+++ b/changelog.d/990-assurance-classifier-doc-parity.documented.md
@@ -1,0 +1,4 @@
+Documented (#990): align `docs/DESIGN-assurance-classes.md` classifier rules
+with the keys and values `assurance.py` / `ledger.rs` actually accept; record
+that FSL core classifies external evidence for display only and does not verify
+it (confirmation rules remain issue #994).

--- a/docs/DESIGN-assurance-classes.md
+++ b/docs/DESIGN-assurance-classes.md
@@ -32,7 +32,8 @@ gate failure that produced **no interval** (`dataset_invalid`,
 `evaluator_untrusted`, `insufficient_samples`, `slice_missing`, `inconclusive`)
 is `not_run` — there is no bound to point at — while
 `statistically_unsupported` (interval computed, threshold missed) stays
-`statistical` with a failing verdict.
+`statistical` with a failing verdict. The classifier matches the status token
+itself; it does not inspect whether an interval was produced.
 
 ## Classification table (what each class does / does not guarantee)
 
@@ -51,24 +52,38 @@ re-derive classes locally.
 
 - `classify_result(result: dict) -> str` — one command's result dict (envelope
   or bare) to a token. Ordered rules, first match wins:
-  1. formal evidence present (`completeness` / `kernel.completeness` /
-     `formal_result` in kernel vocabulary): `"unbounded"` or `proved` →
-     `proved`; `"bounded"` or `verified/violated/reachable_failed/unknown_cti`
-     → `bounded`.
+  1. formal completeness (`completeness` or nested `kernel.completeness`):
+     `"unbounded"` → `proved`; `"bounded"` → `bounded`. Keys such as
+     `formal_result` and the top-level `result` token are **not** read for
+     this step — e.g. `{"result":"proved",...}` without `completeness` does
+     not upgrade assurance class.
   2. observation markers (`guarantee_kind:"runtime_observed"`,
-     `evidence.kind` in `runtime_replay`/`runtime_telemetry`, or result in
-     `conformant`/`nonconformant`/`replay_*`/`observed_*`/
+     `evidence.kind` in `runtime_replay`/`runtime_telemetry`, or `result` in
+     `conformant`/`nonconformant`/`replay_conformant`/`replay_nonconformant`/
+     `observed_conformant`/`observed_mismatch`/`observed_supported`/
      `conformance_checked`/`evidence_supported`/`evidence_failed`) →
      `replay-observed`.
-  3. statistical markers (schema `fsl-ai-statistical-result.v0` /
-     `fsl-ai-migration-result.v0` with status
-     `statistically_supported|statistically_unsupported`) → `statistical`;
-     gate statuses (see above) → `not_run`.
+  3. statistical: `status` (when absent, fall back to `result`) in
+     `statistically_supported`/`statistically_unsupported` → `statistical`;
+     `dataset_invalid`/`evaluator_untrusted`/`insufficient_samples`/
+     `slice_missing`/`inconclusive` → `not_run`. Schema names such as
+     `fsl-ai-statistical-result.v0` are not consulted.
   4. else → `not_run`.
-- `classify_source(result: dict) -> dict` —
-  `{"assurance", "verdict": "pass"|"fail"|"none", "under_assumptions": bool,
-  "label", "detail"}`; `under_assumptions` is true for dialect wrappers
-  (`verified_under_assumptions`).
+- `classify_source` — **not** in `src/fslc/assurance.py` (none of its seven
+  `def`s map a result dict to a pass/fail verdict). Issue #508's verdict
+  mapping lives in the native ledger as `evidence_verdict`
+  (`rust/fsl-tools/src/ledger.rs`), which returns `Option<bool>`:
+  `Some(true)` / `Some(false)` on rule 2's same 10 `result` tokens —
+  `Some(true)`: `conformant`/`replay_conformant`/`observed_conformant`/
+  `conformance_checked`/`observed_supported`/`evidence_supported`;
+  `Some(false)`: `nonconformant`/`replay_nonconformant`/`observed_mismatch`/
+  `evidence_failed` — or from `status` `statistically_supported` /
+  `statistically_unsupported`;
+  `None` when the envelope carries no verdict (gate failures like
+  `dataset_invalid`, structural output like `compared`). It does **not**
+  return a dict. Class (method strength) and verdict (outcome) remain
+  orthogonal — a failing source must never change the assurance label, only
+  add a finding.
 - `classify_element(group, name, verification) -> str` — per spec element.
   Under BMC everything is `bounded`. Under `result:"proved"`: `invariants`,
   `transitions` → `proved`; a `leadstos` entry → `proved` iff
@@ -76,11 +91,41 @@ re-derive classes locally.
   else `bounded`; `reachables` and action coverage → `bounded` (base BMC only —
   `prove()` already notes this). `result:"error"` without `completeness` →
   `not_run`.
-- `strongest(classes) -> str`, `ASSURANCE_ORDER`, `assurance_label(token, *,
-  depth=None, confidence=None, steps=None, under_assumptions=False) -> str`.
-- `requirement_assurance(registry, verification, replay_result=None,
-  evidence_results=()) -> dict` — `{req_id: {"assurance", "sources": [...],
-  "under_assumptions"}}`.
+- `strongest(classes) -> str`, `weakest(classes) -> str`, `ASSURANCE_ORDER`,
+  `assurance_label(token, *, depth=None, confidence=None,
+  under_assumptions=False) -> str`, `confidence_of(result) -> float | None`.
+- `requirement_assurance(registry, verification, evidence_results=()) -> dict`
+  — `{req_id: {"assurance", "sources": [...], "under_assumptions"}}`.
+
+### External evidence — classification without verification (issue #990)
+
+The shared classifier is a **display mapper**: it reads fields already present
+in a JSON dict and renders assurance labels. It is **not** a trust boundary
+for external evidence files.
+
+The loader rejects unreadable paths, non-UTF-8 bytes, invalid JSON, and
+non-object envelopes — and performs no schema, version, or producer checks
+beyond that.
+
+- **Completeness-only upgrade.** `completeness` / `kernel.completeness` alone
+  can classify as `proved` or `bounded` (e.g.
+  `{"completeness":"unbounded",...}` without a matching `result` token). The
+  loader and classifier do not confirm that the value came from a completed
+  verification run.
+- **No binding.** Classification does not tie evidence to producer identity,
+  target spec digest/revision, or proof artifacts. The same `fslc ledger`
+  `--approval` path does compare versioned approval record spec/rendering
+  digests; external evidence has no equivalent.
+- **Confirmation is out of band.** Responsibility for confirming that external
+  evidence is authentic and applicable rests with a **versioned public
+  Adapter** (rules under design in issue #994, go/no-go pending). FSL core —
+  evidence loading and this classifier — does not perform that confirmation.
+- **Caller bears trust.** Treating ledger/html assurance labels as audit
+  conclusions requires upstream trust decisions; the labels alone assert no
+  integrity or applicability guarantee.
+
+This section records that FSL core does not verify external evidence and does
+not adopt a future trust model or Adapter contract (issue #994).
 
 ### Producer → class map (the acceptance-criteria table)
 

--- a/docs/DESIGN-assurance-classes.md
+++ b/docs/DESIGN-assurance-classes.md
@@ -69,8 +69,8 @@ re-derive classes locally.
      `slice_missing`/`inconclusive` → `not_run`. Schema names such as
      `fsl-ai-statistical-result.v0` are not consulted.
   4. else → `not_run`.
-- `classify_source` — **not** in `src/fslc/assurance.py` (none of its seven
-  `def`s map a result dict to a pass/fail verdict). Issue #508's verdict
+- `classify_source` — **not** in `src/fslc/assurance.py` (none of its `def`s
+  map a result dict to a pass/fail verdict). Issue #508's verdict
   mapping lives in the native ledger as `evidence_verdict`
   (`rust/fsl-tools/src/ledger.rs`), which returns `Option<bool>`:
   `Some(true)` / `Some(false)` on rule 2's same 10 `result` tokens —
@@ -103,19 +103,20 @@ The shared classifier is a **display mapper**: it reads fields already present
 in a JSON dict and renders assurance labels. It is **not** a trust boundary
 for external evidence files.
 
-The loader rejects unreadable paths, non-UTF-8 bytes, invalid JSON, and
-non-object envelopes — and performs no schema, version, or producer checks
-beyond that.
+Both evidence-loading paths — `fslc ledger`'s inline read and the one
+`fslc document` uses — reject unreadable paths, non-UTF-8 bytes, invalid
+JSON, and non-object envelopes, and neither applies a schema, version, or
+producer check beyond that.
 
 - **Completeness-only upgrade.** `completeness` / `kernel.completeness` alone
   can classify as `proved` or `bounded` (e.g.
   `{"completeness":"unbounded",...}` without a matching `result` token). The
   loader and classifier do not confirm that the value came from a completed
   verification run.
-- **No binding.** Classification does not tie evidence to producer identity,
-  target spec digest/revision, or proof artifacts. The same `fslc ledger`
-  `--approval` path does compare versioned approval record spec/rendering
-  digests; external evidence has no equivalent.
+- **No binding.** Classification of external evidence does not tie it to
+  producer identity, target spec digest/revision, or proof artifacts. The same
+  `fslc ledger` `--approval` path does compare versioned approval record
+  spec/rendering digests; external evidence has no equivalent.
 - **Confirmation is out of band.** Responsibility for confirming that external
   evidence is authentic and applicable rests with a **versioned public
   Adapter** (rules under design in issue #994, go/no-go pending). FSL core —


### PR DESCRIPTION
## 問題

`docs/DESIGN-assurance-classes.md` は、assurance 分類器が受理する key と値を、初版
（`07a4e3b43af37b221f5ed09a19826ead720b8591`、2026-07-10）から誤って記述していました。

- `formal_result` と `result` の kernel vocabulary を formal evidence の入力として挙げていますが、
  Rust (`rust/fsl-tools/src/ledger.rs` の `assurance_token`) も凍結 Python (`src/fslc/assurance.py` の
  `classify_result`) も読んでいません
- `replay_*` / `observed_*` というワイルドカード表記が、実装が実際に照合する有限のトークン集合より
  広い集合を示唆していました
- statistical の規則に schema 名 (`fsl-ai-statistical-result.v0` 等) の一致を課していますが、実装は
  `status`（欠落時は `result`）の値だけを見ます
- `classify_source` という関数を記述していますが、`src/fslc/assurance.py` に存在しません
- `assurance_label` の `steps=` と `requirement_assurance` の `replay_result=` は実装のシグネチャに
  ありません。逆に実装にある `weakest` / `confidence_of` が関数一覧にありませんでした

これは互換破壊ではなく、**初版からの文書・実装差**です（issue #990 の履歴節に実測があります）。

## 契約変更

issue #990 の受理済み裁定に従い、**分類器の実装は変更せず、文書を実装へ揃えました。** 外部証跡が
真正かつ適用可能であることの確認責任は版付き公開 Adapter に置かれ、その規則は #994 で設計中
（go/no-go 判断前）です。

あわせて、**現行挙動を「意図した信頼境界」として説明しない**節を追加しました。

- `completeness` / `kernel.completeness` 単独で `proved` / `bounded` に達する
- producer identity・対象 spec の digest/revision・証明 artifact との binding が無い
- 確認は帯域外（版付き公開 Adapter、規則は #994 で設計中）
- 呼び出し側が信頼を負う
- loader は unreadable / non-UTF-8 / invalid JSON / non-object を拒否し、それを超える schema・version・
  producer 検査はしない
- **同じ `fslc ledger` の `--approval` 経路は versioned approval record の spec/rendering digest を
  照合するのに、external evidence には相当物が無い**

この節は将来の trust model や Adapter 契約を採択していません（末尾に明記）。`result` token だけでは
形式保証へ昇格しない現行判断も維持しています。

## テスト証拠

| コマンド | exit | 所要 | この変更に触ったか |
|---|---|---|---|
| `BASE_SHA=<base> HEAD_SHA=0f2955d4 tools/aggregate_changelog.sh check-pr` | 0 | 81.1s | **触った**（CI の `merge-readiness.yml` が回す形） |
| `tools/aggregate_changelog.sh check` | 0 | 15.2s | **触った**（本 PR の fragment を検査） |
| `tools/check-design-citation-headings.py check` | 0 | 1.2s | **触った**（citations=78, findings=0） |
| `tools/check-design-citation-headings.py selftest` | 0 | 0.1s | rejecting controls の校正 |
| `pytest tests/test_site_reference_snapshot.py` | 0 | 6.1s | **触っていない** — この gate の入力は `docs/LANGUAGE.md` / `docs/LANGUAGE.ja.md` / 凍結 `cli.py` で、DESIGN 文書は入力ではない。生成ページを壊していないことの確認 |
| `tools/aggregate_changelog.sh selftest` | 0 | 39.4s | **触っていない** — tmp fixture で controls の動作を検査するだけで、実 fragment を読まない |

**校正（無故障と故障を同じ実行経路で両方測定）**

- `aggregate_changelog.sh check`: 無故障 → exit=0。fragment を未宣言 category の `.fix.md` に rename →
  **exit=1**、`changelog-fragment-name-invalid: 990-assurance-classifier-doc-parity.fix.md` と当該
  fragment を名指し。revert 後は内容が byte 一致
- 修正前の再現: issue #990 の3コマンドを worktree の binary（`fslc 4.4.1`、base commit）で実行し、
  **issue 本文の実測表と produced が完全一致**（`{"result":"proved"}` と
  `{"formal_result":"proved"}` は `not_run`、`{"completeness":"unbounded"}` は `proved(induction)`）

**commit ごとの目的と検証**

| commit | 目的 | 検証 |
|---|---|---|
| `0f2955d4` | 分類器の受理規則と API 記述を実装へ揃え、外部証跡の信頼境界を実態として記録 | 上表のゲート全件 exit=0、`check` は故障注入で校正済み |

## 検証されていない項目（gate が無いことを明示します）

**「文書が列挙する受理集合 == 実装が受理する集合」を判定する決定論的検査はありません。この項目は
検証されていません。**

新設を検討し、4条件のうち**条件4（その検査を通す最短の書き方が、要求を満たす書き方と一致する）が
書けない**ため入れませんでした。実装側の集合を機械抽出するには Rust の `match` arm をパターンで抜くか
（実装の書き方が変わるだけで壊れる false failure）、文書側に機械可読マーカーを要求することになり
（マーカーを整えることが通すための最短経路になる）、実装に受理集合を出力させる経路の追加は
「コード挙動を変えない」という本 issue の範囲に反します。条件1〜3（要求に紐づく／baseline 文書で
落ちる／既存検査と重複しない）は書けますが、1つでも書けなければ入れない規則に従いました。

したがって、**文書が将来また実装とずれることを検出する仕組みは入っていません。**

散文の意味・語調・読みやすさにも gate はありません。「検証済み」ではありません。

## レビュー

- Sol (`gpt-5.6-sol-medium`) による6観点レビューを**3巡、残存指摘ゼロまで**反復
  （1巡目 major 2 / 2巡目 major 1 / 3巡目 0）
- 系列独立レビュー（Claude）: 事実主張14件を実装と全数照合し**食い違い0件**で PASS

**PASS の境界**: このレビューは文書と実装の一致を照合したものです。文書が**将来**実装とずれない
ことは保証していません（それを判定する検査は上記の理由で入れていません）。散文の意味・語調も
保証範囲外です。

## 残スコープ（この PR では直していません）

実装を全数列挙する過程で見つかった2件を、範囲外として切り出しました。

- **https://github.com/ymm-oss/fsl/issues/995** — Rust `formal_assurance` が `result:"error"` を
  `completeness` より先に評価するため、本文書と凍結 Python から乖離します。**差の向きは Rust 側が
  保守的**（実在する保証を過小報告）で false green ではなく、現時点の公開 CLI 経路からは到達できない
  ことも実測済みです
- **https://github.com/ymm-oss/fsl/issues/996** — 本文書が権威ある Rust ではなく凍結 Python を
  記述対象にしている構造。#995 が初版から気づかれなかった原因です

## 文書・skill の更新

`docs/DESIGN-assurance-classes.md` のみ。`docs/LANGUAGE.md` / `docs/LANGUAGE.ja.md` /
`skills/fsl/references/` は分類器の受理規則を記述していないため変更していません。既存の ATX heading
は変更・削除しておらず（追加1件のみ）、この文書の節タイトルを引用しているコードコメントは
`check-design-citation-headings.py check`（findings=0）で健全性を確認しています。

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
