### PR TITLE
fix(document): project const-valued analysis bounds as evaluated integers (#993)

### DIFF
--- a/changelog.d/993-document-const-bounds.fixed.md
+++ b/changelog.d/993-document-const-bounds.fixed.md
@@ -1,0 +1,17 @@
+Fixed (#993): `fslc document claims` no longer rejects a `verify { values N =
+lo..hi }` bound written with compile-time consts. The projector now reads the
+evaluated `KernelModel::types` domain bounds the model already built, so RCIR
+v1's `analysis_scope.values[].lo/hi` carry plain integers and the renderer
+shows `-1` to `2`. This aligns the projector with `docs/LANGUAGE.md`, which has
+always written the bound as `values <Number> = <lo>..<hi>` without restricting
+it to integer literals — it does not widen a documented contract. RCIR v1's
+schema is unchanged, and existing literal bounds project byte-identically. A
+`values` bound naming a number the spec never declares is not rejected either,
+so no `values` bound makes `document claims` refuse a `requirements` spec that
+`fslc check` accepts; a dialect RCIR v1 has no adapter for is still refused, as
+a scope boundary. Rejection of a
+non-constant bound is unchanged and now carries the model's own message
+(`unknown constant 'LO'` rather than `must be an integer literal`); a
+preservation control pins that, and separate detectors cover the evaluated,
+literal-fallback, and omitted cases. `fslc diff` still drops such a bound
+silently — that surface is tracked in #997, not fixed here.

--- a/docs/DESIGN-document-controlled-language-renderer.md
+++ b/docs/DESIGN-document-controlled-language-renderer.md
@@ -129,9 +129,8 @@ just wording discipline:
 their own section with a fixed "not a verification condition" disclaimer.
 `analysis_scope` (`instances`/`values`) renders in its own section with a
 fixed "these are analysis bounds, not operational capacity" disclaimer;
-numeric bounds are read from RCIR's normalized-AST `["num", N]` shape and
-shown as the plain number (any other shape — e.g. a `const` reference — falls
-back to a compact JSON dump rather than fabricating a value).
+numeric bounds are plain evaluated integers from RCIR and are shown as the
+bare number.
 
 A claim referenced by more than one requirement (RCIR's many-to-many
 relation) renders in full only the first time it is encountered while
@@ -149,14 +148,14 @@ anywhere in the renderer. Two runs over the same `RequirementClaimSet` and
 
 ## Verification evidence
 
-`rust/fsl-tools/tests/document_render.rs` (28 tests): an exact byte-for-byte
+`rust/fsl-tools/tests/document_render.rs` (29 tests): an exact byte-for-byte
 golden match of `examples/pm/cancel_system.fsl`'s REQ-2 in both locales
 (issue #326's acceptance criterion 1 — two guards, a struct-literal update,
 and fairness, all present); requirement text and formalized meaning kept in
 separate sections; the acceptance/forbidden non-generalization disclaimer
 (with a negative check that no absolute-guarantee phrasing appears);
 analysis-scope's not-a-capacity disclaimer and correct plain-number
-rendering; byte-identical repeated renders; `requires`-as-enablement and
+rendering (including negative compile-time const bounds); byte-identical repeated renders; `requires`-as-enablement and
 `not`-is-preserved meaning-fidelity checks; the transition-rule N-AND
 special case together with `old(...)`; the deadline/progress/reachability
 distinctions; undecided exclusion from claims; a forbidden case with an

--- a/docs/DESIGN-document-requirement-claim-ir.md
+++ b/docs/DESIGN-document-requirement-claim-ir.md
@@ -173,7 +173,9 @@ digest even though the claim record itself only holds a reference.
   annotation's span; `undecided_declarations`'s existing JSON output and callers
   are unchanged (it is now a thin projection over the typed records). Undecided
   items are metadata, never claims, and never verification conditions.
-- `analysis_scope` carries authored `verify { instances ...; values ... }` bounds.
+- `analysis_scope` carries the authored `verify { instances ...; values ... }`
+  bounds it can resolve to integers; a `values` bound naming a number the spec
+  never declares is omitted when it cannot (see the end of this item).
   **These do not survive kernel lowering**: `entity`/`number` declarations plus
   their `verify` bounds are fully consumed by `lower_requirements` into concrete
   bounded types (an `entity Case` + `verify { instances Case = 2 }` becomes a plain
@@ -181,7 +183,12 @@ digest even though the claim record itself only holds a reference.
   `_from_source` entry point instead reads `RequirementsItem::Common(SpecItem::
   VerifyBounds { .. })` directly from the parsed `SurfaceRequirements` — the same
   surface tree it already inspects for `implements` names — before lowering
-  erases it, and passes the result into `DocumentInput::analysis_scope`. Direct
+  erases it, and passes the result into `DocumentInput::analysis_scope`. The
+  number name comes from that surface tree; when `KernelModel::types` holds a
+  `TypeDef::Domain` for the name, `lo`/`hi` are the compile-time evaluated
+  bounds from model construction (the same constant expressions `fslc check`
+  accepts). Otherwise the projector falls back to integer literals in the
+  surface tree; unresolvable bounds are skipped. Direct
   `spec` dialect has no `entity`/`number`/`verify` concept at all, so its
   `analysis_scope` is always empty. Scope is disclosure of analysis coverage, not a
   system limit, and is never merged into requirement bodies.
@@ -325,13 +332,23 @@ classifies checked nodes and serializes them.
 
 ## Verification evidence
 
-`rust/fsl-tools/tests/document.rs` (29 tests) against
-`examples/pm/cancel_system.fsl` and two dedicated fixtures
+`rust/fsl-tools/tests/document.rs` (34 tests) against
+`examples/pm/cancel_system.fsl` and seven dedicated fixtures
 (`document_claims_fixture.fsl` — kernel-wrapper `requirements` covering `trans`,
 `reachable`, `leadsTo`, `terminal`, a deadline, `forbidden`, a multi-statement
 requirement, a multi-requirement action, `@undecided`, and `entity`/`number`/
 `verify` bounds; `document_kpi_fixture.fsl` — the process+data profile plus a
-`kpi` projection):
+`kpi` projection; `document_const_bound_fixture.fsl` — compile-time const
+`verify { values ... }` bounds projected as evaluated integers;
+`document_const_bound_reject_fixture.fsl` — preservation control for undefined
+const bounds (the rejection comes from `build_model`, so it keeps passing when
+this change is reverted); `document_const_bound_undeclared_literal_fixture.fsl`
+— undeclared number names with literal bounds, a detector cited for the
+mutation "reject when `KernelModel::types` has no entry" and a preservation
+control with respect to the revert (its bounds are all literals, so pre-fix
+output is byte-identical); `document_const_bound_undeclared_const_fixture.fsl`
+— undeclared number names with const bounds skipped without rejection, a
+detector for the revert and for one mutation per independent assertion):
 
 - projection completeness (exact target-universe partition, all nine claim kinds,
   unattributed claims are still emitted, dialect rejection is fail-closed);
@@ -349,6 +366,16 @@ requirement, a multi-requirement action, `@undecided`, and `entity`/`number`/
   `terminal_rule` under a stripped origin registry, never for claims with a real
   declared span);
 - undecided/analysis-scope separation from claims;
-- schema validation of every fixture's output against
+- compile-time const `verify { values ... }` bounds project as evaluated
+  integers, and a `values` bound naming a number the spec never declares is not
+  rejected — it projects through the integer-literal path when it can and is
+  omitted otherwise, so no `values` bound causes `document claims` to refuse a
+  `requirements` input that `check` accepts (a dialect outside
+  `RCIR_SUPPORTED_DIALECTS` is still refused, as a scope boundary);
+- schema validation of the output of every fixture that projects, against
   `requirement-claims.v1.schema.json` via the `jsonschema` crate, plus one negative
-  control (a truncated document fails validation).
+  control (a truncated document fails validation). Two fixtures are excluded,
+  each because it has no projected output to validate at all:
+  `document_const_bound_reject_fixture.fsl` (`build_model` rejects it first) and
+  `document_unsupported_dialect_broken_model_fixture.fsl` (`dbsystem` is outside
+  `RCIR_SUPPORTED_DIALECTS`).

--- a/rust/fsl-tools/src/document_project.rs
+++ b/rust/fsl-tools/src/document_project.rs
@@ -13,13 +13,13 @@ use std::path::Path;
 use fsl_core::{
     ActionDef, ActionGuard, Annotation, Annotations, FsResolver, INIT_TARGET, KernelModel,
     KernelSpec, OriginChain, ParamDef, PublicKernelVersion, RequirementLink, RequirementsTraceCase,
-    RequirementsTraceContract, RequirementsTraceExpectation, TERMINAL_TARGET, TypeRef,
+    RequirementsTraceContract, RequirementsTraceExpectation, TERMINAL_TARGET, TypeDef, TypeRef,
     action_target, build_model, display_name, parse_kernel_source, property_target,
     public_kernel_contract_for_version, public_kernel_expression, requirements_trace_contract,
 };
 use fsl_syntax::{
-    Expr, RequirementsItem, SourceFile, SourcePos, Span, SpecItem, SurfaceDocument, VerifyItem,
-    parse_document,
+    Expr, ParsedDocument, RequirementsItem, SourceFile, SourcePos, Span, SpecItem, SurfaceDocument,
+    VerifyItem, parse_document,
 };
 use serde_json::{Value, json};
 
@@ -95,12 +95,30 @@ pub struct DocumentInput<'a> {
 /// consumed during `lower_requirements` (folded into concrete bounded types)
 /// and leave no trace in the lowered `KernelSpec`/`SurfaceSpec`, so analysis
 /// scope must be read from the surface `requirements` tree directly, the same
-/// way `implements` names are.
+/// way `implements` names are. Number names come from that tree; when
+/// `KernelModel::types` holds a `TypeDef::Domain` for the name, `lo`/`hi` are
+/// the compile-time evaluated bounds from model construction (the same
+/// expressions `fslc check` accepts). Otherwise the projector falls back to
+/// integer literals in the surface tree; unresolvable bounds are skipped
+/// rather than reported. This function has no rejection path at all, which is
+/// the point: no `values` bound can make `project_requirement_claims_from_source`
+/// refuse a `requirements` input that `fslc check` accepts. (A dialect outside
+/// `RCIR_SUPPORTED_DIALECTS` is still refused there, by design — that is a
+/// scope boundary, not a bound.)
 fn requirements_analysis_scope(
     requirements: &fsl_syntax::SurfaceRequirements,
-) -> Result<AnalysisScope, String> {
+    model: &KernelModel,
+) -> AnalysisScope {
     let mut instances = Vec::new();
     let mut values = Vec::new();
+    let literal_bound = |expr: &Expr| match expr {
+        Expr::Num(value) => Some(*value),
+        Expr::Neg(inner) => match inner.as_ref() {
+            Expr::Num(value) => value.checked_neg(),
+            _ => None,
+        },
+        _ => None,
+    };
     for item in &requirements.items {
         if let RequirementsItem::Common(SpecItem::VerifyBounds { items, .. }) = item {
             for verify_item in items {
@@ -109,31 +127,29 @@ fn requirements_analysis_scope(
                         instances.push(json!({"entity": name, "count": count}));
                     }
                     VerifyItem::Values(name, lo, hi, _) => {
-                        let bound = |expr: &Expr| match expr {
-                            Expr::Num(value) => Some(*value),
-                            Expr::Neg(inner) => match inner.as_ref() {
-                                Expr::Num(value) => value.checked_neg(),
+                        let resolved = if let Some(TypeDef::Domain { lo, hi, .. }) =
+                            model.types.get(name.as_str())
+                        {
+                            Some((*lo, *hi))
+                        } else {
+                            match (literal_bound(lo), literal_bound(hi)) {
+                                (Some(lo), Some(hi)) => Some((lo, hi)),
                                 _ => None,
-                            },
-                            _ => None,
+                            }
                         };
-                        let lo = bound(lo).ok_or_else(|| {
-                            format!("analysis bound for '{name}' must be an integer literal")
-                        })?;
-                        let hi = bound(hi).ok_or_else(|| {
-                            format!("analysis bound for '{name}' must be an integer literal")
-                        })?;
-                        values.push(json!({
-                            "number": name,
-                            "lo": lo,
-                            "hi": hi,
-                        }));
+                        if let Some((lo, hi)) = resolved {
+                            values.push(json!({
+                                "number": name,
+                                "lo": lo,
+                                "hi": hi,
+                            }));
+                        }
                     }
                 }
             }
         }
     }
-    Ok(AnalysisScope { instances, values })
+    AnalysisScope { instances, values }
 }
 
 /// Parse, lower, build, and project `source` in one call (test/tooling
@@ -150,12 +166,23 @@ pub fn project_requirement_claims_from_source(
     source_path: Option<&str>,
     resolver_root: &Path,
 ) -> Result<RequirementClaimSet, DocumentProjectionError> {
-    let (dialect, implements_names, analysis_scope) = projection_context(source)?;
+    let parsed = parse_document(SourceFile::new(source))
+        .map_err(|error| DocumentProjectionError::Other(error.to_string()))?;
+    if !matches!(
+        &parsed.surface,
+        SurfaceDocument::Spec(_) | SurfaceDocument::Requirements(_)
+    ) {
+        return Err(DocumentProjectionError::UnsupportedDialect {
+            dialect: surface_dialect_name(&parsed.surface),
+        });
+    }
     let resolver = FsResolver::new(resolver_root);
     let kernel = parse_kernel_source(source, &resolver)
         .map_err(|error| DocumentProjectionError::Other(error.to_string()))?;
     let model = build_model(kernel.clone())
         .map_err(|error| DocumentProjectionError::Other(error.to_string()))?;
+    let (dialect, implements_names, analysis_scope) =
+        projection_context_from_parsed(&parsed, &model)?;
     project_requirement_claims(&DocumentInput {
         kernel: &kernel,
         model: &model,
@@ -170,9 +197,17 @@ pub fn project_requirement_claims_from_source(
 
 fn projection_context(
     source: &str,
+    model: &KernelModel,
 ) -> Result<(DocumentDialect, Vec<String>, AnalysisScope), DocumentProjectionError> {
     let parsed = parse_document(SourceFile::new(source))
         .map_err(|error| DocumentProjectionError::Other(error.to_string()))?;
+    projection_context_from_parsed(&parsed, model)
+}
+
+fn projection_context_from_parsed(
+    parsed: &ParsedDocument,
+    model: &KernelModel,
+) -> Result<(DocumentDialect, Vec<String>, AnalysisScope), DocumentProjectionError> {
     Ok(match &parsed.surface {
         SurfaceDocument::Spec(_) => (DocumentDialect::Spec, Vec::new(), AnalysisScope::default()),
         SurfaceDocument::Requirements(requirements) => {
@@ -187,8 +222,7 @@ fn projection_context(
             (
                 DocumentDialect::Requirements,
                 names,
-                requirements_analysis_scope(requirements)
-                    .map_err(DocumentProjectionError::Other)?,
+                requirements_analysis_scope(requirements, model),
             )
         }
         other => {
@@ -1224,7 +1258,7 @@ pub(crate) fn project_renderer_contract(
     trace: Option<&RequirementsTraceContract>,
 ) -> Result<RequirementClaimSet, String> {
     let (dialect, implements_names, analysis_scope) =
-        projection_context(source).map_err(|error| error.to_string())?;
+        projection_context(source, model).map_err(|error| error.to_string())?;
     project_requirement_claims_with_trace(
         &DocumentInput {
             kernel,

--- a/rust/fsl-tools/src/document_render.rs
+++ b/rust/fsl-tools/src/document_render.rs
@@ -626,15 +626,10 @@ fn undecided_section(claims: &RequirementClaimSet, locale: Locale) -> String {
     format!("{head}\n\n{intro}\n\n{blocks}")
 }
 
-/// `verify { values N = lo..hi }` bounds are almost always plain integer
-/// literals (normalized AST shape `["num", N]`); show the bare number rather
-/// than the raw AST JSON. Anything else (e.g. a const reference) falls back
-/// to a compact JSON dump rather than fabricating a number.
+/// RCIR stores compile-time evaluated integer bounds in `lo`/`hi`; render them
+/// as plain numbers rather than raw JSON.
 fn ast_bound_text(value: &serde_json::Value) -> String {
-    match value.as_array().map(Vec::as_slice) {
-        Some([tag, number]) if tag.as_str() == Some("num") => number.to_string(),
-        _ => value.to_string(),
-    }
+    value.to_string()
 }
 
 fn analysis_scope_section(claims: &RequirementClaimSet, locale: Locale) -> String {

--- a/rust/fsl-tools/tests/document.rs
+++ b/rust/fsl-tools/tests/document.rs
@@ -44,6 +44,34 @@ fn kpi_fixture() -> (String, PathBuf) {
     )
 }
 
+fn const_bound_fixture() -> (String, PathBuf) {
+    (
+        read("tests/fixtures/document_const_bound_fixture.fsl"),
+        manifest_path("tests/fixtures"),
+    )
+}
+
+fn const_bound_reject_fixture() -> (String, PathBuf) {
+    (
+        read("tests/fixtures/document_const_bound_reject_fixture.fsl"),
+        manifest_path("tests/fixtures"),
+    )
+}
+
+fn const_bound_undeclared_literal_fixture() -> (String, PathBuf) {
+    (
+        read("tests/fixtures/document_const_bound_undeclared_literal_fixture.fsl"),
+        manifest_path("tests/fixtures"),
+    )
+}
+
+fn const_bound_undeclared_const_fixture() -> (String, PathBuf) {
+    (
+        read("tests/fixtures/document_const_bound_undeclared_const_fixture.fsl"),
+        manifest_path("tests/fixtures"),
+    )
+}
+
 fn claim_digest<'a>(set: &'a RequirementClaimSet, id: &str) -> &'a str {
     &set.claims
         .iter()
@@ -733,6 +761,120 @@ fn verify_bounds_project_into_analysis_scope_only() {
     assert!(!claim_text.contains("\"Budget\""));
 }
 
+/// Detector for removing the early dialect check in
+/// `project_requirement_claims_from_source`. This issue moved `build_model`
+/// ahead of the analysis-scope extraction; without that check the model error
+/// wins and the projector returns `Other(..)`, which contradicts
+/// `DocumentProjectionError`'s contract (issue #334) that `UnsupportedDialect`
+/// marks a scope boundary rather than a defective input.
+///
+/// `rust/fslc/tests/document_cli.rs` already covers an unsupported dialect
+/// whose model builds cleanly; that case cannot detect the removal. With a
+/// clean model, execution reaches `projection_context_from_parsed`, which
+/// returns the same `UnsupportedDialect` the early check would have — so the
+/// observable outcome is identical with or without it. What separates the two
+/// is an input that also fails between surface parsing and that later check;
+/// this fixture uses a model failure, but a `parse_kernel_source` failure
+/// would separate them too.
+#[test]
+fn unsupported_dialect_reports_scope_not_a_model_defect() {
+    let source = read("tests/fixtures/document_unsupported_dialect_broken_model_fixture.fsl");
+    let root = manifest_path("tests/fixtures");
+    let error = fsl_tools::project_requirement_claims_from_source(
+        &source,
+        Some("document_unsupported_dialect_broken_model_fixture.fsl"),
+        &root,
+    )
+    .expect_err("an unsupported dialect must not project");
+    assert_eq!(
+        error,
+        fsl_tools::DocumentProjectionError::UnsupportedDialect {
+            dialect: "dbsystem"
+        },
+        "expected a scope boundary, got: {error}"
+    );
+}
+
+#[test]
+fn const_bound_analysis_scope_uses_evaluated_domain_bounds() {
+    let (source, root) = const_bound_fixture();
+    let claims = project(&source, "document_const_bound_fixture.fsl", &root);
+
+    let value = claims
+        .analysis_scope
+        .values
+        .iter()
+        .find(|entry| entry["number"] == "Amount")
+        .expect("Amount analysis bound is projected");
+    assert_eq!(value["lo"], serde_json::json!(-1));
+    assert_eq!(value["hi"], serde_json::json!(2));
+}
+
+/// Preservation control, not a detector: the rejection comes from
+/// `build_model`, so the inner RCIR construction is never reached and the test
+/// keeps passing when this issue's change is reverted. It establishes only that an undefined
+/// const in a `verify { values ... }` bound still fails closed.
+#[test]
+fn undefined_const_bound_still_fails_via_model_build() {
+    let (source, root) = const_bound_reject_fixture();
+    let error = fsl_tools::project_requirement_claims_from_source(
+        &source,
+        Some("document_const_bound_reject_fixture.fsl"),
+        &root,
+    )
+    .expect_err("undefined const in verify values bound must fail projection");
+    assert!(
+        error.to_string().contains("unknown constant 'LO'"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn undeclared_number_literal_bound_projects_via_literal_fallback() {
+    let (source, root) = const_bound_undeclared_literal_fixture();
+    let claims = project(
+        &source,
+        "document_const_bound_undeclared_literal_fixture.fsl",
+        &root,
+    );
+
+    let ghost = claims
+        .analysis_scope
+        .values
+        .iter()
+        .find(|entry| entry["number"] == "Ghost")
+        .expect("undeclared Ghost literal bound is projected");
+    assert_eq!(ghost["lo"], serde_json::json!(1));
+    assert_eq!(ghost["hi"], serde_json::json!(3));
+}
+
+#[test]
+fn undeclared_number_const_bound_is_skipped_not_rejected() {
+    let (source, root) = const_bound_undeclared_const_fixture();
+    let claims = project(
+        &source,
+        "document_const_bound_undeclared_const_fixture.fsl",
+        &root,
+    );
+
+    assert!(
+        claims
+            .analysis_scope
+            .values
+            .iter()
+            .all(|entry| entry["number"] != "Ghost"),
+        "undeclared Ghost const bound must not appear in analysis_scope"
+    );
+    assert!(
+        claims
+            .analysis_scope
+            .values
+            .iter()
+            .any(|entry| entry["number"] == "Amount"),
+        "declared Amount bound is still projected"
+    );
+}
+
 // --- Schema conformance ---------------------------------------------------------
 
 fn compiled_schema() -> jsonschema::Validator {
@@ -759,7 +901,20 @@ fn compiled_schema() -> jsonschema::Validator {
 #[test]
 fn rcir_output_validates_against_the_v1_schema() {
     let validator = compiled_schema();
-    let fixtures: [(String, PathBuf, &str); 3] = [
+    // Every fixture that projects. Two are excluded, each because it has no
+    // projected output at all to validate, not because its output varies:
+    //
+    // - `document_const_bound_reject_fixture.fsl` — `build_model` rejects its
+    //   undefined const before the projector runs (see
+    //   `undefined_const_bound_still_fails_via_model_build`).
+    // - `document_unsupported_dialect_broken_model_fixture.fsl` — `dbsystem`
+    //   is outside `RCIR_SUPPORTED_DIALECTS` (see
+    //   `unsupported_dialect_reports_scope_not_a_model_defect`).
+    //
+    // Adding a projecting fixture without adding it here silently drops it
+    // from schema validation; the count in the type below is the only thing
+    // that forces this comment to be re-read.
+    let fixtures: [(String, PathBuf, &str); 6] = [
         (cancel_system().0, cancel_system().1, "cancel_system.fsl"),
         (
             claims_fixture().0,
@@ -767,6 +922,21 @@ fn rcir_output_validates_against_the_v1_schema() {
             "document_claims_fixture.fsl",
         ),
         (kpi_fixture().0, kpi_fixture().1, "document_kpi_fixture.fsl"),
+        (
+            const_bound_fixture().0,
+            const_bound_fixture().1,
+            "document_const_bound_fixture.fsl",
+        ),
+        (
+            const_bound_undeclared_literal_fixture().0,
+            const_bound_undeclared_literal_fixture().1,
+            "document_const_bound_undeclared_literal_fixture.fsl",
+        ),
+        (
+            const_bound_undeclared_const_fixture().0,
+            const_bound_undeclared_const_fixture().1,
+            "document_const_bound_undeclared_const_fixture.fsl",
+        ),
     ];
     for (source, root, path) in fixtures {
         let claims = project(&source, path, &root);

--- a/rust/fsl-tools/tests/document_render.rs
+++ b/rust/fsl-tools/tests/document_render.rs
@@ -46,6 +46,14 @@ fn kpi_fixture() -> Fixture {
     }
 }
 
+fn const_bound_fixture() -> Fixture {
+    Fixture {
+        source: read("tests/fixtures/document_const_bound_fixture.fsl"),
+        root: manifest_path("tests/fixtures"),
+        source_path: "document_const_bound_fixture.fsl".to_owned(),
+    }
+}
+
 fn render(fixture: &Fixture, locale: Locale) -> (RequirementClaimSet, RenderedDocument) {
     let claims = fsl_tools::project_requirement_claims_from_source(
         &fixture.source,
@@ -555,6 +563,16 @@ fn analysis_scope_numeric_bounds_render_as_plain_numbers() {
     );
     // Never the raw normalized-AST JSON shape leaking into the document.
     assert!(!ja.markdown.contains("[\"num\""));
+}
+
+#[test]
+fn const_bound_analysis_scope_renders_evaluated_negative_bounds() {
+    let fixture = const_bound_fixture();
+    let (_, en) = render(&fixture, Locale::En);
+    assert!(
+        en.markdown
+            .contains("Analysis range of number `Amount`: `-1` to `2`")
+    );
 }
 
 // --- Acceptance criterion 5: repeated runs are byte-identical. ---

--- a/rust/fsl-tools/tests/fixtures/document_const_bound_fixture.fsl
+++ b/rust/fsl-tools/tests/fixtures/document_const_bound_fixture.fsl
@@ -1,0 +1,10 @@
+// Synthetic fixture for issue #993. Exercises compile-time const `verify {
+// values ... }` bounds projected as evaluated integers in RCIR analysis_scope.
+requirements ConstBound {
+  number Amount
+  const LO = -1
+  const HI = 2
+  state { amount: Amount }
+  init { amount = 0 }
+}
+verify { values Amount = LO..HI }

--- a/rust/fsl-tools/tests/fixtures/document_const_bound_reject_fixture.fsl
+++ b/rust/fsl-tools/tests/fixtures/document_const_bound_reject_fixture.fsl
@@ -1,0 +1,10 @@
+// Preservation control for issue #993 / R8. Undefined const in a verify values
+// bound is rejected by model construction, so the RCIR projection this issue
+// changes is never reached and this control keeps passing under a revert.
+requirements RejectConstBound {
+  number Amount
+  const HI = 2
+  state { amount: Amount }
+  init { amount = 0 }
+}
+verify { values Amount = LO..HI }

--- a/rust/fsl-tools/tests/fixtures/document_const_bound_undeclared_const_fixture.fsl
+++ b/rust/fsl-tools/tests/fixtures/document_const_bound_undeclared_const_fixture.fsl
@@ -1,0 +1,17 @@
+// Issue #993. Undeclared number name with const bounds has no model type and
+// no literal fallback; the entry is skipped (exit 0, no Ghost).
+//
+// Detector for reverting this issue's change: the pre-fix projector rejects
+// this input outright (measured: exit 2, `analysis bound for 'Ghost' must be
+// an integer literal`), so projection fails and the test fails. It is also a
+// detector for two narrower mutations, one per independent assertion —
+// resolving `Expr::Var` from `KernelModel::consts` makes `Ghost` appear, and
+// emptying `values` on any unresolvable name makes `Amount` disappear.
+requirements UndeclaredConstBound {
+  number Amount
+  const LO = 1
+  const HI = 3
+  state { amount: Amount }
+  init { amount = 0 }
+}
+verify { values Amount = 0..2; values Ghost = LO..HI }

--- a/rust/fsl-tools/tests/fixtures/document_const_bound_undeclared_literal_fixture.fsl
+++ b/rust/fsl-tools/tests/fixtures/document_const_bound_undeclared_literal_fixture.fsl
@@ -1,0 +1,15 @@
+// Issue #993. Undeclared number name with integer-literal bounds must still
+// project via the literal fallback path.
+//
+// Detector cited for the mutation "return `Err` when `KernelModel::types` has
+// no entry for the name" — that implementation turns this input's exit 0 into
+// exit 2 and the test fails. It is a *preservation control* with respect to
+// reverting this issue's change: every bound here is an integer literal, so
+// the pre-fix projector produces byte-identical output (measured: exit 0,
+// `Amount 0..2` + `Ghost 1..3`). Do not cite it as a detector for the revert.
+requirements UndeclaredLiteralBound {
+  number Amount
+  state { amount: Amount }
+  init { amount = 0 }
+}
+verify { values Amount = 0..2; values Ghost = 1..3 }

--- a/rust/fsl-tools/tests/fixtures/document_unsupported_dialect_broken_model_fixture.fsl
+++ b/rust/fsl-tools/tests/fixtures/document_unsupported_dialect_broken_model_fixture.fsl
@@ -1,0 +1,37 @@
+// Issue #993. An unsupported dialect whose model also fails to build.
+//
+// Detector for removing the early dialect check in
+// `project_requirement_claims_from_source`: this issue moved `build_model`
+// ahead of the analysis-scope extraction, so without that check the model
+// error wins and the projector returns `Other(..)` instead of
+// `UnsupportedDialect`. `DocumentProjectionError`'s own contract (issue #334)
+// exists to let a caller tell a scope boundary apart from a defective input,
+// so `Other(..)` here would report an out-of-scope dialect as a bad spec.
+//
+// `reads users.nonexistent_column` is the model failure; `dbsystem` is the
+// out-of-scope dialect. Both must be present for this fixture to establish
+// anything — a dbsystem spec with a clean model is already covered by
+// `rust/fslc/tests/document_cli.rs`.
+dbsystem UnsupportedDialectBrokenModel {
+  database app {
+    schema 0
+    table users {
+      column id: Int present backfilled not_null;
+    }
+  }
+
+  artifact server_v1 {
+    reads users.nonexistent_column;
+    writes users.id;
+  }
+
+  environment prod {
+    schema 0..0;
+    active server_v1 when schema 0..0;
+    supported server_v1 when schema 0..0;
+  }
+
+  check compatibility {
+    rule all_active_reads_exist;
+  }
+}


### PR DESCRIPTION
## 問題

FSL として有効で `fslc check` を exit 0 で通る const-valued analysis bound を、
`fslc document claims` が `analysis bound for 'Amount' must be an integer literal` で拒否していた（exit 2）。

```console
$ fslc check const-bound.fsl        # verify { values Amount = LO..HI }, const LO = -1, const HI = 2
# exit 0
$ fslc document claims const-bound.fsl
{"result":"error","kind":"semantics","message":"analysis bound for 'Amount' must be an integer literal"}
# exit 2
```

## 契約の変更 —— **文書化された契約を広げるのではない**

**`docs/LANGUAGE.md` は最初から const bound を排除していない。narrower だったのは projector だけである。**

実測3件（`origin/main` = `dbbf6889a0c1f3001552952ffc537632a01f8188`）:

1. `docs/LANGUAGE.md:84` と `docs/LANGUAGE.ja.md:82` はどちらも `values <Number> = <lo>..<hi>` という
   **総称のプレースホルダ**で、整数 literal に限る記述が無い
2. `docs/LANGUAGE.md:2144` / `docs/LANGUAGE.ja.md:2079` も「範囲は `verify { values Amount = lo..hi }` に住む」だけ
3. `git grep -n "integer literal" dbbf6889 -- docs/ skills/` = **3件のみ**で、すべて `Seq<T, N>` の
   capacity の説明（`docs/DESIGN-seq.md:22,28` / `docs/DESIGN-v1.md:161`）。
   **document pipeline の受理範囲を「整数 literal に限る」と書いた文書は存在しない**

したがってこの変更は **projector を `docs/LANGUAGE.md` の記述へ合わせる**ものである。
作者の裁定と、この訂正は issue に記録されている:
<https://github.com/ymm-oss/fsl/issues/993#issuecomment-5566353019>

**リポジトリ内の前例**（新しい語彙を発明していない）:

- 挙動の前例 —— `docs/LANGUAGE.md:2180-2182`（`docs/LANGUAGE.ja.md:2113-2117` に 1:1 で対応）逐語:
  > Action arguments in `acceptance`/`forbidden` steps accept enum member names
  > and const names in addition to numeric literals (e.g. `answer(0, Triggered)`
  > is equivalent to `answer(0, 1)` when `Triggered` is `Trigger`'s second
  > member) — **an undefined name is a check-time error**.

  const 名を数値 literal に加えて受理し、**未定義の名前は check 時エラー**にするのが既存の型である。
  本変更の挙動はこれと同型（未定義 const → `unknown constant 'LO'` → exit 2）。
- 文言の前例 —— `docs/DESIGN-seq.md:28` 逐語:
  > N is a positive constant expression (an integer literal or a const name).

## 実装 —— 既存の評価器へ委譲する（第2の評価器を書かない）

`rust/fsl-tools/src/document_project.rs` の `requirements_analysis_scope` が、
`KernelModel::types`（pub フィールド）の **評価済み** `TypeDef::Domain { lo: i64, hi: i64 }` を読む。
評価は `rust/fsl-core/src/model.rs` の `collect_types` → `eval_const` が既に済ませている。

- **`rust/fsl-core/` を1行も変更していない。** 新しい公開 API を増やしていない
- **`eval_const` 相当を projector 側に書いていない。** リポジトリ内の const 評価器は1本のままである
  （手書きの2本目が AST drift を起こし #698 で共有 walker へ寄せ直した前例を再現しない）
- 変更の本質は **projector から判定を取り除き、既存の単一の評価器へ委譲すること**である。
  結果として `requirements_analysis_scope` は `Result` を返さなくなった
- `projection_context` の呼び出し元は2箇所あり、**両方**を直している（half-fix にしていない）
- 非対応 dialect の早期チェックを維持している。これが無いと `build_model` を前に出した結果、
  `FSL-DOC-DIALECT-UNSUPPORTED` ではなく model エラーが出る
  （`rust/fslc/tests/document_cli.rs:295-317` / `:319-340` が envelope を逐語 pin している）

**RCIR v1 schema は変更していない**（`schemas/fslc/document/requirement-claims.v1.schema.json`）。
評価済み整数を出すので `lo`/`hi` は plain integer のままである。

## 宣言のない名前への bound —— 拒否しない

`lower_requirements` は宣言のない名前の `values` bound を黙って捨てるので、
その名前は `KernelModel::types` に存在しない。**そこで `Err` を返すと
`fslc check` が通す入力を `document claims` が拒否することになり、直している欠陥を別の構文で
再生産する。** よって:

- `KernelModel::types` に `Domain` がある → 評価済み `lo`/`hi`
- 無い → 既存の整数 literal 経路へフォールバック（**今日と同一の出力**）
- literal でも解決できない → **entry を出さない**。`Err` にしない

**entry を出さないことは model と一致している**（model はその名前を bound していない）。
逆に、literal 経路が出す entry は model に存在しない number の entry であり、
それ自体が hollow である。**既存出力を1バイトも変えないためにそれは保存し、除去は #997 の裁定へ回した。**

## 検証

すべて rebase 後の `e24ecbe9`（base `18a9b99b`）に対する測定。binary は sha256 で固定した:
base `7d7fb5bfb19b0d11ffa7c741112d2f74356057652b7653b16b92f67ba6f287a9`（`git worktree add --detach 18a9b99b`
で切った別 checkout でビルド）/ head `043463687b17f17d1fd6bf3c8395e3b6bf02917660e2b8d6946864f25b719826`。

### 校正（修正前に落ち、修正後に通ることを実測）

入力は `rust/fsl-tools/tests/fixtures/document_const_bound_fixture.fsl`（issue 本文と同じ spec）。

| binary | `fslc check` | `fslc document claims` | 出力 |
| --- | --- | --- | --- |
| base `18a9b99b` | exit 0 | **exit 2** | `analysis bound for 'Amount' must be an integer literal` |
| head `e24ecbe9` | exit 0 | **exit 0** | `{"number":"Amount","lo":-1,"hi":2}` |

### R3: 既存 literal 出力が1バイトも変わらない（封筒全体の比較）

フィールドを手で選んでいない。**出力全体を `diff` した。**

| fixture | 出力 | `diff` | bytes |
| --- | --- | --- | --- |
| `document_claims_fixture.fsl` | `document claims` | **exit 0** | 154869 / 154869 |
| `document_claims_fixture.fsl` | `document generate` | **exit 0** | 24160 / 24160 |
| `document_kpi_fixture.fsl` | `document claims` | **exit 0** | 92619 / 92619 |
| `document_kpi_fixture.fsl` | `document generate` | **exit 0** | 15691 / 15691 |

### 検査の校正（分岐単位で11件。関数単位ではない）

1関数が独立した失敗理由を複数束ねている場合、理由ごとに1つ mutation を注入した。
すべて隔離注入で、戻したことは baseline との byte 一致（sha256）で確認した。

| 分岐 | 注入 | 注入時 | 落ちた assert / produced |
| --- | --- | --- | --- |
| 評価済み bound: entry 存在 | revert（`Err` を返す旧実装） | exit 101 | `project …: analysis bound for 'Amount' must be an integer literal` |
| 同: `lo == -1` | 置換 `Some((*hi,*hi))` | exit 101 | left `Number(2)` / right `Number(-1)` |
| 同: `hi == 2` | 置換 `Some((*lo,*lo))` | exit 101 | left `Number(-1)` / right `Number(2)` |
| literal fallback: entry 存在 | `types` に無いとき `Err` | exit 101 | `analysis bound for 'Ghost' must be an integer literal` |
| 同: `lo == 1` | fallback の lo/hi 取り違え | exit 101 | left `Number(3)` / right `Number(1)` |
| 同: `hi == 3` | 同（別注入） | exit 101 | left `Number(1)` / right `Number(3)` |
| skip: `Ghost` 不在 | `model.consts` から `Expr::Var` を解決 | exit 101 | `undeclared Ghost const bound must not appear in analysis_scope` |
| skip: `Amount` 存在 | 未解決時に `values.clear()` | exit 101 | `declared Amount bound is still projected` |
| renderer の `-1` to `2` | `ast_bound_text` が常に `"MUTANT"` を返す | exit 101 | `document_render.rs:572`。**同時に `analysis_scope_numeric_bounds_render_as_plain_numbers`（`:560`）も落ちた** |
| schema 適合 | `"lo"` に `json!("x")` | exit 101 | `document_claims_fixture.fsl failed schema validation: ["\"x\" is not of type \"integer\""]` |
| 早期 dialect チェック | 削除 | exit 101 | left `Other("invalid model expression: … 'col_users_nonexistent_column' …")` / right `UnsupportedDialect { dialect: "dbsystem" }` |

**校正できなかった分岐が1つある。** `undefined_const_bound_still_fails_via_model_build` は
preservation control で、`build_model` が拒否するため RCIR 構築に到達しない。**revert しても通り続ける**
（base で exit 2 / `unknown constant 'LO'`、head でも同一）。**detector と称していない。**

### ゲート

| コマンド | exit | 所要 | 変更クレートの compile 行 | `Blocking waiting` |
| --- | --- | --- | --- | --- |
| `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` | **0** | 2s | N/A（fmt はコンパイルしない。出力0バイト） | 0 |
| `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --locked -- -D warnings` | **0** | 42s | `Checking fsl-tools` / `Compiling fslc-rust` | 0 |
| `cargo build --manifest-path rust/Cargo.toml --workspace --locked` | **0** | 158s | 2件 | 0 |
| `cargo test --manifest-path rust/Cargo.toml -p fsl-tools --locked` | **0** | 68s / 11s（2回） | 1件 | 0 |
| `python3 -m pytest tests/test_site_reference_snapshot.py` | **0** | 6s | — | — |
| `python3 -m pytest tests/test_site_refresh_contract.py` | **0** | 6s | — | — |
| `python3 -m pytest tests/test_site_manual_integrity.py` | **0** | 8s | — | — |
| `tools/aggregate_changelog.sh check` | **0** | 34s | — | — |
| `tools/aggregate_changelog.sh check-pr` | **0** | 28s | — | — |

`tests/document.rs` は **34 passed / 0 failed**、`tests/document_render.rs` は **29 passed / 0 failed**、
`rust/fslc/tests/corpus_check_sweep.rs` は **5 passed / 0 failed**（272.30s）。

`tools/aggregate_changelog.sh` は Bash 4 以上を要求する（macOS の `/bin/bash` は 3.2）。
`BASE_SHA` と `HEAD_SHA` の両方が必須である。

## 同伴した変更

- `docs/DESIGN-document-requirement-claim-ir.md` —— `analysis_scope` の解決経路、
  `analysis_scope carries authored bounds` の完全性主張の限定、evidence 節の fixture ラベルと
  schema 検証の範囲、const bound / 宣言なし名前の bullet
- `docs/DESIGN-document-controlled-language-renderer.md` —— normalized AST `["num", N]` と
  「const reference は compact JSON dump へ fallback」の記述が実装と食い違っていたのを訂正
  （創設設計ノート `docs/DESIGN-document-requirement-claim-ir.md:54-55` の
  「The historical Python-shaped AST ... is never serialized as RCIR」が正で、renderer 文書側が誤っていた）
- `rust/fsl-tools/src/document_render.rs` —— `ast_bound_text` の到達不能な第1アーム
  （`["num", N]` 配列を解く分岐）を削除。**`value.to_string()` の本番経路は残している**
- `changelog.d/993-document-const-bounds.fixed.md`

**`docs/LANGUAGE.md` / `docs/LANGUAGE.ja.md` は変更していない。**
言語仕様は最初から const bound を排除していないので追記の要求が無く、
触ると必須 CI（`.github/workflows/site-reference-freshness.yml`）が
`docs/intro/language.{en,ja}.html` の再生成を要求する。

## 残 risk

1. **ローカルの `cargo test --workspace --locked` は未取得である。**
   最終 SHA に対して exit=0 を得ていない。CI の `rust tests` 3シャードと `rust workspace` が代替する。
   **「回していない」のではなく「途中まで回して止めた」。**両方をそのまま書く。
   - **前提条件（`pgrep -x cargo` = 0 かつ 1分 load average ≤ CPU 数）を満たして 57 分走らせた。**
     launch 時 `load1=14.60 / cargo=0`。その run の中で
     **`domain_commands_validate_their_single_fifo_source_snapshot` は PASS した。**
   - **完走前に停止した。** 直前に別 PR が main へ入り、この PR の rebase が必要になったため、
     その結果は最終 SHA に紐づかなくなった。**停止は結果が悪かったからではない。**
   - **その前に一度 exit=101 になった run がある。** 前提未達（load average 40 超、他の
     `cargo test --workspace` と同時実行）で回した 2746s の run で、上記のテストが1本落ちた。
     assert の失敗ではなく `rust/fslc/tests/support/fifo_snapshot.rs:443` の
     **固定5秒 deadline による SIGKILL** である。
     単独で再実行すると **1回目 ok（21.08s）/ 2回目 同じ timeout で FAILED（15.34s）**
     ——そのときの load average は 46.50（CPU 16）で、上位消費はこの変更と無関係の
     `cursor-agent` 4本と常駐セキュリティ製品群だった。
   - **同じテストが CI では PASS した。逐語:**
     `PASS [ 0.062s] (493/624) fslc-rust::issue_796_domain_command_validation
     domain_commands_validate_their_single_fifo_source_snapshot`
     （`rust tests (1/3)`、そのシャードは 624 tests run / 624 passed）。
     **deadline 5000ms に対して実測 62ms** で、約80倍の余裕がある。
     `#[ignore]` は付いていない（`issue_796_domain_command_validation.rs:193-195` は
     `#[cfg(unix)]` + `#[test]`）。
   - **CI 側の被覆は機械的に検査されている。** 各シャードは実行前に `full.txt`
     （ワークスペースの非 ignored な全テスト）と `shard.txt` を書き、`rust workspace` が
     3つの `full.txt` の byte 一致を assert し、`tools/check-shard-union.sh` が
     全 `shard.txt` の和集合 = `full.txt` を検査する。nextest がシャードできない doctest は
     `rust checks` が `cargo test --workspace --doc --locked` として明示的に持つ。
   - **`fifo_snapshot.rs:443` の 5 秒 deadline は伸ばしていない**（spec を弱める側の操作になる）。
   - ⚠️ **「変更面に `rust/fslc/` のソースが無いから無関係」とは言えない。**
     `rust/fslc/Cargo.toml:15-23` のとおり `fslc-rust` は既定 feature で `fsl-tools` をリンクするので、
     `rust/fsl-tools/src/document_project.rs` の変更は **`fslc` バイナリを作り直す**
     （ビルドログにも `Compiling fslc-rust` が出る）。変更が document projector に閉じており、
     落ちたテストが domain command の FIFO snapshot であることは**記述として書けるが、
     影響が無いことの根拠にはならない**。
   - **`fmt` / `clippy` / `build` は固定 timeout を持たないので、上表の exit=0 は有効である。**
   - ⚠️ **この PR の緑を「全 lane が走った」と読まないこと。** `native Z3 4.16 (macos-15)` と
     `(windows-latest)` は PR で個別行を持たず、`native Z3 4.16` は skipping 2件として出る。
     `product gate` の rollup 自体も skipping である。
2. **`fslc diff` は同じ const bound を黙って捨てる**（fail-open）。本 PR の範囲外で、#997 が追跡する。
   本 PR はそのクラスを1件も増やしていない（未定義 const は exit 2 のまま）。
3. **`analysis_scope` に model 不在の number の entry が出る**形は保存した（R3 のため）。
   それ自体が hollow な出力で、除去は #997 の裁定事項である。
4. **gate が覆っていない範囲**: 散文の整合・意味・語調には決定論的検査が無い。
   系列をまたぐレビュー（`gpt-5.6-sol-medium`、3巡で指摘ゼロ）と読みで見ており、
   **「検証済み」とは書かない。**

## 関連

- 裁定と訂正の記録: <https://github.com/ymm-oss/fsl/issues/993#issuecomment-5566353019>
- **#997** —— 同じ構文が surface ごとに3通りに扱われているクラス。**本 PR の範囲外。**
  `fslc diff` は const bound を `else` 無しで**黙って捨てる**（fail-open）ため、
  境界の変更が「変更なし」と判定され得る（literal 対照つきで実測）。
  `lower_requirements` が宣言のない名前の bound を捨てることと、
  RCIR に model 不在の number の entry が出ることも同 issue に記録した。
  **本 PR はそのクラスを1件も増やしていない**（未定義 const は exit 2 のまま）。

Closes #993
