### PR TITLE
fix(verify): propagate --instances/--values into the inline implements abstraction (#1003)

### DIFF
--- a/changelog.d/1003-implements-bounds-override.fixed.md
+++ b/changelog.d/1003-implements-bounds-override.fixed.md
@@ -1,0 +1,8 @@
+Propagate `fslc verify --instances` / `--values` overrides into inline `implements`
+abstract specs, filtered to names the abstraction declares, so refinement keeps
+running at the same world size on both sides.
+
+Scoped runs now apply the same model-warning finalization as unscoped runs, so a
+spec's `warnings` no longer depend on whether `--instances` / `--values` were
+passed. Measured on the #1003 reproducer, this removes a `no_user_invariants`
+warning that only scoped runs emitted.

--- a/docs/DESIGN-refinement.md
+++ b/docs/DESIGN-refinement.md
@@ -509,6 +509,33 @@ Violation:
 
 exit: refines = 0, refinement_failed = 1, error = 2/3.
 
+### Inline `implements` bounds propagation (`fslc verify`)
+
+When `fslc verify` carries `--instances` / `--values` scope overrides, the native
+CLI still evaluates inline `implements` and keeps the nested `implements` field in
+the envelope. Overrides propagate into the abstract spec **only for entity/number
+names the abstraction itself declares**; impl-only names are filtered out before
+direct-spec validation so they cannot trigger undeclared-name errors on a business
+or spec abstract that does not model them.
+
+This matches the language contract in `docs/LANGUAGE.md` (inline `implements`
+bounds propagation). Before #1003 the native Rust CLI violated that documented
+contract; the frozen Python reference exercised the intended behavior in
+`tests/test_implements_bounds_override.py` (#94). Refinement remains a
+same-size forward simulation: a shrunken implementation and an unfiltered
+full-size abstract would otherwise disagree with `map_out_of_bounds`.
+
+**Independent suppressors (not treated as safe):** inline `implements` is still
+omitted silently when any of these hold:
+
+- `--property`
+- `--exclude-properties`
+- `--from-state`
+
+No omission reason is recorded in the envelope today. This design does **not**
+declare those suppressions safe; they remain an explicit follow-up contract
+decision ([#1008](https://github.com/ymm-oss/fsl/issues/1008)).
+
 Static checks (`kind: "type"` error, exit 2):
 - An abs state variable that is not mapped / a nonexistent variable or action
   name

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -373,6 +373,11 @@ spec がインラインの `implements` を持つ場合、上書きは抽象 spe
 impl 側だけの carried number(例: business の抽象には存在しない `Amount`)は impl
 のみに適用されます。
 
+`fslc verify` は `--instances` / `--values` の scope override だけが付いている場合でも
+インライン `implements` を評価します。`--property`、`--exclude-properties`、
+`--from-state` は引き続き理由を記録せず `implements` フィールドを省略します。
+この挙動は安全とみなされておらず、契約上の未決定事項として残ります。
+
 `acceptance`/`forbidden` シナリオは、spec の元の世界の id や数値をハードコード
 しがちで(`accept(2)`)、それが縮小された上書き(`--instances Case=1`)の外に出る
 ことがあります。上書きが有効なとき、replay の失敗が*純粋に*上書き後の境界の外の値を

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -385,6 +385,11 @@ and a full-size abstract would fail with `map_out_of_bounds`). An impl-only
 carried number (e.g. `Amount`, absent from a business abstract) applies to the
 impl only.
 
+`fslc verify` still evaluates inline `implements` when only `--instances` /
+`--values` scope overrides are present. `--property`, `--exclude-properties`, and
+`--from-state` continue to omit the `implements` field without recording a reason;
+that behavior is not treated as safe and remains an open contract decision.
+
 `acceptance`/`forbidden` scenarios often hardcode ids/numbers from the spec's
 original world (`accept(2)`), which can fall outside a shrunken override
 (`--instances Case=1`). When overrides are active, a scenario whose replay

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -410,6 +410,10 @@ declares — so the refinement check runs at the same world size on both sides
 and a full-size abstract would fail with <code>map_out_of_bounds</code>). An impl-only
 carried number (e.g. <code>Amount</code>, absent from a business abstract) applies to the
 impl only.</p>
+<p><code>fslc verify</code> still evaluates inline <code>implements</code> when only <code>--instances</code> /
+<code>--values</code> scope overrides are present. <code>--property</code>, <code>--exclude-properties</code>, and
+<code>--from-state</code> continue to omit the <code>implements</code> field without recording a reason;
+that behavior is not treated as safe and remains an open contract decision.</p>
 <p><code>acceptance</code>/<code>forbidden</code> scenarios often hardcode ids/numbers from the spec's
 original world (<code>accept(2)</code>), which can fall outside a shrunken override
 (<code>--instances Case=1</code>). When overrides are active, a scenario whose replay

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -400,6 +400,10 @@ fslc verify spec.fsl --values Amount=0..3
 これがないと、縮小した impl とフルサイズの抽象は <code>map_out_of_bounds</code> で失敗します)。
 impl 側だけの carried number(例: business の抽象には存在しない <code>Amount</code>)は impl
 のみに適用されます。</p>
+<p><code>fslc verify</code> は <code>--instances</code> / <code>--values</code> の scope override だけが付いている場合でも
+インライン <code>implements</code> を評価します。<code>--property</code>、<code>--exclude-properties</code>、
+<code>--from-state</code> は引き続き理由を記録せず <code>implements</code> フィールドを省略します。
+この挙動は安全とみなされておらず、契約上の未決定事項として残ります。</p>
 <p><code>acceptance</code>/<code>forbidden</code> シナリオは、spec の元の世界の id や数値をハードコード
 しがちで(<code>accept(2)</code>)、それが縮小された上書き(<code>--instances Case=1</code>)の外に出る
 ことがあります。上書きが有効なとき、replay の失敗が<em>純粋に</em>上書き後の境界の外の値を

--- a/rust/fsl-core/src/lib.rs
+++ b/rust/fsl-core/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! Typed kernel lowering and semantic model for the Rust FSL port.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 
 use fsl_syntax::{
@@ -12,6 +12,10 @@ use fsl_syntax::{
     TypeExpr, VerifyItem, parse_document,
 };
 use serde_json::Value;
+
+type InstanceOverrides = BTreeMap<String, i64>;
+type ValueOverrides = BTreeMap<String, (i64, i64)>;
+type FilteredScopeOverrides = Option<(InstanceOverrides, ValueOverrides)>;
 
 /// Re-exported so every crate that recurses over `KernelExpr` reaches the same
 /// stack guard without depending on `fsl-syntax` directly (#620).
@@ -83,6 +87,7 @@ pub use public_kernel::{
 pub use refinement::{
     ActionCorrespondence, ActionCorrespondenceTarget, ActionRef, ImplementsContract, ProgressMap,
     Refinement, RefinementError, StateMap, parse_refinement, requirements_implements,
+    requirements_implements_with_bounds,
 };
 pub use trace::{TraceAction, TraceChange, TraceStep};
 pub use trace_json::{
@@ -366,6 +371,130 @@ fn validate_direct_scope_overrides(
         )));
     }
     Ok(())
+}
+
+fn collect_spec_entity_number_names(
+    items: &[SpecItem],
+    entities: &mut HashSet<String>,
+    numbers: &mut HashSet<String>,
+) {
+    for item in items {
+        match item {
+            SpecItem::Entity(name, _) => {
+                entities.insert(name.clone());
+            }
+            SpecItem::Number(name, _) => {
+                numbers.insert(name.clone());
+            }
+            _ => {}
+        }
+    }
+}
+
+fn declared_entity_number_names(document: &SurfaceDocument) -> (HashSet<String>, HashSet<String>) {
+    let mut entities = HashSet::new();
+    let mut numbers = HashSet::new();
+    match document {
+        SurfaceDocument::Spec(spec) => {
+            collect_spec_entity_number_names(&spec.items, &mut entities, &mut numbers);
+        }
+        SurfaceDocument::Business(business) => {
+            // `BusinessItem` has no `Number` variant (`surface.rs:393-433`), so only
+            // entity names are collected here.
+            for item in &business.items {
+                if let BusinessItem::Entity(name, _) = item {
+                    entities.insert(name.clone());
+                }
+            }
+        }
+        SurfaceDocument::Requirements(requirements) => {
+            for item in &requirements.items {
+                if let RequirementsItem::Common(spec_item) = item {
+                    match spec_item {
+                        SpecItem::Entity(name, _) => {
+                            entities.insert(name.clone());
+                        }
+                        SpecItem::Number(name, _) => {
+                            numbers.insert(name.clone());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        // These dialects carry no `VerifyItem`; `VerifyBounds` exists only on
+        // `SpecItem` (`surface.rs:219`) and `BusinessItem` (`surface.rs:430`).
+        SurfaceDocument::Refinement(_)
+        | SurfaceDocument::Governance(_)
+        | SurfaceDocument::Compose(_)
+        | SurfaceDocument::Db(_)
+        | SurfaceDocument::Domain(_)
+        | SurfaceDocument::AiComponent(_)
+        | SurfaceDocument::Agent(_) => {}
+    }
+    (entities, numbers)
+}
+
+/// Restrict scope overrides to entity/number names declared by an abstraction surface.
+///
+/// Used when propagating `fslc verify --instances` / `--values` into an inline
+/// `implements` abstract spec: the implementation already validated the full
+/// override against its own declarations, and the abstract must be shrunk to
+/// the same world size for refinement to stay well-posed — but only for names
+/// the abstraction shares.
+///
+/// # Errors
+///
+/// Returns [`CoreError`] when the abstraction source fails to parse.
+pub fn filter_scope_overrides_for_abstraction(
+    source: &str,
+    instances: &InstanceOverrides,
+    values: &ValueOverrides,
+) -> Result<FilteredScopeOverrides, CoreError> {
+    if instances.is_empty() && values.is_empty() {
+        return Ok(None);
+    }
+    let parsed = parse_document(SourceFile::new(source))?;
+    let (entities, numbers) = declared_entity_number_names(&parsed.surface);
+    let filtered_instances: BTreeMap<String, i64> = instances
+        .iter()
+        .filter(|(name, _)| entities.contains(name.as_str()))
+        .map(|(name, value)| (name.clone(), *value))
+        .collect();
+    let filtered_values: BTreeMap<String, (i64, i64)> = values
+        .iter()
+        .filter(|(name, _)| numbers.contains(name.as_str()))
+        .map(|(name, value)| (name.clone(), *value))
+        .collect();
+    if filtered_instances.is_empty() && filtered_values.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some((filtered_instances, filtered_values)))
+    }
+}
+
+/// Parse an inline-implements abstraction with scope overrides filtered to its
+/// declared entity/number names before validation and lowering.
+///
+/// # Errors
+///
+/// Returns [`CoreError`] with the same contract as [`parse_kernel_source_with_bounds`].
+pub fn parse_abstraction_kernel_source_with_bounds(
+    source: &str,
+    resolver: &dyn FileResolver,
+    instances: &InstanceOverrides,
+    values: &ValueOverrides,
+) -> Result<KernelSpec, CoreError> {
+    let (instances, values) =
+        match filter_scope_overrides_for_abstraction(source, instances, values)? {
+            Some((instances, values)) => (instances, values),
+            None => (BTreeMap::new(), BTreeMap::new()),
+        };
+    if instances.is_empty() && values.is_empty() {
+        parse_kernel_source(source, resolver)
+    } else {
+        parse_kernel_source_with_bounds(source, &instances, &values)
+    }
 }
 
 /// Parse a direct spec/business/requirements document with temporary verify-bound overrides.

--- a/rust/fsl-core/src/refinement.rs
+++ b/rust/fsl-core/src/refinement.rs
@@ -12,7 +12,7 @@ use fsl_syntax::{
 use crate::recursion;
 use crate::{
     ActionDef, FileResolver, KernelModel, ParamDef, TypeDef, TypeRef, build_model,
-    parse_kernel_source,
+    parse_abstraction_kernel_source_with_bounds,
 };
 
 #[derive(Clone, Debug)]
@@ -1247,6 +1247,31 @@ pub fn requirements_implements(
     resolver: &dyn FileResolver,
     implementation: &KernelModel,
 ) -> Result<Option<ImplementsContract>, RefinementError> {
+    requirements_implements_with_bounds(
+        source,
+        resolver,
+        implementation,
+        &BTreeMap::new(),
+        &BTreeMap::new(),
+    )
+}
+
+/// Resolve an inline `implements` contract with abstraction bounds overrides.
+///
+/// Overrides are filtered to entity/number names declared by the abstraction
+/// before validation and lowering.
+///
+/// # Errors
+///
+/// Returns [`RefinementError`] for dependency, lowering, or mapping failures.
+#[allow(clippy::too_many_lines)]
+pub fn requirements_implements_with_bounds(
+    source: &str,
+    resolver: &dyn FileResolver,
+    implementation: &KernelModel,
+    instances: &BTreeMap<String, i64>,
+    values: &BTreeMap<String, (i64, i64)>,
+) -> Result<Option<ImplementsContract>, RefinementError> {
     let document = fsl_syntax::parse_surface_document(source).map_err(|error| RefinementError {
         message: error.message,
         span: Some(error.span),
@@ -1270,10 +1295,12 @@ pub fn requirements_implements(
         message: error.message,
         span: Some(span),
     })?;
-    let kernel = parse_kernel_source(&abs_source, resolver).map_err(|error| RefinementError {
-        message: error.message,
-        span: Some(span),
-    })?;
+    let kernel =
+        parse_abstraction_kernel_source_with_bounds(&abs_source, resolver, instances, values)
+            .map_err(|error| RefinementError {
+                message: error.message,
+                span: Some(span),
+            })?;
     let abstraction = build_model(kernel).map_err(|error| RefinementError {
         message: error.message,
         span: Some(span),

--- a/rust/fsl-core/tests/action_correspondence.rs
+++ b/rust/fsl-core/tests/action_correspondence.rs
@@ -2,19 +2,22 @@
 
 use fsl_core::{
     ActionCorrespondenceTarget, CoreError, CorrespondenceOrigin, FileResolver, FsResolver,
-    build_model, parse_kernel_source, parse_refinement, requirements_implements,
+    build_model, filter_scope_overrides_for_abstraction, parse_kernel_source,
+    parse_kernel_source_with_bounds, parse_refinement, requirements_implements,
+    requirements_implements_with_bounds,
 };
+use std::collections::BTreeMap;
 
 fn build(source: &str) -> fsl_core::KernelModel {
     let kernel = parse_kernel_source(source, &FsResolver::new(".")).expect("parse source");
     build_model(kernel).expect("build model")
 }
 
-struct Resolver(&'static str);
+struct Resolver(String);
 
 impl FileResolver for Resolver {
     fn read(&self, _: &str) -> Result<String, CoreError> {
-        Ok(self.0.to_owned())
+        Ok(self.0.clone())
     }
 }
 
@@ -172,7 +175,7 @@ fn requirements_routes_report_both_duplicate_origins() {
   action pay(x: N, retry: N) maps settle(x) { paid = true }
 }"#;
     let implementation = build(source);
-    let error = requirements_implements(source, &Resolver(ABS), &implementation)
+    let error = requirements_implements(source, &Resolver(ABS.to_owned()), &implementation)
         .expect_err("the implementation block and maps clause conflict");
     assert!(error.message.contains("implements_block"));
     assert!(error.message.contains("inline_maps_clause"));
@@ -211,12 +214,14 @@ fn requirements_routes_lower_to_the_same_typed_target() {
   init { paid = false }
   action pay(x: N, retry: N) maps settle(x) { paid = true }
 }"#;
-    let explicit_contract = requirements_implements(explicit, &Resolver(ABS), &build(explicit))
-        .expect("explicit implements route")
-        .expect("implements contract");
-    let inline_contract = requirements_implements(inline, &Resolver(ABS), &build(inline))
-        .expect("inline maps route")
-        .expect("implements contract");
+    let explicit_contract =
+        requirements_implements(explicit, &Resolver(ABS.to_owned()), &build(explicit))
+            .expect("explicit implements route")
+            .expect("implements contract");
+    let inline_contract =
+        requirements_implements(inline, &Resolver(ABS.to_owned()), &build(inline))
+            .expect("inline maps route")
+            .expect("implements contract");
     let explicit_mapping = &explicit_contract.refinement.action_correspondences["pay"];
     let inline_mapping = &inline_contract.refinement.action_correspondences["pay"];
     assert_eq!(explicit_mapping.target, inline_mapping.target);
@@ -241,7 +246,7 @@ fn requirements_implicit_auto_returns_an_error_instead_of_indexing_past_params()
   action pay(x: N) { paid = true }
 }"#;
     let implementation = build(source);
-    let error = requirements_implements(source, &Resolver(abstraction), &implementation)
+    let error = requirements_implements(source, &Resolver(abstraction.to_owned()), &implementation)
         .expect_err("arity mismatch must be diagnosed");
     assert!(
         error
@@ -274,9 +279,66 @@ verify { instances Case = 2 }
 verify { instances Case = 2 }
 "#;
     let implementation = build(source);
-    let error = requirements_implements(source, &Resolver(abstraction), &implementation)
+    let error = requirements_implements(source, &Resolver(abstraction.to_owned()), &implementation)
         .expect_err("auto-mapped actors must match");
     assert!(error.message.contains("actor mismatch"));
     assert!(error.message.contains("System"));
     assert!(error.message.contains("Manager"));
+}
+
+/// detector (mutation A: empty abstraction overrides -> `map_out_of_bounds`;
+/// mutation B: unfiltered overrides -> undeclared-name error on direct `spec`)
+#[test]
+fn bounds_are_filtered_and_propagated_to_inline_abstraction() {
+    let spec_abs = r"spec SharedOnly {
+  entity Item
+  state { st: Map<Item, Bool> }
+  init { forall i: Item { st[i] = false } }
+  action finish(i: Item) {
+    st[i] = true
+  }
+}
+verify { instances Item = 3 }
+";
+    let spec_impl = r#"requirements SharedOnlyReq {
+  implements SharedOnly from "abs.fsl" { maps auto }
+  entity Item
+  entity Extra
+  state { st: Map<Item, Bool> }
+  init { forall i: Item { st[i] = false } }
+  action finish(i: Item) maps finish(i) {
+    st[i] = true
+  }
+}
+verify {
+  instances Item = 1
+  instances Extra = 1
+}
+"#;
+    let overrides = BTreeMap::from([("Item".to_owned(), 1), ("Extra".to_owned(), 1)]);
+    let filtered = filter_scope_overrides_for_abstraction(spec_abs, &overrides, &BTreeMap::new())
+        .expect("filter overrides")
+        .expect("shared override");
+    assert_eq!(filtered.0, BTreeMap::from([("Item".to_owned(), 1)]));
+    assert!(filtered.1.is_empty());
+
+    let implementation = build(spec_impl);
+    let contract = requirements_implements_with_bounds(
+        spec_impl,
+        &Resolver(spec_abs.to_owned()),
+        &implementation,
+        &overrides,
+        &BTreeMap::new(),
+    )
+    .expect("filtered abstraction parse")
+    .expect("implements contract");
+    assert_eq!(contract.abstraction.name, "SharedOnly");
+
+    let error = parse_kernel_source_with_bounds(spec_abs, &overrides, &BTreeMap::new())
+        .expect_err("unfiltered overrides must fail validation on direct spec");
+    assert!(
+        error
+            .message
+            .contains("verify instances references undeclared entity 'Extra'")
+    );
 }

--- a/rust/fslc/src/main.rs
+++ b/rust/fslc/src/main.rs
@@ -15586,8 +15586,25 @@ fn implements_result_from_source(
     model: &KernelModel,
     depth: usize,
 ) -> Result<Option<Value>, fslc_rust::verification_output::RequirementsImplementsError> {
+    implements_result_from_source_with_bounds(path, source, model, depth, &ScopeBounds::default())
+}
+
+fn implements_result_from_source_with_bounds(
+    path: &Path,
+    source: &str,
+    model: &KernelModel,
+    depth: usize,
+    scope: &ScopeBounds,
+) -> Result<Option<Value>, fslc_rust::verification_output::RequirementsImplementsError> {
     let resolver = fsl_core::FsResolver::new(path.parent().unwrap_or_else(|| Path::new(".")));
-    fslc_rust::verification_output::requirements_implements_output(source, &resolver, model, depth)
+    fslc_rust::verification_output::requirements_implements_output_with_bounds(
+        source,
+        &resolver,
+        model,
+        depth,
+        &scope.instances,
+        &scope.values,
+    )
 }
 
 fn implements_error_output(

--- a/rust/fslc/src/verification.rs
+++ b/rust/fslc/src/verification.rs
@@ -10,8 +10,8 @@ use sha2::{Digest, Sha256};
 use super::{
     CliVerifyOptions, ScopeBounds, SpecLoadError, add_strict_tag_warnings, apply_vacuity_mode,
     block_on_native, display, envelope, error_output, implements_error_output,
-    implements_result_from_source, invariant_names, load_kernel_model_from_source, load_model,
-    load_model_from_source, load_model_scoped, load_model_scoped_from_source,
+    implements_result_from_source_with_bounds, invariant_names, load_kernel_model_from_source,
+    load_model, load_model_from_source, load_model_scoped, load_model_scoped_from_source,
     load_snapshot_value_object, load_state_snapshot, read_spec_source, select_properties,
     selected_implicit_bounds, semantic_error_output, spec_load_error_output,
     surface_parse_error_output, validate_requirement_traces_from_source,
@@ -2210,11 +2210,10 @@ fn execute_cli_verification(
     options: &CliVerifyOptions,
     prepared: &PreparedCliVerification,
 ) -> CommandResult {
-    let filtered = prepared.has_scope
-        || options.property.is_some()
+    let selection_filtered = options.property.is_some()
         || !options.exclude_properties.is_empty()
         || prepared.initial_state.is_some();
-    if !filtered && prepared.is_agent_document {
+    if !(selection_filtered || prepared.has_scope) && prepared.is_agent_document {
         return (
             error_output(
                 "parse",
@@ -2231,10 +2230,16 @@ fn execute_cli_verification(
         Ok(model) => model,
         Err(error) => return (spec_load_error_output(error), 2),
     };
-    let implements = if filtered {
+    let implements = if selection_filtered {
         None
     } else {
-        match implements_result_from_source(path, source, model, options.depth) {
+        match implements_result_from_source_with_bounds(
+            path,
+            source,
+            model,
+            options.depth,
+            &options.scope,
+        ) {
             Ok(implements) => implements,
             Err(error) => return (implements_error_output(&error), 2),
         }
@@ -2290,7 +2295,7 @@ fn execute_cli_verification(
         }),
         Err(error) => return (error_output("usage", &error), 2),
     };
-    if !filtered {
+    if !selection_filtered {
         decorate_default_cli_verification(
             &mut output,
             source,

--- a/rust/fslc/src/verification_output.rs
+++ b/rust/fslc/src/verification_output.rs
@@ -302,12 +302,36 @@ pub fn requirements_implements_output(
     model: &KernelModel,
     depth: usize,
 ) -> Result<Option<Value>, RequirementsImplementsError> {
+    requirements_implements_output_with_bounds(
+        source,
+        resolver,
+        model,
+        depth,
+        &std::collections::BTreeMap::new(),
+        &std::collections::BTreeMap::new(),
+    )
+}
+
+/// Evaluate inline `implements` with abstraction bounds overrides propagated
+/// from `fslc verify --instances` / `--values`.
+///
+/// # Errors
+///
+/// Returns a diagnostic when dependency resolution, lowering, or concrete
+/// refinement checking fails.
+pub fn requirements_implements_output_with_bounds(
+    source: &str,
+    resolver: &dyn fsl_core::FileResolver,
+    model: &KernelModel,
+    depth: usize,
+    instances: &std::collections::BTreeMap<String, i64>,
+    values: &std::collections::BTreeMap<String, (i64, i64)>,
+) -> Result<Option<Value>, RequirementsImplementsError> {
     let Some(contract) =
-        fsl_core::requirements_implements(source, resolver, model).map_err(|error| {
-            RequirementsImplementsError {
-                message: error.message,
-                span: error.span,
-            }
+        fsl_core::requirements_implements_with_bounds(source, resolver, model, instances, values)
+            .map_err(|error| RequirementsImplementsError {
+            message: error.message,
+            span: error.span,
         })?
     else {
         return Ok(None);

--- a/rust/fslc/tests/fixtures/inline_implements_bounds/abs_broken.fsl
+++ b/rust/fslc/tests/fixtures/inline_implements_bounds/abs_broken.fsl
@@ -1,0 +1,14 @@
+business OverrideBusiness {
+  actor Operator
+  entity Item
+
+  process Item {
+    stages Ready, Done
+    initial Ready
+    transition finish Ready -> Done by Operator
+  }
+}
+
+verify {
+  instances Item = 1
+}

--- a/rust/fslc/tests/fixtures/inline_implements_bounds/abs_business.fsl
+++ b/rust/fslc/tests/fixtures/inline_implements_bounds/abs_business.fsl
@@ -1,0 +1,13 @@
+business ClaimFlow {
+  actor Employee, Manager
+  entity Claim
+  process Claim {
+    stages Draft, Submitted, Approved
+    initial Draft
+    transition submit  Draft     -> Submitted by Employee
+    transition approve Submitted -> Approved  by Manager
+  }
+}
+verify {
+  instances Claim = 3
+}

--- a/rust/fslc/tests/fixtures/inline_implements_bounds/abs_spec_number.fsl
+++ b/rust/fslc/tests/fixtures/inline_implements_bounds/abs_spec_number.fsl
@@ -1,0 +1,11 @@
+spec CountedFlow {
+  number Limit
+  state { n: Limit }
+  init { n = 0 }
+  action bump() {
+    n = 0
+  }
+}
+verify {
+  values Limit = 0..3
+}

--- a/rust/fslc/tests/fixtures/inline_implements_bounds/abs_spec_shared.fsl
+++ b/rust/fslc/tests/fixtures/inline_implements_bounds/abs_spec_shared.fsl
@@ -1,0 +1,9 @@
+spec SharedOnly {
+  entity Item
+  state { st: Map<Item, Bool> }
+  init { forall i: Item { st[i] = false } }
+  action finish(i: Item) { st[i] = true }
+}
+verify {
+  instances Item = 3
+}

--- a/rust/fslc/tests/fixtures/inline_implements_bounds/impl_broken.fsl
+++ b/rust/fslc/tests/fixtures/inline_implements_bounds/impl_broken.fsl
@@ -1,0 +1,16 @@
+requirements OverrideBrokenRequirements {
+  process Item {
+    stages Ready, Done
+    initial Ready
+    transition finish Ready -> Done by Operator
+  }
+
+  implements OverrideBusiness from "abs_broken.fsl" {
+    maps auto
+    action finish(c) -> stutter
+  }
+}
+
+verify {
+  instances Item = 1
+}

--- a/rust/fslc/tests/fixtures/inline_implements_bounds/impl_spec_extra.fsl
+++ b/rust/fslc/tests/fixtures/inline_implements_bounds/impl_spec_extra.fsl
@@ -1,0 +1,13 @@
+requirements SharedOnlyReq {
+  implements SharedOnly from "abs_spec_shared.fsl" { maps auto }
+
+  entity Item
+  entity Extra
+  state { st: Map<Item, Bool> }
+  init { forall i: Item { st[i] = false } }
+  action finish(i: Item) maps finish(i) { st[i] = true }
+}
+verify {
+  instances Item = 1
+  instances Extra = 1
+}

--- a/rust/fslc/tests/fixtures/inline_implements_bounds/impl_spec_number.fsl
+++ b/rust/fslc/tests/fixtures/inline_implements_bounds/impl_spec_number.fsl
@@ -1,0 +1,13 @@
+requirements CountedReq {
+  implements CountedFlow from "abs_spec_number.fsl" { maps auto }
+
+  number Limit
+  state { n: Limit }
+  init { n = 0 }
+  action bump() maps bump() {
+    n = 0
+  }
+}
+verify {
+  values Limit = 0..3
+}

--- a/rust/fslc/tests/fixtures/inline_implements_bounds/impl_valid.fsl
+++ b/rust/fslc/tests/fixtures/inline_implements_bounds/impl_valid.fsl
@@ -1,0 +1,13 @@
+requirements ClaimReq {
+  implements ClaimFlow from "abs_business.fsl" { }
+
+  process Claim {
+    stages Draft, Submitted, Approved
+    initial Draft
+    transition submit  Draft     -> Submitted by Employee
+    transition approve Submitted -> Approved  by Manager
+  }
+}
+verify {
+  instances Claim = 3
+}

--- a/rust/fslc/tests/fixtures/inline_implements_bounds/impl_with_amount.fsl
+++ b/rust/fslc/tests/fixtures/inline_implements_bounds/impl_with_amount.fsl
@@ -1,0 +1,16 @@
+requirements ClaimReqAmount {
+  implements ClaimFlow from "abs_business.fsl" { }
+
+  number Amount
+
+  process Claim {
+    stages Draft, Submitted, Approved
+    initial Draft
+    transition submit  Draft     -> Submitted by Employee
+    transition approve Submitted -> Approved  by Manager
+  }
+}
+verify {
+  instances Claim = 3
+  values Amount = 0..3
+}

--- a/rust/fslc/tests/inline_implements_bounds.rs
+++ b/rust/fslc/tests/inline_implements_bounds.rs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Ryoichi Izumita
+
+//! Native contract coverage for inline `implements` bounds propagation (#1003).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+const FIXTURE_DIR: &str = "rust/fslc/tests/fixtures/inline_implements_bounds";
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+fn fixture(name: &str) -> String {
+    format!("{FIXTURE_DIR}/{name}")
+}
+
+fn run_verify(arguments: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(arguments)
+        .current_dir(repository_root())
+        .output()
+        .expect("run native fslc verify");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={arguments:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("native exit status"))
+}
+
+fn is_timing_leaf_key(key: &str) -> bool {
+    key == "elapsed_s" || key == "check_elapsed_s"
+}
+
+fn flatten_leaves(value: &Value, prefix: &str, out: &mut BTreeMap<String, Value>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                let path = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                flatten_leaves(child, &path, out);
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                flatten_leaves(child, &format!("{prefix}.{index}"), out);
+            }
+        }
+        _ => {
+            out.insert(prefix.to_string(), value.clone());
+        }
+    }
+}
+
+fn timing_leaf_paths(value: &Value) -> Vec<String> {
+    let mut leaves = BTreeMap::new();
+    flatten_leaves(value, "", &mut leaves);
+    leaves
+        .keys()
+        .filter(|path| {
+            let leaf = path.rsplit('.').next().unwrap_or(path.as_str());
+            is_timing_leaf_key(leaf)
+        })
+        .cloned()
+        .collect()
+}
+
+fn comparable_leaf_map(value: &Value) -> BTreeMap<String, Value> {
+    let mut leaves = BTreeMap::new();
+    flatten_leaves(value, "", &mut leaves);
+    leaves
+        .into_iter()
+        .filter(|(path, _)| {
+            let leaf = path.rsplit('.').next().unwrap_or(path.as_str());
+            !is_timing_leaf_key(leaf) && !path.starts_with("bounds_overrides")
+        })
+        .collect()
+}
+
+/// Compare two verify envelopes in full, excluding only wall-clock timing leaves
+/// (`elapsed_s`, `check_elapsed_s`) and the scoped-only `bounds_overrides` echo.
+/// Timing fields are real-time measurements and differ across repeated runs with
+/// the same input and binary (observed: 61 leaf keys total, 7 timing leaves differed).
+/// `bounds_overrides` is asserted separately on the scoped side only.
+fn assert_envelopes_agree_modulo_timing(left: &Value, right: &Value) {
+    let left_timing = timing_leaf_paths(left);
+    let right_timing = timing_leaf_paths(right);
+    assert!(
+        !left_timing.is_empty() && !right_timing.is_empty(),
+        "dead timing exclusion: both envelopes lacked elapsed_s/check_elapsed_s leaves; \
+         left={left_timing:?} right={right_timing:?}"
+    );
+
+    let left_map = comparable_leaf_map(left);
+    let right_map = comparable_leaf_map(right);
+    assert_eq!(
+        left_map,
+        right_map,
+        "envelopes differ beyond timing leaves; left-only={:?} right-only={:?}",
+        left_map
+            .keys()
+            .filter(|key| !right_map.contains_key(*key))
+            .collect::<Vec<_>>(),
+        right_map
+            .keys()
+            .filter(|key| !left_map.contains_key(*key))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// detector (mutation D: restoring `has_scope` suppression drops `implements`)
+#[test]
+fn verify_with_instances_keeps_inline_implements_in_envelope() {
+    let (output, status) = run_verify(&[
+        "verify",
+        &fixture("impl_broken.fsl"),
+        "--depth",
+        "2",
+        "--strict-tags",
+        "--no-cache",
+        "--instances",
+        "Item=1",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["result"], "verified");
+    assert_eq!(output["implements"]["result"], "refinement_failed");
+    assert_eq!(
+        output["implements"]["violation"]["kind"],
+        "stutter_changed_abs"
+    );
+}
+
+/// detector (business abstract × shared entity instances)
+#[test]
+fn instances_override_propagates_to_business_abstract() {
+    let (output, status) = run_verify(&[
+        "verify",
+        &fixture("impl_valid.fsl"),
+        "--depth",
+        "6",
+        "--no-cache",
+        "--instances",
+        "Claim=1",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["implements"]["result"], "refines");
+}
+
+/// detector (business abstract × impl-only number values)
+#[test]
+fn impl_only_number_values_do_not_reach_business_abstract() {
+    let (output, status) = run_verify(&[
+        "verify",
+        &fixture("impl_with_amount.fsl"),
+        "--depth",
+        "6",
+        "--no-cache",
+        "--instances",
+        "Claim=1",
+        "--values",
+        "Amount=0..1",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["implements"]["result"], "refines");
+    assert_eq!(
+        output["bounds_overrides"]["values"]["Amount"],
+        Value::Array(vec![Value::from(0), Value::from(1),])
+    );
+}
+
+/// detector (spec abstract × shared number values)
+#[test]
+fn values_override_propagates_to_spec_abstract() {
+    let (output, status) = run_verify(&[
+        "verify",
+        &fixture("impl_spec_number.fsl"),
+        "--depth",
+        "4",
+        "--no-cache",
+        "--values",
+        "Limit=0..1",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["implements"]["result"], "refines");
+}
+
+/// detector (spec abstract × impl-only entity instances)
+#[test]
+fn impl_only_entity_instances_do_not_error_on_spec_abstract() {
+    let (output, status) = run_verify(&[
+        "verify",
+        &fixture("impl_spec_extra.fsl"),
+        "--depth",
+        "4",
+        "--no-cache",
+        "--instances",
+        "Item=1",
+        "--instances",
+        "Extra=1",
+    ]);
+    assert_eq!(status, 0, "{output:#}");
+    assert_eq!(output["implements"]["result"], "refines");
+}
+
+/// preservation control (mutation E: classifying `refines` as failure)
+#[test]
+fn valid_inline_refinement_preserves_success_with_and_without_bounds() {
+    let base_args = [
+        "verify",
+        &fixture("impl_valid.fsl"),
+        "--depth",
+        "6",
+        "--no-cache",
+    ];
+    let (without_bounds, status_without) = run_verify(&base_args);
+    assert_eq!(status_without, 0, "{without_bounds:#}");
+    assert_eq!(without_bounds["implements"]["result"], "refines");
+    assert!(without_bounds.get("bounds_overrides").is_none());
+
+    let (with_bounds, status_with) = run_verify(&[
+        "verify",
+        &fixture("impl_valid.fsl"),
+        "--depth",
+        "6",
+        "--no-cache",
+        "--instances",
+        "Claim=3",
+    ]);
+    assert_eq!(status_with, 0, "{with_bounds:#}");
+    assert_eq!(with_bounds["implements"]["result"], "refines");
+    assert_eq!(with_bounds["bounds_overrides"]["instances"]["Claim"], 3);
+
+    assert_eq!(status_without, status_with);
+    assert_envelopes_agree_modulo_timing(&without_bounds, &with_bounds);
+}
+
+/// preservation control (mutation F: removing timing exclusions must red this)
+#[test]
+fn timing_exclusion_survives_on_repeated_runs() {
+    let args = [
+        "verify",
+        &fixture("impl_valid.fsl"),
+        "--depth",
+        "6",
+        "--no-cache",
+    ];
+    let (first, _) = run_verify(&args);
+    let (second, _) = run_verify(&args);
+    assert_envelopes_agree_modulo_timing(&first, &second);
+}

--- a/rust/fslc/tests/issue_868_result_option_verdict_census.rs
+++ b/rust/fslc/tests/issue_868_result_option_verdict_census.rs
@@ -307,10 +307,24 @@ const CLASSIFICATIONS: &[Classification] = &[
         ResultOption
     ),
     entry!(
+        Ordinary,
+        "rust/fsl-core/src/refinement.rs",
+        1268,
+        "requirements_implements_with_bounds",
+        ResultOption
+    ),
+    entry!(
         Verdict,
         "rust/fslc/src/verification_output.rs",
         253,
         "requirements_implements_output",
+        ResultOption
+    ),
+    entry!(
+        Verdict,
+        "rust/fslc/src/verification_output.rs",
+        322,
+        "requirements_implements_output_with_bounds",
         ResultOption
     ),
     entry!(
@@ -437,6 +451,13 @@ const CLASSIFICATIONS: &[Classification] = &[
         "rust/fslc/src/main.rs",
         14968,
         "implements_result_from_source",
+        ResultOption
+    ),
+    entry!(
+        Verdict,
+        "rust/fslc/src/main.rs",
+        15592,
+        "implements_result_from_source_with_bounds",
         ResultOption
     ),
     entry!(

--- a/skills/fsl/references/layers.md
+++ b/skills/fsl/references/layers.md
@@ -80,7 +80,10 @@ the relevant role skill directs it.
   clauses carry inputs (`with`), guards (`when`), field updates (`set`), and
   traceability (`covers`). Put verifier bounds in `verify { instances E = N
   values T = lo..hi }`. With `implements`, verify simultaneously runs the refine
-  to the upper layer (the `implements` field in the result JSON); an empty body
+  to the upper layer (the `implements` field in the result JSON); CLI
+  `--instances` / `--values` overrides propagate into the abstract spec for that
+  refinement, restricted to entity/number names the abstraction declares (impl-only
+  names stay on the implementation side). An empty body
   auto-generates identity refinement when names match, `maps auto` is allowed for
   same-name kernel-wrapper state/actions, and auto-mapped process transitions are
   actor-checked; the inline block also takes action-correspondence items


### PR DESCRIPTION
## Problem

`fslc verify` silently skipped the inline `implements` refinement whenever an `--instances` /
`--values` scope override was present, dropping the `implements` field from the JSON envelope with
no reason recorded.

`docs/LANGUAGE.md:379-385` (at `dbbf6889`) already stated the opposite, **unconditionally**:

> When the spec has an inline `implements`, the override also propagates into the abstract spec —
> restricted to the entity/number names the abstract itself declares — so the refinement check runs
> at the same world size on both sides (refinement is a same-size forward simulation; without this,
> a shrunken impl and a full-size abstract would fail with `map_out_of_bounds`).

`docs/LANGUAGE.ja.md:369-374` carries the 1:1 counterpart. Neither names an exception for scope
overrides, and the stated rationale (same-size forward simulation) is contradicted by skipping.

So this is not "a behavior present in the frozen Python reference but not yet ported". Per
`AGENTS.md`'s evidence order (1. language/CLI contracts in `docs/LANGUAGE.md` → 2. the authoritative
Rust implementation), **the documented contract is correct and the authoritative implementation was
violating it.** Three defects stacked:

1. the native CLI violated the documented propagation rule (`rust/fslc/src/verification.rs:2213`,
   `:2234-2240`);
2. the violation was silent — the `implements` key simply disappeared;
3. the recorded acceptance test for that contract
   (`tests/test_implements_bounds_override.py`) calls `fslc.cli.run_verify` in-process and never
   launches the native binary, so nothing guarded the authoritative implementation (#1010).

Resolves #1003.

## Contract change

**None to any public verdict or exit code.** This PR restores documented behavior; the exit-code
table, top-level `result` vocabulary, and `fslc refine` are untouched. `fslc check` / `fslc verify`
keep exiting 0 on a failed inline seam — that separate false green is #1002, deliberately isolated
into its own breaking pull request.

Two envelope effects, both stated rather than slipped in:

| Effect | Before | After |
|---|---|---|
| `implements` field on a scoped `verify` | absent | present, evaluated with overrides propagated |
| `warnings` on a scoped `verify` | model-warning finalization did not run | finalized like an unscoped run, so a spec's `warnings` no longer depend on whether an override was passed |

The second follows from evaluating `implements` at all: model-warning finalization and the
`implements` verdict share the same decoration path, so running one runs the other. Requirement R7
("results must not depend on whether an override was passed") is what supports applying the same
finalization to both; nothing supported the previous asymmetry. What was measured is narrower than
the mechanism: on the #1003 reproducer the change removes one warning kind, `no_user_invariants`,
which only the scoped run had emitted. The warning set was not surveyed across other specs.
Declared in the changelog fragment.

Overrides reaching the abstraction are filtered to the entity/number names the abstraction itself
declares, so an impl-only name cannot become an undeclared-name error against a `spec` abstraction
(the filter runs before `validate_direct_scope_overrides`).

## Test evidence

See the commit for the full five-column gate table (command / log / exit / duration / changed-crate
compile line). Calibration mutations, each isolated and reverted by exact `git diff` equality:

| Mutation (each isolated, reverted by exact `git diff` equality) | Produced | Expected |
|---|---|---|
| delete the filter result and pass empty overrides to the abstraction | `exit 2`, `kind: type`, `map index outside finite key domain` | the detector goes red because the shrunken impl no longer matches the full-size abstract |
| delete the filtering and pass the override through unchanged | `exit 2`, `undeclared entity Extra` | the filter must run before `validate_direct_scope_overrides` |
| restore `has_scope` to the suppression condition | `exit 0`, `result: verified`, `implements` absent | the bypass detector goes red |
| classify `refines` as a failure in `verification_output` | preservation control goes red | the control is live |
| make the timing-leaf predicate always false | exclusion-liveness assertion goes red | a dead exclusion cannot pass silently |

Comment-out and deletion are recorded as distinct mutation forms where a check reads source text.

The with/without-override control compares the **full** envelope. The only excluded leaves are
`elapsed_s` / `check_elapsed_s`, because they are wall-clock measurements that differ between two
runs of the same binary on the same input — measured, not assumed: flattening the envelope over two
runs gave 61 leaves with exactly 7 differing, all of them timings. `bounds_overrides` is asserted as
an expected difference rather than excluded, and an exclusion-liveness check fails if an excluded key
disappears from both sides.

### Corpus compatibility (base vs head, both binaries built separately)

`AGENTS.md` requires the transition set to be stated with the command, both SHAs, and the form
count — never assumed. Each SHA's own `specs/`, `examples/`, and `rust/fslc/tests/fixtures/` were
materialized with `git archive` so `use ... from` imports resolve against that SHA's siblings, and
every `.fsl` was run through that SHA's `fslc check`:

| | base | head |
|---|---|---|
| forms | 476 | 485 (+9 new fixtures) |
| exit histogram | `{0: 340, 2: 136}` | `{0: 348, 2: 137}` |

Forms common to both: 476. **Verdict transitions among them: 0.** No form was removed. The nine
added forms account for the histogram delta exactly (+8 at exit 0, +1 at exit 2).

The one added fixture that exits 2 under a bare `check` (`impl_spec_extra.fsl`) is well-posed only
with the override, by construction: the implementation declares `Item = 1` while its abstraction
declares `Item = 3`, so asserting `refines` under `--instances Item=1 --instances Extra=1` requires
both that `Item` propagated and that the impl-only `Extra` was filtered.
`rust/fslc/tests/corpus_check_sweep.rs` sweeps `specs/` + `examples/` only, so this fixture is
outside the required job's scope.

## Documentation and skills

- `docs/LANGUAGE.md` / `docs/LANGUAGE.ja.md`: the propagation paragraph is **unchanged** — it was
  already correct. Added text covers only what the documentation never stated: that `--property`,
  `--exclude-properties`, and `--from-state` still omit `implements` with no recorded reason.
- `docs/DESIGN-refinement.md`: new section for the propagation rule and the three named suppressors,
  with the follow-up issue URL.
- `skills/fsl/references/layers.md`: propagation rule.
- `docs/intro/language.{en,ja}.html`: regenerated by `tools/build_site_reference.py`, not hand-edited.
- `changelog.d/1003-implements-bounds-override.fixed.md`.

## Remaining scope (not in this PR)

- **#1002** — a failed inline `implements` still exits 0. Breaking exit-code change; next in the stack.
- **#1008** — `--property`, `--exclude-properties`, and `--from-state` omit `implements` silently.
  Same defect class as this issue; the semantics are undecided, so this PR does not decide them and
  does not declare the suppression safe.
- **#1009** — `fslc html` discards the verification status and exits 0 over a `violated` spec.
- **#1010** — the acceptance test for this contract exercises only the frozen Python reference.

## Authorship disclosure

Written by an AI agent team (planning, implementation, and review each in a separate session) under
an orchestrating agent. The review findings that changed this diff were produced by the same
orchestrator that wrote the brief, so that review does not establish series independence — please
read the diff rather than relying on the review rounds.

A separate independent pass covered: the implementation against the verbatim `docs/LANGUAGE.md`
rule; that no exit code, `kind`, `message`, or `warnings` value changed outside the one declared
above; that the comparison control compares the full envelope and its exclusion is live; that the
dialect match is total; and a random sample of claim-to-evidence links.

It did **not** cover: the semantic correctness of the `fsl-core` refinement implementation; the
`rust/fslc/src/main.rs` and `verification_output.rs` changes as a whole; the content of the nine
added fixtures; any judgement of test-suite completeness; the individual results inside the
workspace test run; or the per-form verdicts behind the corpus sweep's aggregate. Those are outside
what the review establishes.

One thing the review saw and deliberately left alone: the `SurfaceDocument` match that decides
whether propagation applies at all is total (every variant named, no wildcard), while the
`SpecItem` match nested inside its `Requirements` arm still ends in a wildcard. The asymmetry is
intentional — a missing dialect arm would drop propagation for a whole dialect silently, whereas a
new entity/number declaration form has to pass through the coupled-change list (grammar, lowering,
typed model, both language references) before it could reach that inner match.
