### PR TITLE
fix(causal): exclude timing-not-evaluable evidence from current support (#989)

### DIFF
--- a/changelog.d/989-causal-timing-applicability.fixed.md
+++ b/changelog.d/989-causal-timing-applicability.fixed.md
@@ -1,0 +1,30 @@
+Fixed (#989): causal evidence whose timing eligibility cannot be established
+is now excluded from current support, as the applicability rule already
+required. An unconvertible observation window, or a claim whose `lag` is
+`unknown` so there is no `lag_min` to compare against, previously recorded a
+`not_evaluable` entry while the same evidence/claim edge stayed
+`applicable: true` and cast its vote, so an artifact whose timing could not be
+checked could still decide a claim's `causal_support` between `supported`,
+`mixed` and `challenged`. The edge now excludes with
+`evidence_timing_not_evaluable`, and the record and the vote agree.
+
+Each independent cause is named rather than collapsed into one sentence:
+`period_start_missing`, `period_end_missing`, `period_date_unparsable`,
+`period_end_before_start`, `timebase_not_convertible`,
+`week_window_not_whole_weeks`, and `claim_lag_unknown`. A window that cannot
+convert for a claim whose lag is also unknown reports both, which the previous
+single branch dropped. The records now also travel on the evidence/claim edge
+itself in `causal_evidence_graph` output, not only in the envelope-level
+`not_evaluable` array.
+
+Unchanged: `w == lag_min` still passes and votes, `w < lag_min` still excludes
+with `evidence_window_shorter_than_lag`, and no support-vocabulary value is
+new -- a claim left with no applicable artifact is
+`unsupported_by_current_evidence` exactly as before.
+
+Known limit, unchanged by this fix: a period date is parsed as `YYYY-MM-DD` with a month in
+1..12 and a day in 1..31, and day-of-month validity against the month is not checked, so an
+impossible date such as `2026-02-31` converts as its normalized value instead of reporting
+`period_date_unparsable` — the edge then votes on a window computed from that normalization.
+That is pre-existing `civil_days` behaviour, it also governs `valid_until` staleness, and it is
+tracked as #1011 rather than widened into this fix.

--- a/docs/DESIGN-causal.md
+++ b/docs/DESIGN-causal.md
@@ -488,6 +488,17 @@ check (`causal-check.v0`):
 ```
 
 analyze finding (every finding carries `formal_status: "not_a_violation"`).
+That holds by construction — `evidence_finding` in
+`rust/fsl-tools/src/causal_evidence.rs` writes the field for all fourteen
+evidence-plane finding types, and the structural-review builder does the same
+— but the executable check over the evidence plane is narrower than the claim:
+`causal_review_findings_are_never_violations` drives
+`--profile causal-review` **without** `--evidence`, so it observes none of the
+fourteen, and the `causal-findings.v0` validation added for #989 observes
+exactly one of them (`evidence_timing_not_evaluable`). Widening it to the
+remaining thirteen needs a triggering configuration per type — a single artifact for
+most, but two sharing a lineage for `duplicate_evidence_source` and two disagreeing
+within one lineage for `conflicting_evidence` — and is tracked separately.
 `confidence` is a deterministic structural score (e.g. the fraction of
 reachable outcomes that depend on the flagged claim, computed from the
 graph alone) — it is not a probability of causality, a Bayesian posterior,
@@ -673,7 +684,23 @@ never contradict, the sections above.
   (days × 24); `week` only when the difference is a whole number of weeks;
   `tick` and fractional conversions are `not_evaluable` (never rounded).
   `w < lag_min` excludes with `evidence_window_shorter_than_lag`;
-  `w == lag_min` passes.
+  `w == lag_min` passes. When that comparison cannot be made at all — the
+  window is `not_evaluable`, or the claim's `lag` is `unknown` so there is no
+  `lag_min` — the artifact excludes with `evidence_timing_not_evaluable` and
+  casts no vote, under the same rule as every other applicability condition:
+  it stays in history and in the graph. The window and the lag are two
+  independent reasons the comparison can fail, and each contributes its own
+  `not_evaluable` record on that evidence/claim edge, so a window that cannot
+  convert for a claim whose lag is also unknown reports both. The window side
+  reports the **first** check that refuses, in this fixed order:
+  `period_start_missing`, `period_end_missing`, `period_date_unparsable`,
+  `period_end_before_start`, `timebase_not_convertible`,
+  `week_window_not_whole_weeks`; the lag side reports `claim_lag_unknown`.
+  A date is parsed as `YYYY-MM-DD` with a month in 1..12 and a day in 1..31 —
+  day-of-month validity against the month is **not** checked, so an impossible
+  date such as `2026-02-31` converts as its normalized value rather than
+  reporting `period_date_unparsable`. That is pre-existing `civil_days`
+  behaviour and also governs `valid_until` staleness.
 - **Lineage.** The lineage root is the transitive `derived_from` root when
   present, else `source_study_id`, else the artifact itself. Roots sharing
   members emit `duplicate_evidence_source`; one root is one vote; support

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -2939,7 +2939,10 @@ claim ごとの `causal_support` を集約します: `untested`、`supported`、
 `challenged`、`inconclusive`、`mixed`、`unsupported_by_current_evidence`。
 現行 claim version を pin し、scope が claim scope を `subsumes` し、
 freshness が宣言され、lifecycle が `active` で、観測 window が claim の最小
-lag 以上の artifact だけが票になります。同一 source lineage は 1 票に
+lag 以上の artifact だけが票になります。換算できない観測 window、または claim の
+lag が `unknown` で比較する `lag_min` が無い場合は、timing eligibility が評価不能に
+なります: その edge は履歴とグラフには残りますが、`evidence_timing_not_evaluable`
+で current support から除外され、票を投じません。同一 source lineage は 1 票に
 collapse されます(lineage 内の矛盾は `inconclusive`)。staleness は明示的な
 `--as-of` 日付に対してだけ判定され、実行環境の時計は決して使いません。
 claim 側または artifact 側の片方だけに存在する scope dimension は

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -3004,7 +3004,11 @@ per-claim `causal_support`: `untested`, `supported`, `challenged`,
 that pin the current claim version, whose scope `subsumes` the claim scope,
 with declared freshness, an `active` lifecycle, and an observation window at
 least the claim's minimum lag count; one source lineage collapses to one vote
-(contradictions inside a lineage are `inconclusive`). Staleness is judged only
+(contradictions inside a lineage are `inconclusive`). An observation window
+that cannot be converted, or a claim whose `lag` is `unknown` so there is no
+`lag_min` to compare against, leaves timing eligibility not evaluable: the
+edge stays in history and in the graph but is excluded from current support
+with `evidence_timing_not_evaluable` and casts no vote. Staleness is judged only
 against an explicit `--as-of` date — never the wall clock. A scope dimension
 present on only the claim or artifact side is `unassessable`; absence is never
 treated as universal. **`causal_support`

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -2967,7 +2967,11 @@ per-claim <code>causal_support</code>: <code>untested</code>, <code>supported</c
 that pin the current claim version, whose scope <code>subsumes</code> the claim scope,
 with declared freshness, an <code>active</code> lifecycle, and an observation window at
 least the claim's minimum lag count; one source lineage collapses to one vote
-(contradictions inside a lineage are <code>inconclusive</code>). Staleness is judged only
+(contradictions inside a lineage are <code>inconclusive</code>). An observation window
+that cannot be converted, or a claim whose <code>lag</code> is <code>unknown</code> so there is no
+<code>lag_min</code> to compare against, leaves timing eligibility not evaluable: the
+edge stays in history and in the graph but is excluded from current support
+with <code>evidence_timing_not_evaluable</code> and casts no vote. Staleness is judged only
 against an explicit <code>--as-of</code> date — never the wall clock. A scope dimension
 present on only the claim or artifact side is <code>unassessable</code>; absence is never
 treated as universal. <strong><code>causal_support</code>

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -2903,7 +2903,10 @@ claim ごとの <code>causal_support</code> を集約します: <code>untested</
 <code>challenged</code>、<code>inconclusive</code>、<code>mixed</code>、<code>unsupported_by_current_evidence</code>。
 現行 claim version を pin し、scope が claim scope を <code>subsumes</code> し、
 freshness が宣言され、lifecycle が <code>active</code> で、観測 window が claim の最小
-lag 以上の artifact だけが票になります。同一 source lineage は 1 票に
+lag 以上の artifact だけが票になります。換算できない観測 window、または claim の
+lag が <code>unknown</code> で比較する <code>lag_min</code> が無い場合は、timing eligibility が評価不能に
+なります: その edge は履歴とグラフには残りますが、<code>evidence_timing_not_evaluable</code>
+で current support から除外され、票を投じません。同一 source lineage は 1 票に
 collapse されます(lineage 内の矛盾は <code>inconclusive</code>)。staleness は明示的な
 <code>--as-of</code> 日付に対してだけ判定され、実行環境の時計は決して使いません。
 claim 側または artifact 側の片方だけに存在する scope dimension は

--- a/rust/fsl-tools/src/causal_evidence.rs
+++ b/rust/fsl-tools/src/causal_evidence.rs
@@ -653,24 +653,83 @@ fn scope_application(
     compare_scope(model, claim, &artifact.scope)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WindowConversion {
+    PeriodStartMissing,
+    PeriodEndMissing,
+    PeriodDateUnparsable,
+    PeriodEndBeforeStart,
+    TimebaseNotConvertible,
+    /// The whole-week conversion refused, carrying the day count it refused, so the
+    /// reason never recomputes what the conversion already knew.
+    WeekWindowNotWholeWeeks(u64),
+}
+
+impl WindowConversion {
+    fn code(self) -> &'static str {
+        match self {
+            Self::PeriodStartMissing => "period_start_missing",
+            Self::PeriodEndMissing => "period_end_missing",
+            Self::PeriodDateUnparsable => "period_date_unparsable",
+            Self::PeriodEndBeforeStart => "period_end_before_start",
+            Self::TimebaseNotConvertible => "timebase_not_convertible",
+            Self::WeekWindowNotWholeWeeks(_) => "week_window_not_whole_weeks",
+        }
+    }
+
+    fn reason(self, timebase: &str) -> String {
+        match self {
+            Self::PeriodStartMissing => "the observation period start date is missing".to_owned(),
+            Self::PeriodEndMissing => "the observation period end date is missing".to_owned(),
+            Self::PeriodDateUnparsable => {
+                "an observation period date does not parse as YYYY-MM-DD with a month in 1..12 \
+                 and a day in 1..31"
+                    .to_owned()
+            }
+            Self::PeriodEndBeforeStart => {
+                "the observation period end date is before the start date".to_owned()
+            }
+            Self::TimebaseNotConvertible => format!(
+                "a calendar date interval does not convert to the model timebase '{timebase}' without rounding"
+            ),
+            Self::WeekWindowNotWholeWeeks(days) => {
+                format!("the observation window of {days} days is not a whole number of weeks")
+            }
+        }
+    }
+}
+
 /// Convert an artifact's observation window to model timebase units.
-/// `Ok(None)` means not evaluable (fractional/tick/missing).
-fn window_in_timebase(model: &CausalModel, artifact: &EvidenceArtifact) -> Option<u64> {
-    let (start, end) = (
-        artifact.period_start.as_deref()?,
-        artifact.period_end.as_deref()?,
-    );
-    let days = civil_days(end)? - civil_days(start)?;
+fn window_in_timebase(
+    model: &CausalModel,
+    artifact: &EvidenceArtifact,
+) -> Result<u64, WindowConversion> {
+    let start = artifact
+        .period_start
+        .as_deref()
+        .ok_or(WindowConversion::PeriodStartMissing)?;
+    let end = artifact
+        .period_end
+        .as_deref()
+        .ok_or(WindowConversion::PeriodEndMissing)?;
+    let start_days = civil_days(start).ok_or(WindowConversion::PeriodDateUnparsable)?;
+    let end_days = civil_days(end).ok_or(WindowConversion::PeriodDateUnparsable)?;
+    let days = end_days - start_days;
     if days < 0 {
-        return None;
+        return Err(WindowConversion::PeriodEndBeforeStart);
     }
     #[allow(clippy::cast_sign_loss)]
-    let days = days as u64;
+    let days_u = days as u64;
     match model.timebase.as_str() {
-        "day" => Some(days),
-        "hour" => Some(days * 24),
-        "week" => days.is_multiple_of(7).then_some(days / 7),
-        _ => None,
+        "day" => Ok(days_u),
+        "hour" => Ok(days_u * 24),
+        "week" => {
+            if !days_u.is_multiple_of(7) {
+                return Err(WindowConversion::WeekWindowNotWholeWeeks(days_u));
+            }
+            Ok(days_u / 7)
+        }
+        _ => Err(WindowConversion::TimebaseNotConvertible),
     }
 }
 
@@ -886,36 +945,63 @@ pub fn aggregate_support(
                 }
             }
             // Observation window vs minimum lag.
-            let window = window_in_timebase(model, artifact);
-            match (window, claim.lag) {
-                (Some(window_units), Lag::Known(lag)) => {
-                    if window_units < lag.min {
+            let window_result = window_in_timebase(model, artifact);
+            let window = window_result.ok();
+            let mut edge_not_evaluable: Vec<Value> = Vec::new();
+            let mut timing_reasons: Vec<&'static str> = Vec::new();
+            match window_result {
+                Ok(window_units) => {
+                    if let Lag::Known(lag) = claim.lag
+                        && window_units < lag.min
+                    {
                         exclusions.push("evidence_window_shorter_than_lag");
                         findings.push(evidence_finding(
-                            "evidence_window_shorter_than_lag",
-                            vec![evidence_node.clone(), format!("claim:{claim_id}")],
-                            json!({
-                                "period": {"start": artifact.period_start, "end": artifact.period_end},
-                                "conversion": format!("1 {} timebase units", model.timebase),
-                                "window": window_units,
-                                "lag": {"min": lag.min, "max": lag.max},
-                                "claim": {"id": claim_id, "version": claim.version},
-                            }),
+                                "evidence_window_shorter_than_lag",
+                                vec![evidence_node.clone(), format!("claim:{claim_id}")],
+                                json!({
+                                    "period": {"start": artifact.period_start, "end": artifact.period_end},
+                                    "conversion": format!("1 {} timebase units", model.timebase),
+                                    "window": window_units,
+                                    "lag": {"min": lag.min, "max": lag.max},
+                                    "claim": {"id": claim_id, "version": claim.version},
+                                }),
                             "the observation period is shorter than the claim's minimum lag, so the effect could not have been observed".to_owned(),
                         ));
                     }
                 }
-                (None, _) | (_, Lag::Unknown) => {
-                    not_evaluable.push(json!({
-                        "finding_type": "evidence_window_shorter_than_lag",
-                        "reason": if window.is_none() {
-                            "period missing or not convertible to the model timebase"
-                        } else {
-                            "claim lag is unknown"
-                        },
+                Err(cause) => {
+                    timing_reasons.push(cause.code());
+                    edge_not_evaluable.push(json!({
+                        "finding_type": "evidence_timing_not_evaluable",
+                        "code": cause.code(),
+                        "reason": cause.reason(&model.timebase),
                         "involved_nodes": [evidence_node.clone(), format!("claim:{claim_id}")],
                     }));
                 }
+            }
+            if claim.lag == Lag::Unknown {
+                timing_reasons.push("claim_lag_unknown");
+                edge_not_evaluable.push(json!({
+                    "finding_type": "evidence_timing_not_evaluable",
+                    "code": "claim_lag_unknown",
+                    "reason": "the claim lag is unknown",
+                    "involved_nodes": [evidence_node.clone(), format!("claim:{claim_id}")],
+                }));
+            }
+            if !edge_not_evaluable.is_empty() {
+                exclusions.push("evidence_timing_not_evaluable");
+                findings.push(evidence_finding(
+                    "evidence_timing_not_evaluable",
+                    vec![evidence_node.clone(), format!("claim:{claim_id}")],
+                    json!({
+                        "reasons": timing_reasons,
+                        "period": {"start": artifact.period_start, "end": artifact.period_end},
+                        "timebase": model.timebase,
+                        "claim": {"id": claim_id, "version": claim.version},
+                    }),
+                    "the timing eligibility of this artifact for this claim could not be established, so it is kept in history but casts no vote".to_owned(),
+                ));
+                not_evaluable.extend(edge_not_evaluable.iter().cloned());
             }
             let applicable = exclusions.is_empty();
             if applicable {
@@ -935,7 +1021,7 @@ pub fn aggregate_support(
                 exclusions,
                 scope,
                 window,
-                not_evaluable: Vec::new(),
+                not_evaluable: edge_not_evaluable,
             });
         }
     }
@@ -1240,6 +1326,7 @@ pub fn causal_evidence_graph(
                 "applicable": entry.applicable,
                 "scope_relation": entry.scope.as_str(),
                 "exclusions": entry.exclusions,
+                "not_evaluable": entry.not_evaluable,
             })
         })
         .collect();
@@ -1296,11 +1383,31 @@ mod aggregation_tests {
 
     fn overlay_for(artifacts: Vec<EvidenceArtifact>, as_of: Option<&str>) -> SupportOverlay {
         let (model, _) = build(VALID_MODEL).expect("model");
+        overlay_for_model(&model, artifacts, as_of)
+    }
+
+    fn overlay_for_model(
+        model: &CausalModel,
+        artifacts: Vec<EvidenceArtifact>,
+        as_of: Option<&str>,
+    ) -> SupportOverlay {
         let map: BTreeMap<String, EvidenceArtifact> = artifacts
             .into_iter()
             .map(|artifact| (artifact.evidence_id.clone(), artifact))
             .collect();
-        aggregate_support(&model, &map, as_of)
+        aggregate_support(model, &map, as_of)
+    }
+
+    fn edge_for<'a>(
+        overlay: &'a SupportOverlay,
+        evidence_id: &str,
+        claim_id: &str,
+    ) -> &'a Applicability {
+        overlay
+            .applicability
+            .iter()
+            .find(|entry| entry.evidence_id == evidence_id && entry.claim_id == claim_id)
+            .expect("edge")
     }
 
     #[test]
@@ -1502,6 +1609,243 @@ mod aggregation_tests {
         exact.lifecycle_status = LifecycleStatus::Active;
         let overlay = overlay_for(vec![exact], None);
         assert_eq!(overlay.support["C_SupportHabit"], "supported");
+    }
+
+    fn assert_window_not_evaluable(overlay: &SupportOverlay, expected_code: &str, label: &str) {
+        let edge = edge_for(overlay, "E1", "C_SupportHabit");
+        assert!(!edge.applicable, "{label}");
+        assert_eq!(edge.not_evaluable[0]["code"], expected_code, "{label}");
+        assert_eq!(
+            edge.exclusions
+                .iter()
+                .filter(|token| **token == "evidence_timing_not_evaluable")
+                .count(),
+            1,
+            "{label}"
+        );
+        assert_eq!(
+            overlay.support["C_SupportHabit"], "unsupported_by_current_evidence",
+            "{label}"
+        );
+    }
+
+    fn artifact_with_period(period: &Value) -> EvidenceArtifact {
+        let mut parsed = parse_artifact(&stamped(json!({
+            "schema_version": EVIDENCE_SCHEMA_VERSION,
+            "evidence_id": "E1",
+            "claims": [{"id": "C_SupportHabit", "version": 1}],
+            "design": "randomized_experiment",
+            "support": "supports",
+            "scope": {"population": ["all_users"]},
+            "period": period,
+            "observation": null,
+            "formal_result": "not_run"
+        })))
+        .expect("artifact");
+        parsed.lifecycle_status = LifecycleStatus::Active;
+        parsed
+    }
+
+    #[test]
+    fn unknown_lag_excludes_the_edge_and_the_known_lag_boundary_still_votes() {
+        let source = VALID_MODEL.replace("lag 7..30", "lag unknown");
+        let (model, _) = build(&source).expect("model");
+        let overlay = overlay_for_model(
+            &model,
+            vec![artifact("E1", "C_SupportHabit", 1, "supports")],
+            None,
+        );
+        let edge = edge_for(&overlay, "E1", "C_SupportHabit");
+        assert!(!edge.applicable);
+        assert_eq!(edge.exclusions, vec!["evidence_timing_not_evaluable"]);
+        assert_eq!(edge.not_evaluable.len(), 1);
+        assert_eq!(edge.not_evaluable[0]["code"], "claim_lag_unknown");
+        assert!(
+            overlay
+                .findings
+                .iter()
+                .any(|finding| finding["finding_type"] == "evidence_timing_not_evaluable")
+        );
+        assert_eq!(
+            overlay.support["C_SupportHabit"],
+            "unsupported_by_current_evidence"
+        );
+
+        // Negative control: known lag with an observation window equal to lag.min votes.
+        let mut exact = parse_artifact(&stamped(json!({
+            "schema_version": EVIDENCE_SCHEMA_VERSION,
+            "evidence_id": "E1",
+            "claims": [{"id": "C_SupportHabit", "version": 1}],
+            "design": "randomized_experiment",
+            "support": "supports",
+            "scope": {"population": ["all_users"]},
+            "period": {"start": "2026-01-01", "end": "2026-01-08", "valid_until": "2027-03-31"},
+            "observation": null,
+            "formal_result": "not_run"
+        })))
+        .expect("artifact");
+        exact.lifecycle_status = LifecycleStatus::Active;
+        let overlay = overlay_for(vec![exact], None);
+        let edge = edge_for(&overlay, "E1", "C_SupportHabit");
+        assert!(edge.applicable);
+        assert!(edge.exclusions.is_empty());
+        assert_eq!(overlay.support["C_SupportHabit"], "supported");
+    }
+
+    #[test]
+    fn unconvertible_window_excludes_naming_each_cause_and_a_convertible_window_still_votes() {
+        assert_each_conversion_cause_is_named();
+        assert_timebase_and_week_reasons_are_exact();
+        assert_both_axes_report_two_causes();
+        assert_a_convertible_window_still_votes();
+    }
+
+    /// Every conversion failure names *which* conversion refused, exactly.
+    fn assert_each_conversion_cause_is_named() {
+        const UNPARSABLE: &str = "an observation period date does not parse as YYYY-MM-DD \
+                                  with a month in 1..12 and a day in 1..31";
+        for (label, period, expected_code, expected_reason) in [
+            (
+                "period_start_missing",
+                json!({"start": null, "end": "2026-03-31", "valid_until": "2027-03-31"}),
+                "period_start_missing",
+                "the observation period start date is missing",
+            ),
+            (
+                "period_end_missing",
+                json!({"start": "2026-01-01", "end": null, "valid_until": "2027-03-31"}),
+                "period_end_missing",
+                "the observation period end date is missing",
+            ),
+            (
+                "period_date_unparsable_start",
+                json!({"start": "garbage", "end": "2026-03-31", "valid_until": "2027-03-31"}),
+                "period_date_unparsable",
+                UNPARSABLE,
+            ),
+            (
+                // The end-date conversion is a second, independent call site: the row above
+                // returns before it ever runs.
+                "period_date_unparsable_end",
+                json!({"start": "2026-01-01", "end": "garbage", "valid_until": "2027-03-31"}),
+                "period_date_unparsable",
+                UNPARSABLE,
+            ),
+            (
+                "period_end_before_start",
+                json!({"start": "2026-03-31", "end": "2026-01-01", "valid_until": "2027-03-31"}),
+                "period_end_before_start",
+                "the observation period end date is before the start date",
+            ),
+        ] {
+            let overlay = overlay_for(vec![artifact_with_period(&period)], None);
+            assert_window_not_evaluable(&overlay, expected_code, label);
+            let edge = edge_for(&overlay, "E1", "C_SupportHabit");
+            assert_eq!(
+                edge.not_evaluable[0]["reason"].as_str().expect("reason"),
+                expected_reason,
+                "{label}"
+            );
+        }
+    }
+
+    /// The two model-level conversions that refuse: an unconvertible timebase and a
+    /// window that is not a whole number of weeks.
+    fn assert_timebase_and_week_reasons_are_exact() {
+        let tick_source = tick_timebase_source();
+        let (tick_model, _) = build(&tick_source).expect("tick model");
+        let mut tick_artifact = artifact("E1", "C_SupportHabit", 1, "supports");
+        tick_artifact.lifecycle_status = LifecycleStatus::Active;
+        let overlay = overlay_for_model(&tick_model, vec![tick_artifact], None);
+        assert_window_not_evaluable(&overlay, "timebase_not_convertible", "tick");
+        let edge = edge_for(&overlay, "E1", "C_SupportHabit");
+        assert_eq!(
+            edge.not_evaluable[0]["reason"].as_str().expect("reason"),
+            "a calendar date interval does not convert to the model timebase 'tick' without rounding"
+        );
+
+        let week_model = week_timebase_model();
+        let mut week_artifact = artifact("E1", "C_SupportHabit", 1, "supports");
+        week_artifact.lifecycle_status = LifecycleStatus::Active;
+        let overlay = overlay_for_model(&week_model, vec![week_artifact], None);
+        assert_window_not_evaluable(&overlay, "week_window_not_whole_weeks", "week");
+        let edge = edge_for(&overlay, "E1", "C_SupportHabit");
+        assert_eq!(
+            edge.not_evaluable[0]["reason"].as_str().expect("reason"),
+            "the observation window of 89 days is not a whole number of weeks"
+        );
+    }
+
+    /// Both axes refuse at once: two records, one exclusion, one finding.
+    fn assert_both_axes_report_two_causes() {
+        // Both axes fail at once: the previous single match arm reported only the
+        // window cause and dropped the unknown lag.
+        let combined_source = tick_timebase_source().replace("lag 7..30", "lag unknown");
+        let (combined_model, _) = build(&combined_source).expect("combined model");
+        let mut combined_artifact = artifact("E1", "C_SupportHabit", 1, "supports");
+        combined_artifact.lifecycle_status = LifecycleStatus::Active;
+        let overlay = overlay_for_model(&combined_model, vec![combined_artifact], None);
+        let edge = edge_for(&overlay, "E1", "C_SupportHabit");
+        assert!(!edge.applicable);
+        assert_eq!(edge.not_evaluable.len(), 2);
+        let codes: Vec<&str> = edge
+            .not_evaluable
+            .iter()
+            .map(|record| record["code"].as_str().expect("code"))
+            .collect();
+        assert!(codes.contains(&"timebase_not_convertible"));
+        assert!(codes.contains(&"claim_lag_unknown"));
+        assert_eq!(
+            edge.exclusions
+                .iter()
+                .filter(|token| **token == "evidence_timing_not_evaluable")
+                .count(),
+            1
+        );
+        assert_eq!(
+            overlay
+                .findings
+                .iter()
+                .filter(|finding| finding["finding_type"] == "evidence_timing_not_evaluable")
+                .count(),
+            1
+        );
+        assert_eq!(
+            overlay.support["C_SupportHabit"],
+            "unsupported_by_current_evidence"
+        );
+    }
+
+    /// Preservation control: a window that does convert, meeting the minimum lag, keeps
+    /// voting. An over-broad fix that excluded on any timing record fails here.
+    fn assert_a_convertible_window_still_votes() {
+        let week_model = week_timebase_model();
+        // Preservation control: a window that does convert, meeting the minimum lag,
+        // keeps voting. An over-broad fix that excluded on any timing record fails here.
+        let whole_week = artifact_with_period(&json!({
+            "start": "2026-01-01",
+            "end": "2026-01-08",
+            "valid_until": "2027-03-31"
+        }));
+        let overlay = overlay_for_model(&week_model, vec![whole_week], None);
+        let edge = edge_for(&overlay, "E1", "C_SupportHabit");
+        assert!(edge.applicable);
+        assert!(edge.exclusions.is_empty());
+        assert_eq!(overlay.support["C_SupportHabit"], "supported");
+    }
+
+    fn week_timebase_model() -> CausalModel {
+        let source = VALID_MODEL
+            .replace("timebase day", "timebase week")
+            .replace("1 tick = 1 day", "1 tick = 1 week")
+            .replace("lag 7..30", "lag 1..30");
+        build(&source).expect("week model").0
+    }
+
+    fn tick_timebase_source() -> String {
+        VALID_MODEL
+            .replace("timebase day", "timebase tick")
+            .replace("1 tick = 1 day", "1 tick = 1 tick")
     }
 
     #[test]

--- a/rust/fslc/tests/causal_cli.rs
+++ b/rust/fslc/tests/causal_cli.rs
@@ -10,7 +10,7 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-use serde_json::Value;
+use serde_json::{Value, json};
 
 fn run_process(arguments: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_fslc"))
@@ -389,6 +389,286 @@ fn check_and_review_outputs_are_deterministic() {
 
 const EVIDENCE: &str = "examples/causal/evidence/onboarding-2026.causal.json";
 const LIFECYCLE: &str = "examples/causal/evidence/onboarding-2026.lifecycle.json";
+
+fn compiled_schema(relative: &str) -> jsonschema::Validator {
+    let schema_text = std::fs::read_to_string(repository_root().join(relative))
+        .unwrap_or_else(|error| panic!("read {relative}: {error}"));
+    let schema_value: Value = serde_json::from_str(&schema_text).expect("schema is valid JSON");
+    jsonschema::validator_for(&schema_value).expect("schema compiles")
+}
+
+fn assert_valid_against(record: &Value, schema_relative: &str) {
+    let validator = compiled_schema(schema_relative);
+    let errors: Vec<String> = validator
+        .iter_errors(record)
+        .map(|error| error.to_string())
+        .collect();
+    assert!(errors.is_empty(), "schema validation errors: {errors:?}");
+}
+
+fn stamped_evidence(mut artifact: Value) -> Value {
+    let digest = fsl_tools::artifact_digest(&artifact);
+    artifact
+        .as_object_mut()
+        .expect("object")
+        .insert("artifact_digest".to_owned(), json!(digest));
+    artifact
+}
+
+fn stamped_lifecycle(evidence_id: &str, artifact_digest: &str, chain: Value) -> Value {
+    let records = chain["records"].as_array().expect("records");
+    let mut stamped_records = Vec::new();
+    let mut previous_digest = None;
+    for record in records {
+        let mut stamped = record.clone();
+        if let Some(previous) = previous_digest.clone() {
+            stamped
+                .as_object_mut()
+                .expect("record object")
+                .insert("previous_record_digest".to_owned(), json!(previous));
+        }
+        let digest = fsl_tools::lifecycle_record_digest(evidence_id, artifact_digest, &stamped);
+        stamped
+            .as_object_mut()
+            .expect("record object")
+            .insert("record_digest".to_owned(), json!(digest));
+        previous_digest = Some(digest);
+        stamped_records.push(stamped);
+    }
+    let mut result = chain;
+    result
+        .as_object_mut()
+        .expect("chain object")
+        .insert("records".to_owned(), json!(stamped_records));
+    result
+}
+
+const UNKNOWN_LAG_MODEL: &str = r"causal LagUnknownVote {
+  timebase day
+  horizon 365
+  scope population { token all_users token new_users subset_of all_users }
+  scope environment { token production }
+  scope segment { token self_serve }
+  default_scope { population new_users environment production segment self_serve }
+  variable onboarding_support { role intervention }
+  variable first_success { role outcome }
+  claim C_Onboarding_FirstSuccess onboarding_support -> first_success {
+    version 1
+    status active
+    polarity positive
+    lag unknown
+    persists 7..30
+    basis hypothesis
+    scope { population new_users environment production segment self_serve }
+  }
+}
+";
+
+fn write_unknown_lag_fixture(scratch: &Path) -> (String, String, String) {
+    let model_path = scratch.join("unknown.fsl");
+    std::fs::write(&model_path, UNKNOWN_LAG_MODEL).expect("write model");
+    let evidence = stamped_evidence(json!({
+        "schema_version": "fsl-causal-evidence.v0",
+        "evidence_id": "S1",
+        "claims": [{"id": "claim:C_Onboarding_FirstSuccess", "version": 1}],
+        "design": "randomized_experiment",
+        "source_study_id": "S1",
+        "derived_from": [],
+        "support": "supports",
+        "scope": {
+            "population": ["new_users"],
+            "environment": ["production"],
+            "segment": ["self_serve"]
+        },
+        "period": {
+            "start": "2026-01-01",
+            "end": "2026-03-31",
+            "valid_until": "2027-03-31"
+        },
+        "estimate": {
+            "estimand": "risk_difference",
+            "value": 0.08,
+            "lower": 0.03,
+            "upper": 0.13,
+            "confidence": 0.95
+        },
+        "assumptions": ["randomization_integrity", "no_interference"],
+        "observation": null,
+        "formal_result": "not_run"
+    }));
+    let artifact_digest = evidence["artifact_digest"]
+        .as_str()
+        .expect("artifact digest");
+    let evidence_path = scratch.join("S1.json");
+    std::fs::write(&evidence_path, evidence.to_string()).expect("write evidence");
+    let lifecycle = stamped_lifecycle(
+        "S1",
+        artifact_digest,
+        json!({
+            "schema_version": "fsl-causal-evidence-lifecycle.v0",
+            "evidence_id": "S1",
+            "artifact_digest": artifact_digest,
+            "records": [{
+                "sequence": 1,
+                "status": "active",
+                "superseded_by": null,
+                "recorded_at": "2026-04-01T00:00:00Z",
+                "previous_record_digest": null
+            }]
+        }),
+    );
+    let lifecycle_path = scratch.join("S1.lifecycle.json");
+    std::fs::write(&lifecycle_path, lifecycle.to_string()).expect("write lifecycle");
+    (
+        model_path.to_str().expect("utf-8 model").to_owned(),
+        evidence_path.to_str().expect("utf-8 evidence").to_owned(),
+        lifecycle_path.to_str().expect("utf-8 lifecycle").to_owned(),
+    )
+}
+
+fn assert_timing_not_evaluable_graph(model: &str, evidence: &str, lifecycle: &str) {
+    let (graph, status) = run_cli(&[
+        "causal",
+        "analyze",
+        model,
+        "--projection",
+        "causal_evidence_graph",
+        "--evidence",
+        evidence,
+        "--lifecycle",
+        lifecycle,
+    ]);
+    assert_eq!(status, 0, "{graph}");
+    let edge = &graph["edges"][0];
+    assert_eq!(edge["applicable"], false);
+    assert_eq!(edge["exclusions"], json!(["evidence_timing_not_evaluable"]));
+    assert!(
+        edge["not_evaluable"][0]["reason"]
+            .as_str()
+            .is_some_and(|reason| !reason.is_empty())
+    );
+    let claim = &graph["claims"][0];
+    assert_eq!(claim["causal_support"], "unsupported_by_current_evidence");
+    assert_eq!(claim["formal_assurance"], "not_run");
+    assert_valid_against(
+        &graph,
+        "schemas/fslc/causal/causal-evidence-graph.v0.schema.json",
+    );
+}
+
+fn assert_timing_not_evaluable_review_schema(model: &str, evidence: &str, lifecycle: &str) {
+    let (review, status) = run_cli(&[
+        "causal",
+        "analyze",
+        model,
+        "--profile",
+        "causal-review",
+        "--evidence",
+        evidence,
+        "--lifecycle",
+        lifecycle,
+    ]);
+    assert_eq!(status, 0, "{review}");
+    assert_valid_against(
+        &review,
+        "schemas/fslc/causal/causal-findings.v0.schema.json",
+    );
+}
+
+fn assert_timing_not_evaluable_ledger(model: &str, evidence: &str, lifecycle: &str) {
+    let (ledger, status) = run_cli(&[
+        "causal",
+        "ledger",
+        model,
+        "--evidence",
+        evidence,
+        "--lifecycle",
+        lifecycle,
+    ]);
+    assert_eq!(status, 0, "{ledger}");
+    let claim_entry = ledger["claims"]
+        .as_array()
+        .expect("claims")
+        .iter()
+        .find(|entry| entry["id"] == "claim:C_Onboarding_FirstSuccess")
+        .expect("claim");
+    let excluded = claim_entry["evidence"]["excluded"]
+        .as_array()
+        .expect("excluded");
+    assert!(
+        excluded.iter().any(|entry| {
+            entry["evidence_id"] == "evidence:S1"
+                && entry["exclusions"]
+                    .as_array()
+                    .is_some_and(|tokens| tokens.contains(&json!("evidence_timing_not_evaluable")))
+        }),
+        "expected excluded evidence with timing token: {excluded:?}"
+    );
+    let reasons = claim_attention(&ledger, "C_Onboarding_FirstSuccess");
+    assert!(reasons.contains(&"current_evidence_missing".to_owned()));
+    assert!(!reasons.iter().any(|reason| reason.contains("freshness")));
+}
+
+/// Preservation control: evidence whose timing *is* evaluable keeps voting, and both
+/// envelopes still validate. This is what fails if the exclusion is made too broad.
+fn assert_onboarding_evidence_still_eligible() {
+    let (eligible_graph, eligible_status) = run_cli(&[
+        "causal",
+        "analyze",
+        RETENTION,
+        "--projection",
+        "causal_evidence_graph",
+        "--evidence",
+        EVIDENCE,
+        "--lifecycle",
+        LIFECYCLE,
+    ]);
+    assert_eq!(eligible_status, 0, "{eligible_graph}");
+    assert_eq!(eligible_graph["edges"][0]["applicable"], true);
+    let supported = eligible_graph["claims"]
+        .as_array()
+        .expect("claims")
+        .iter()
+        .find(|claim| claim["id"] == "claim:C_Onboarding_FirstSuccess")
+        .expect("supported claim");
+    assert_eq!(supported["causal_support"], "supported");
+    assert_valid_against(
+        &eligible_graph,
+        "schemas/fslc/causal/causal-evidence-graph.v0.schema.json",
+    );
+    let (eligible_review, _) = run_cli(&[
+        "causal",
+        "analyze",
+        RETENTION,
+        "--profile",
+        "causal-review",
+        "--evidence",
+        EVIDENCE,
+        "--lifecycle",
+        LIFECYCLE,
+    ]);
+    assert_valid_against(
+        &eligible_review,
+        "schemas/fslc/causal/causal-findings.v0.schema.json",
+    );
+}
+
+/// An evidence/claim edge whose timing eligibility cannot be established must be
+/// excluded consistently everywhere it surfaces: `applicable`/`exclusions` in the
+/// evidence-graph envelope, the `finding_type` enum of `causal-findings.v0` (the
+/// review profile is validated against the published schema, so a finding type
+/// missing from the enum fails here), and the ledger's excluded list and attention
+/// reason. Regression for #989, where such an edge stayed `applicable: true` and
+/// voted while a `not_evaluable` record was recorded beside it.
+#[test]
+fn timing_not_evaluable_edge_excludes_across_graph_schema_and_ledger() {
+    let scratch = tempfile_dir();
+    let (model, evidence, lifecycle) = write_unknown_lag_fixture(&scratch);
+    assert_timing_not_evaluable_graph(&model, &evidence, &lifecycle);
+    assert_timing_not_evaluable_review_schema(&model, &evidence, &lifecycle);
+    assert_timing_not_evaluable_ledger(&model, &evidence, &lifecycle);
+    assert_onboarding_evidence_still_eligible();
+}
 
 #[test]
 fn evidence_graph_overlays_support_without_touching_formal_assurance() {

--- a/schemas/fslc/causal/causal-evidence-graph.v0.schema.json
+++ b/schemas/fslc/causal/causal-evidence-graph.v0.schema.json
@@ -86,6 +86,22 @@
           "exclusions": {
             "type": "array",
             "items": { "type": "string" }
+          },
+          "not_evaluable": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["finding_type", "reason", "involved_nodes"],
+              "properties": {
+                "finding_type": { "type": "string" },
+                "reason": { "type": "string" },
+                "involved_nodes": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              },
+              "additionalProperties": true
+            }
           }
         },
         "additionalProperties": true

--- a/schemas/fslc/causal/causal-findings.v0.schema.json
+++ b/schemas/fslc/causal/causal-findings.v0.schema.json
@@ -116,6 +116,7 @@
             "unknown_lifecycle",
             "evidence_claim_version_mismatch",
             "evidence_window_shorter_than_lag",
+            "evidence_timing_not_evaluable",
             "duplicate_evidence_source",
             "unknown_freshness",
             "retracted_or_superseded_evidence",

--- a/skills/fsl/references/impl.md
+++ b/skills/fsl/references/impl.md
@@ -230,7 +230,12 @@ deterministic per-claim `causal_support`
 unsupported_by_current_evidence`) counts only artifacts pinning the current
 claim version with `subsumes` scope, declared freshness, an `active`
 lifecycle, and an observation window ≥ the claim's minimum lag; one source
-lineage is one vote. A scope dimension present on only one side is
+lineage is one vote. An observation window that cannot be converted, or a
+claim whose `lag` is `unknown` so there is no `lag_min` to compare against,
+leaves timing eligibility not evaluable: the edge stays in history but is
+excluded from current support with `evidence_timing_not_evaluable` and casts
+no vote — it is never counted on the strength of the other conditions alone.
+A scope dimension present on only one side is
 `unassessable`, never universal. Staleness needs an explicit `--as-of` — never the wall
 clock. **Agents: `causal_support` and `formal_assurance` are separate axes;
 `supported` never means proved, `challenged` never means refuted, and


### PR DESCRIPTION
Closes #989.

## Problem

In causal evidence aggregation, an evidence/claim edge whose **timing eligibility could not be
established** — the claim's `lag` is `unknown`, or the observation window does not convert to the
model timebase — recorded a `not_evaluable` entry while the same edge stayed `applicable: true`
and cast its vote. An artifact whose timing could not be checked could therefore decide a claim's
`causal_support` between `supported`, `mixed` and `challenged`. Not a display problem.

Reproduced at `dbbf6889` before touching anything, with the issue's own input:

| input | produced at `dbbf6889` | expected |
|---|---|---|
| `lag unknown`, timebase `day`, one supporting artifact | `causal_support: "supported"`, `edge.applicable: true`, `exclusions: []`, `not_evaluable[0].reason: "claim lag is unknown"`, exit 0 | excluded, `unsupported_by_current_evidence` |
| `lag 1..2`, timebase `tick` (window unconvertible) | `causal_support: "supported"`, `applicable: true`, `exclusions: []`, `not_evaluable[0].reason: "period missing or not convertible to the model timebase"`, exit 0 | excluded, `unsupported_by_current_evidence` |

## Contract change

**The applicability rule already required exclusion.** `docs/DESIGN-causal.md`'s Fail-closed
boundary bullet lists `window-vs-lag` among the conditions under which an artifact "stays in
history and in the graph but is excluded from current support". This is a defect against that
rule, not a change to it — the design document is not amended, its `**Window conversion.**`
bullet is *completed*, because it named `not_evaluable` and then specified only `w < lag_min` and
`w == lag_min`.

- The edge now excludes with `evidence_timing_not_evaluable`, so the record and the vote agree.
  `let applicable = exclusions.is_empty();` is untouched — the vote stops because the exclusion is
  present, which is the smallest contract-preserving shape.
- `window_in_timebase` returns `Result<u64, WindowConversion>` with six ordered causes
  (`period_start_missing`, `period_end_missing`, `period_date_unparsable`,
  `period_end_before_start`, `timebase_not_convertible`, `week_window_not_whole_weeks`), and the
  lag axis is evaluated independently, so a window that cannot convert **for a claim whose lag is
  also unknown reports both** — the previous single match arm dropped the second.
- `Applicability.not_evaluable`, a public field that was always `Vec::new()`, now carries the
  edge's records and is the single producer of the envelope-level array. The records also appear on
  the edge in `causal_evidence_graph` output.
- **No support vocabulary is added.** A claim left with no applicable artifact is
  `unsupported_by_current_evidence`, already the value for that case.
- `causal-findings.v0` gains one `finding_type` enum member. That is the additive shape this same
  v0 enum already took: 15 members at `68dd3e6b` → 31 at `f9942ec1` (a descendant), filename and
  `$id` unchanged. `causal-evidence-graph.v0` documents the optional `edges[].not_evaluable` with
  the same required item shape its sibling in `causal-findings.v0` already declares.
- Unchanged: `w == lag_min` still passes and votes; `w < lag_min` still excludes with
  `evidence_window_shorter_than_lag`; lifecycle / freshness / staleness / version-pin / scope keep
  their tokens; `formal_result` and `formal_assurance` stay `not_run`; exit codes do not move. The
  new token contains neither `stale` nor `freshness`, so the ledger's substring classification
  (`causal_ledger_projection.rs`) reports `current_evidence_missing` rather than a freshness reason.

## Commits

| commit | purpose | verification |
|---|---|---|
| `1f561d85` `fix(causal): exclude timing-not-evaluable evidence from current support` — `rust/fsl-tools/src/causal_evidence.rs`, `rust/fslc/tests/causal_cli.rs`, `schemas/fslc/causal/causal-findings.v0.schema.json`, `schemas/fslc/causal/causal-evidence-graph.v0.schema.json` (4 files, +678/−37) | stop the vote, make `applicable` agree with the record, name each cause | the pre-fix reproduction above; 22 isolated mutations; `-p fsl-tools causal`; `--test causal_cli`; fmt; clippy; `--workspace` test; build |
| `a8658ade` `docs(causal): state the timing-eligibility rule and its verification limits` — `docs/DESIGN-causal.md`, `docs/LANGUAGE.md`, `docs/LANGUAGE.ja.md`, `skills/fsl/references/impl.md`, `docs/intro/language.{en,ja}.html`, `changelog.d/989-causal-timing-applicability.fixed.md` (7 files, +82/−6) | move the contract text with the fix and record the measured verification limits | `pytest tests/test_site_reference_snapshot.py`; `tools/aggregate_changelog.sh check`; `tools/build_site_reference.py` run twice for idempotence; 18 `## ` sections in both language files |

The detectors live in commit 1 with the fix, so the fix cannot land without them. Everything a
later rebase may have to regenerate is confined to commit 2.

## Verification

Run as one uninterrupted serial sequence with **no edit while it ran** — and that is measured, not
asserted: `git status --porcelain` and the sha256 of all eleven changed files were captured before
and after, and both comparisons came back identical. The fifth column is whether the log actually
contains a `Checking`/`Compiling` line for a changed crate; a gate that returns 0 without touching
`fsl-tools` or `fslc-rust` has not judged this change.

| command | exit | elapsed | compile line for a changed crate |
|---|---|---|---|
| `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` | 0 | 3s | N/A (fmt does not compile; output 0 bytes) |
| `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings` | 0 | 89s | yes (2) |
| `cargo test --manifest-path rust/Cargo.toml -p fsl-tools causal` | 0 | 154s | yes (1) |
| `cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test causal_cli` | 0 | 60s | yes (1) |
| `cargo test --manifest-path rust/Cargo.toml --workspace --locked` | 0 | 3405s | yes (2) |
| `cargo build --manifest-path rust/Cargo.toml --workspace --locked` | 0 | 17s | yes (2) |
| `python3 -m pytest tests/test_site_reference_snapshot.py -v` | 0 | 2s | N/A (6 passed, both freshness cases) |
| `./tools/aggregate_changelog.sh check` | 0 | 7s | N/A |
| `python3 tools/build_site_reference.py` | 0 | 1s | N/A (idempotent on a second run) |
| `BASE_SHA=dbbf6889 HEAD_SHA=a8658ade ./tools/check-merge-readiness.sh automation` | 0 | 133s | N/A — `commits to enumerate: 2`, `check-spdx-headers: PASS` |

That last row was deliberately re-run **after** committing: `check-spdx-headers` enumerates
commits between the two SHAs, so before the commits existed it passed without looking at any file
from this change.

### Required contexts NOT run locally

Stated as not run, not as passing:

- **`WASM`** — no file under `rust/fsl-wasm/` changes, and the browser leg has hung in this
  environment before.
- **`semantic mutation (changed)`** and **`FSL Logic Test (pr)`** — both cover the kernel's
  concrete/symbolic semantics. The causal graph never enters `KernelModel`, `fsl-runtime` or
  `fsl-solver` by design (`docs/DESIGN-causal.md` §1), and this change touches neither.

## Calibration

**22 mutations, 22 detected, 22 restored by byte equality to a pre-mutation snapshot, 0 skipped.**
Each falsifies **one** branch: a blanket revert makes the table test panic on its first row, so
every later row would have stayed uncalibrated behind a broken premise. Restores are proved by
`diff` and sha256 against the snapshot, never by a `grep -c`.

| mutation | branch it falsifies | produced vs expected |
|---|---|---|
| exclusion made unconditional | the paired preservation controls | 7 tests FAILED, including **five pre-existing ones** (`support_aggregation_follows_the_table`, `observation_window_shorter_than_lag_is_excluded_with_boundaries`, `staleness_requires_the_explicit_as_of_date`, `one_lineage_collapses_to_one_vote`, `observational_only_support_is_flagged_but_still_supported`) |
| lag check skipped once the window failed (the pre-fix arm) | both-axes reporting | `left: 1` / `right: 2` records |
| each of the six `code()` arms, one at a time | that cause's code | `left: String("wrong_code")` / `right: "<that code>"` |
| the `tick` reason text | naming *which* timebase refused | `left: "the observation window is not evaluable"` / `right: "a calendar date interval does not convert to the model timebase 'tick' without rounding"` |
| the week reason text | carrying the day count | `left: "…is not a whole number of weeks"` / `right: "the observation window of 89 days is not a whole number of weeks"` |
| the four remaining reason arms, one at a time | each row's exact reason | e.g. `left: "the window is not evaluable"` / `right: "the observation period start date is missing"` |
| the finding push removed | a review finding is emitted, not only a record | both new unit tests FAILED |
| the exclusion pushed twice / the finding pushed twice | exactly one per edge | `left: [token, token]` / `right: [token]`; `left: 2` / `right: 1` |
| `entry.not_evaluable` replaced by an empty vec | the records travel on the edge | FAILED at the edge assertion |
| `scope_relation` renamed | the graph envelope really is schema-validated | `schema validation errors: ["\"scope_relation\" is a required property"]` |
| `formal_status` set to `violation` | the evidence-bearing review envelope enforces it | `schema validation errors: ["\"not_a_violation\" was expected"]` |
| the end-date parse site's cause changed | the **end** date is its own call site | `left: String("period_end_missing")` / `right: "period_date_unparsable"` |
| `all_stale` forced true in the ledger | the attention reason is not a freshness one | FAILED at the ledger assertion |

Three regression tests, each with a **rejecting control in the same test**, and each named for
what it establishes:

- `unknown_lag_excludes_the_edge_and_the_known_lag_boundary_still_votes`
- `unconvertible_window_excludes_naming_each_cause_and_a_convertible_window_still_votes`
- `timing_not_evaluable_edge_excludes_across_graph_schema_and_ledger`

**No existing expected verdict moves.** No `.fsl` under `examples/` or `specs/` declares
`lag unknown`, and no causal model uses `timebase tick`; the existing window-boundary test covers
known lag only.

## Series-independent review

The controller injected the primary mutation independently, in this worktree, after confirming no
cargo process was running: removing the `exclusions.push("evidence_timing_not_evaluable")` line
and running `cargo test -p fsl-tools --locked causal` gave **exit 101, 45 passed, 2 failed**, the
two failures being exactly the new unit detectors; restoring the file returned `diff -q` IDENTICAL
and **exit 0, 47 passed**. (The five further failures reported here come from the `fslc-rust`
side, which that scoped run does not include.)

**The boundary of that review:** the controller did not read the +416 lines of
`causal_evidence.rs` for semantic correctness (the numeric correctness of the lag/window
conversion, or whether the ordering of the six causes is the best one), did not judge test
sufficiency subjectively, and did not read the `--workspace` run's 218 test files. The PASS is
inside that boundary only.

A Sol reviewer reached zero findings in three rounds (round 1: 0 blocker / 2 major / 8 minor;
round 2: all addressed or their reason accepted, plus one new minor about a design sentence that
was too literal; round 3: no findings). A coupled-change reviewer reported no missing coupled
surface across eight items — LSP index, `tests/dialect_registry.py`, the frozen Python reference,
other published schemas, goldens/snapshots, language-file alignment, and the changelog fragment.

## Residual risk

1. **`civil_days` accepts an impossible calendar date — #1011.** It validates a day as `1..31`
   without checking it against the month, so `2026-02-31` converts as its normalized value and
   the edge votes: measured `applicable: true`, `exclusions: []`, `causal_support: "supported"`,
   against controls `garbage` → excluded with `period_date_unparsable` and `2026-01-01` →
   supported. **This is the false-green direction.** It is byte-identical at `dbbf6889`, so it is
   not introduced here, and the same function decides `valid_until` staleness, which makes
   tightening it a separate requirement. What *was* in scope: the reason string introduced by this
   change claimed "not valid ISO-8601 calendar dates", which is false for exactly that input, and
   now states what is actually parsed; the limit is recorded in `docs/DESIGN-causal.md` and as a
   Known limit in the changelog fragment.
2. **`docs/DESIGN-causal.md`'s "every finding carries `formal_status: not_a_violation`" is
   verified for 1 of the 14 evidence-plane finding types.** It holds by construction for all
   fourteen (`evidence_finding` writes the field), but the test that quantifies over findings runs
   `--profile causal-review` **without** `--evidence` and so observed **none** of them; the schema
   validation added here observes one. The document now records that limit instead of leaving the
   claim unqualified. Widening it needs a triggering configuration per type and is tracked
   separately.
3. **The list of seven causes is not mechanically exhaustive.** The total `match` in
   `WindowConversion::code()` forces a new variant to have a code, but nothing forces a new
   variant to gain a table row or an entry in the design list. No exhaustiveness check is added
   deliberately: the shortest way to pass such a check is to edit the list.
4. **Conflict surface with the docs-site track is `docs/intro/language.{en,ja}.html` only.** If
   that lands first, commit 2 needs `python3 tools/build_site_reference.py` re-run followed by
   `pytest tests/test_site_reference_snapshot.py`; the markdown inputs do not overlap.
