### PR TITLE
fix(kernel): project an empty relation initializer as set_lit (#1000)

### DIFF
--- a/changelog.d/1000-kernel-empty-relation.fixed.md
+++ b/changelog.d/1000-kernel-empty-relation.fixed.md
@@ -1,0 +1,3 @@
+Fixed (#1000): `fslc kernel` now projects relation state fields initialized with
+`Set {}` as `set_lit` with relation-typed `type` and empty `items`, matching
+`fslc check`; non-empty relation literals remain rejected.

--- a/docs/DESIGN-nested-option-support.md
+++ b/docs/DESIGN-nested-option-support.md
@@ -270,6 +270,11 @@ Full language support is incomplete if engines distinguish `none` from
 collapse them. Preserve the legacy `null`/value bytes for `Option<scalar>` and
 introduce a tag only when the declared payload is itself an Option:
 
+Public Kernel projection (`expr_json`): an accepted empty relation initializer
+is exported as `kind="set_lit"` with `type` naming the relation endpoints and
+`items` as an empty array. The closed public Kernel schema introduces no new
+expression `kind`; there is no `relation_lit` variant.
+
 | Type and value | Canonical ordinary JSON |
 |---|---|
 | `Option<T> = none` | `null` |

--- a/docs/LANGUAGE.ja.md
+++ b/docs/LANGUAGE.ja.md
@@ -676,6 +676,9 @@ until  Name { P until Q }    // unless safety plus a leadsTo P ~> Q progress obl
 - 代入: `x = expr`、`m[k] = expr`、`m[k].field = expr`、`o.field = expr`
 - Set/Seq/relation の更新は**再代入イディオム**を使います:
   `s = s.add(x)`、`q = q.pop()`、`r = r.add(a, b)`
+- relation 型フィールドの**リテラル**初期化子は空の `Set {}` でなければならず、空でない Set
+  リテラルは `init` と inline 初期化子の両方で拒否される。対の追加は再代入イディオム
+  `r = r.add(a, b)` で行い、これは `init` の中でも使える。
 - `if expr { stmt... } else { stmt... }` は `init` と action 本体の両方で使えます
   (else の内側の if でネストできます)
 - `forall x: T { stmt... }`(一括初期化 / 一括更新)

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -699,6 +699,9 @@ variable.
 - Assignment: `x = expr`, `m[k] = expr`, `m[k].field = expr`, `o.field = expr`
 - Updating a Set/Seq/relation uses the **reassignment idiom**:
   `s = s.add(x)`, `q = q.pop()`, `r = r.add(a, b)`
+- A relation-typed field's **literal** initializer must be the empty `Set {}` — a non-empty
+  Set literal is rejected in both `init` and an inline initializer — and pairs are added with
+  the reassignment idiom `r = r.add(a, b)`, which is also allowed inside `init`.
 - `if expr { stmt... } else { stmt... }` is allowed in both `init` and action bodies
   (can be nested with an if inside the else)
 - `forall x: T { stmt... }` (bulk initialization / bulk update)

--- a/docs/intro/language.en.html
+++ b/docs/intro/language.en.html
@@ -750,6 +750,9 @@ variable.</p></div></details>
 <li>Assignment: <code>x = expr</code>, <code>m[k] = expr</code>, <code>m[k].field = expr</code>, <code>o.field = expr</code></li>
 <li>Updating a Set/Seq/relation uses the <strong>reassignment idiom</strong>:
   <code>s = s.add(x)</code>, <code>q = q.pop()</code>, <code>r = r.add(a, b)</code></li>
+<li>A relation-typed field's <strong>literal</strong> initializer must be the empty <code>Set {}</code> — a non-empty
+  Set literal is rejected in both <code>init</code> and an inline initializer — and pairs are added with
+  the reassignment idiom <code>r = r.add(a, b)</code>, which is also allowed inside <code>init</code>.</li>
 <li><code>if expr { stmt... } else { stmt... }</code> is allowed in both <code>init</code> and action bodies
   (can be nested with an if inside the else)</li>
 <li><code>forall x: T { stmt... }</code> (bulk initialization / bulk update)</li>

--- a/docs/intro/language.ja.html
+++ b/docs/intro/language.ja.html
@@ -728,6 +728,9 @@ until  Name { P until Q }    // unless safety plus a leadsTo P ~&gt; Q progress 
 <li>代入: <code>x = expr</code>、<code>m[k] = expr</code>、<code>m[k].field = expr</code>、<code>o.field = expr</code></li>
 <li>Set/Seq/relation の更新は<strong>再代入イディオム</strong>を使います:
   <code>s = s.add(x)</code>、<code>q = q.pop()</code>、<code>r = r.add(a, b)</code></li>
+<li>relation 型フィールドの<strong>リテラル</strong>初期化子は空の <code>Set {}</code> でなければならず、空でない Set
+  リテラルは <code>init</code> と inline 初期化子の両方で拒否される。対の追加は再代入イディオム
+  <code>r = r.add(a, b)</code> で行い、これは <code>init</code> の中でも使える。</li>
 <li><code>if expr { stmt... } else { stmt... }</code> は <code>init</code> と action 本体の両方で使えます
   (else の内側の if でネストできます)</li>
 <li><code>forall x: T { stmt... }</code>(一括初期化 / 一括更新)</li>

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -308,16 +308,16 @@ fn expr_json_inner(
                 // Relation literals only support the empty initializer `Set {}`;
                 // there is no per-element type to project against.
                 //
-                // This guard is unreachable on today's paths and is kept regardless:
-                // the branch never reads `items`, so without it a non-empty literal
-                // would project as `set_lit` with `items: []` and silently drop its
-                // pairs. The `_` arm below is kept on the same grounds.
+                // This guard is kept as a fail-closed defense: the branch never reads
+                // `items`, so without it a non-empty literal would project as
+                // `set_lit` with `items: []` and silently drop its pairs. The `_` arm
+                // below is kept on the same grounds.
                 //
-                // The reachability derivation -- which sites enforce the emptiness
-                // rule, which only record it, and what would have to change for this
-                // arm to run -- is recorded in #1000, not here. Four attempts to
-                // state it in this comment were each corrected by review; it depends
-                // on the call graph, which a comment cannot track.
+                // Whether either arm can be reached today, which sites enforce the
+                // emptiness rule, which only record it, and what would have to change
+                // -- all of that depends on the call graph and is recorded in #1000,
+                // not here. Four attempts to state it in this comment were each
+                // corrected by review.
                 if !items.is_empty() {
                     return Err(error("collection literal type mismatch"));
                 }

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -324,14 +324,16 @@ fn expr_json_inner(
                 //
                 // Deleting it would not fall back on the checked-model contract: the
                 // branch never reads `items`, so a non-empty literal would project
-                // as `set_lit` with `items: []` and silently drop its pairs. That
-                // needs the upstream rejection *invariant* to stop holding, not any
-                // single check above -- those are redundant, and `expression_type`
-                // always runs first within this function -- so the ways in are a
-                // change that relaxes all of them together, or a new caller reaching
-                // `expr_json` without an `expected` type that carries the relation.
-                // The `_` arm below is unreachable for the same reason and is kept on
-                // the same grounds.
+                // as `set_lit` with `items: []` and silently drop its pairs. The
+                // condition for that is narrow and worth stating exactly:
+                // `expression_type` would have to start returning a relation type for
+                // a *non-empty* `Expr::Set`, because this branch is reached only when
+                // the resolved type is a relation and `infer_type` applies the
+                // emptiness rule on precisely that path. A caller cannot arrange it by
+                // omitting `expected`: with no expected relation type an `Expr::Set`
+                // infers as a `Set`, or fails outright when it is empty, so it never
+                // enters here. The `_` arm below is unreachable for the same reason
+                // and is kept on the same grounds.
                 if !items.is_empty() {
                     return Err(error("collection literal type mismatch"));
                 }

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -306,34 +306,18 @@ fn expr_json_inner(
             let resolved = resolve(model, &ty)?;
             if matches!(resolved, TypeRef::Relation(_, _)) {
                 // Relation literals only support the empty initializer `Set {}`;
-                // emptiness is enforced by typecheck, and there is no per-element
-                // type to project against.
+                // there is no per-element type to project against.
                 //
-                // The guard below is unreachable on today's paths, and is kept
-                // anyway. `expression_type` at the head of this function already
-                // ran `infer_type`, which rejects a non-empty relation literal with
-                // its own `relation literals only support the empty initializer
-                // Set {}` diagnostic; `ensure_assignable` and `validate_expression`
-                // reject it too, and `statement_json` repeats `ensure_assignable`
-                // immediately before calling into here. Measured: across the 485
-                // `.fsl` files under `specs/`, `examples/` and
-                // `rust/fslc/tests/fixtures/`, no non-empty relation literal
-                // produced this arm's message under either the base or the head
-                // binary. (Four forms did produce it under base -- all *empty*
-                // relation initializers, which this change makes project instead.)
+                // This guard is unreachable on today's paths and is kept regardless:
+                // the branch never reads `items`, so without it a non-empty literal
+                // would project as `set_lit` with `items: []` and silently drop its
+                // pairs. The `_` arm below is kept on the same grounds.
                 //
-                // Deleting it would not fall back on the checked-model contract: the
-                // branch never reads `items`, so a non-empty literal would project
-                // as `set_lit` with `items: []` and silently drop its pairs. The
-                // condition for that is narrow and worth stating exactly:
-                // `expression_type` would have to start returning a relation type for
-                // a *non-empty* `Expr::Set`, because this branch is reached only when
-                // the resolved type is a relation and `infer_type` applies the
-                // emptiness rule on precisely that path. A caller cannot arrange it by
-                // omitting `expected`: with no expected relation type an `Expr::Set`
-                // infers as a `Set`, or fails outright when it is empty, so it never
-                // enters here. The `_` arm below is unreachable for the same reason
-                // and is kept on the same grounds.
+                // The reachability derivation -- which sites enforce the emptiness
+                // rule, which only record it, and what would have to change for this
+                // arm to run -- is recorded in #1000, not here. Four attempts to
+                // state it in this comment were each corrected by review; it depends
+                // on the call graph, which a comment cannot track.
                 if !items.is_empty() {
                     return Err(error("collection literal type mismatch"));
                 }

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -308,6 +308,26 @@ fn expr_json_inner(
                 // Relation literals only support the empty initializer `Set {}`;
                 // emptiness is enforced by typecheck, and there is no per-element
                 // type to project against.
+                //
+                // The guard below is unreachable on today's paths, and is kept
+                // anyway. `expression_type` at the head of this function already
+                // ran `infer_type`, which rejects a non-empty relation literal with
+                // its own `relation literals only support the empty initializer
+                // Set {}` diagnostic; `ensure_assignable` and `validate_expression`
+                // reject it too, and `statement_json` repeats `ensure_assignable`
+                // immediately before calling into here. Measured: across the 485
+                // `.fsl` files under `specs/`, `examples/` and
+                // `rust/fslc/tests/fixtures/`, no non-empty relation literal
+                // produced this arm's message under either the base or the head
+                // binary. (Four forms did produce it under base -- all *empty*
+                // relation initializers, which this change makes project instead.)
+                //
+                // Deleting it would not fall back on the checked-model contract: the
+                // branch never reads `items`, so a non-empty literal would project
+                // as `set_lit` with `items: []` and silently drop its pairs if any
+                // of those upstream checks ever stopped rejecting it. The `_` arm
+                // below is unreachable for the same reason and is kept on the same
+                // grounds.
                 if !items.is_empty() {
                     return Err(error("collection literal type mismatch"));
                 }

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -324,10 +324,14 @@ fn expr_json_inner(
                 //
                 // Deleting it would not fall back on the checked-model contract: the
                 // branch never reads `items`, so a non-empty literal would project
-                // as `set_lit` with `items: []` and silently drop its pairs if any
-                // of those upstream checks ever stopped rejecting it. The `_` arm
-                // below is unreachable for the same reason and is kept on the same
-                // grounds.
+                // as `set_lit` with `items: []` and silently drop its pairs. That
+                // needs the upstream rejection *invariant* to stop holding, not any
+                // single check above -- those are redundant, and `expression_type`
+                // always runs first within this function -- so the ways in are a
+                // change that relaxes all of them together, or a new caller reaching
+                // `expr_json` without an `expected` type that carries the relation.
+                // The `_` arm below is unreachable for the same reason and is kept on
+                // the same grounds.
                 if !items.is_empty() {
                     return Err(error("collection literal type mismatch"));
                 }

--- a/rust/fsl-core/src/public_kernel.rs
+++ b/rust/fsl-core/src/public_kernel.rs
@@ -303,21 +303,33 @@ fn expr_json_inner(
             );
         }
         Expr::Set(items) | Expr::Seq(items) => {
-            let (kind, item_ty) = match resolve(model, &ty)? {
-                TypeRef::Set(item) => ("set_lit", item),
-                TypeRef::Seq(item, _) => ("seq_lit", item),
-                _ => return Err(error("collection literal type mismatch")),
-            };
-            output.insert("kind".to_owned(), json!(kind));
-            output.insert(
-                "items".to_owned(),
-                Value::Array(
-                    items
-                        .iter()
-                        .map(|item| expr_json(item, env, model, path, span, Some(&item_ty)))
-                        .collect::<Result<_, _>>()?,
-                ),
-            );
+            let resolved = resolve(model, &ty)?;
+            if matches!(resolved, TypeRef::Relation(_, _)) {
+                // Relation literals only support the empty initializer `Set {}`;
+                // emptiness is enforced by typecheck, and there is no per-element
+                // type to project against.
+                if !items.is_empty() {
+                    return Err(error("collection literal type mismatch"));
+                }
+                output.insert("kind".to_owned(), json!("set_lit"));
+                output.insert("items".to_owned(), Value::Array(vec![]));
+            } else {
+                let (kind, item_ty) = match resolved {
+                    TypeRef::Set(item) => ("set_lit", item),
+                    TypeRef::Seq(item, _) => ("seq_lit", item),
+                    _ => return Err(error("collection literal type mismatch")),
+                };
+                output.insert("kind".to_owned(), json!(kind));
+                output.insert(
+                    "items".to_owned(),
+                    Value::Array(
+                        items
+                            .iter()
+                            .map(|item| expr_json(item, env, model, path, span, Some(&item_ty)))
+                            .collect::<Result<_, _>>()?,
+                    ),
+                );
+            }
         }
         Expr::Struct { name, fields } => {
             output.insert("kind".to_owned(), json!("struct_lit"));

--- a/rust/fslc/tests/kernel_contract.rs
+++ b/rust/fslc/tests/kernel_contract.rs
@@ -1,16 +1,96 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeSet;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use fsl_core::{FsResolver, KernelExpr, ProjectionDef, build_model, parse_kernel_source};
 use serde_json::{Value, json};
+
+static NEXT_SCRATCH: AtomicU64 = AtomicU64::new(0);
 
 fn fixture(name: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures")
         .join(name)
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repository root")
+}
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let id = NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed);
+    let dir = repo_root().join(format!(
+        "rust/target/kernel-contract-{name}-{}-{id}",
+        std::process::id()
+    ));
+    if dir.exists() {
+        fs::remove_dir_all(&dir).expect("clean stale scratch dir");
+    }
+    fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+fn run_cli(args: &[&str]) -> (Value, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_fslc"))
+        .args(args)
+        .current_dir(repo_root())
+        .output()
+        .expect("run native CLI");
+    let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid JSON: {error}; args={args:?}; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    (value, output.status.code().expect("exit status"))
+}
+
+fn compiled_kernel_v1_schema() -> jsonschema::Validator {
+    let schema: Value = serde_json::from_str(
+        &fs::read_to_string(repo_root().join("schemas/fslc/kernel/kernel.v1.schema.json"))
+            .expect("read Kernel v1 schema"),
+    )
+    .expect("Kernel v1 schema JSON");
+    jsonschema::validator_for(&schema).expect("Kernel v1 schema compiles")
+}
+
+fn kernel_state<'a>(contract: &'a Value, name: &str) -> &'a Value {
+    contract["state"]
+        .as_array()
+        .expect("kernel state")
+        .iter()
+        .find(|entry| entry["name"] == name)
+        .unwrap_or_else(|| panic!("missing state '{name}'"))
+}
+
+/// Returns the `init` assignment statement whose target variable is `name`.
+///
+/// `init` is an object (`origin` / `requirement` / `span` / `statements`), not an
+/// array of named entries, and each statement carries its variable under
+/// `target.name` rather than a top-level `name`. Reading it as a flat array
+/// panicked with "kernel init"; the first revision of this helper assumed the
+/// wrong shape and could not be caught while the tests still stopped at the
+/// `kernel_status` assertion.
+fn kernel_init<'a>(contract: &'a Value, name: &str) -> &'a Value {
+    contract["init"]["statements"]
+        .as_array()
+        .expect("kernel init statements")
+        .iter()
+        .find(|statement| statement["target"]["name"] == name)
+        .unwrap_or_else(|| panic!("missing init assignment for '{name}'"))
+}
+
+fn assert_empty_relation_init(init: &Value, label: &str) {
+    assert_eq!(init["value"]["kind"], "set_lit", "{label}");
+    assert_eq!(init["value"]["type"]["kind"], "relation", "{label}");
+    assert_eq!(init["value"]["items"], json!([]), "{label}");
 }
 
 fn load(path: &Path) -> (fsl_core::KernelSpec, fsl_core::KernelModel) {
@@ -636,4 +716,102 @@ fn published_schema_ids_match_the_rust_api_constants() {
         .expect("expression kind enum");
     assert!(kinds.contains(&Value::String("ite".to_owned())));
     assert!(!kinds.contains(&Value::String("totally_unknown".to_owned())));
+}
+
+/// Detector: empty relation initializers must export through `fslc kernel` as
+/// schema-valid `set_lit` values. Mutation: delete the proposed empty-
+/// `TypeRef::Relation` arm in `public_kernel.rs`; before the fix that restores
+/// exit 2, `kind="semantics"`, and `message="collection literal type mismatch"`.
+#[test]
+fn empty_relation_initializer_exports_as_schema_valid_kernel() {
+    let fixture_path = "rust/fslc/tests/fixtures/issue_467_relation_demo.fsl";
+
+    let (check_output, check_status) = run_cli(&["check", fixture_path]);
+    assert_eq!(check_status, 0, "{check_output:#}");
+    assert_eq!(check_output["result"], "ok");
+
+    let (kernel_output, kernel_status) = run_cli(&["kernel", fixture_path]);
+    assert_eq!(kernel_status, 0, "{kernel_output:#}");
+    assert_eq!(kernel_output["result"], "kernel");
+    compiled_kernel_v1_schema()
+        .validate(&kernel_output)
+        .expect("kernel output validates against public Kernel v1 schema");
+
+    assert_eq!(
+        kernel_state(&kernel_output, "delegates")["type"]["kind"],
+        "relation"
+    );
+    assert_eq!(
+        kernel_state(&kernel_output, "roles")["type"]["kind"],
+        "relation"
+    );
+    assert_empty_relation_init(kernel_init(&kernel_output, "delegates"), "delegates");
+    assert_empty_relation_init(kernel_init(&kernel_output, "roles"), "roles");
+}
+
+/// Detector: the issue's minimal requirements reproduction must agree on `check`
+/// and `kernel`. Mutation: delete the proposed empty-`TypeRef::Relation` arm in
+/// `public_kernel.rs`; before the fix that restores exit 2, `kind="semantics"`,
+/// and `message="collection literal type mismatch"`.
+#[test]
+fn minimal_requirements_empty_relation_has_consistent_check_and_kernel() {
+    const SOURCE: &str = r"requirements KernelEmptyRelation {
+  entity Company
+  enum Capability { Skill }
+  state { enabled: relation Company -> Capability }
+  init { enabled = Set {} }
+}
+verify { instances Company = 1 }
+";
+    let dir = scratch_dir("minimal-empty-relation");
+    let path = dir.join("kernel_empty_relation.fsl");
+    fs::write(&path, SOURCE).expect("write minimal reproduction");
+    let path = path.to_str().expect("UTF-8 path");
+
+    let (check_output, check_status) = run_cli(&["check", path, "--strict-tags"]);
+    assert_eq!(check_status, 0, "{check_output:#}");
+    assert_eq!(check_output["result"], "ok");
+
+    let (kernel_output, kernel_status) = run_cli(&["kernel", path]);
+    assert_eq!(kernel_status, 0, "{kernel_output:#}");
+    assert_eq!(kernel_output["result"], "kernel");
+    assert_eq!(kernel_output["spec"]["name"], "KernelEmptyRelation");
+    assert_eq!(kernel_output["spec"]["source"]["dialect"], "requirements");
+    assert_eq!(
+        kernel_state(&kernel_output, "enabled")["type"]["kind"],
+        "relation"
+    );
+    assert_empty_relation_init(kernel_init(&kernel_output, "enabled"), "enabled");
+}
+
+/// Preservation control: a non-empty relation literal must remain a semantic
+/// rejection on both public paths after the projection fix.
+#[test]
+fn nonempty_relation_literal_remains_a_semantic_rejection() {
+    const SOURCE: &str = r"requirements KernelEmptyRelation {
+  entity Company
+  enum Capability { Skill }
+  state { enabled: relation Company -> Capability }
+  init { enabled = Set { 0 } }
+}
+verify { instances Company = 1 }
+";
+    const EXPECTED_MESSAGE: &str = "invalid init statement: relation literals only support the empty initializer Set {}; use r = r.add(a, b) to add pairs at 5:10";
+
+    let dir = scratch_dir("nonempty-relation-literal");
+    let path = dir.join("nonempty_relation.fsl");
+    fs::write(&path, SOURCE).expect("write rejecting source");
+    let path = path.to_str().expect("UTF-8 path");
+
+    for command in ["check", "kernel"] {
+        let (output, status) = run_cli(&[command, path]);
+        assert_eq!(status, 2, "{command}: {output:#}");
+        assert_eq!(output["result"], "error", "{command}");
+        assert_eq!(output["kind"], "semantics", "{command}");
+        assert_eq!(
+            output["message"].as_str(),
+            Some(EXPECTED_MESSAGE),
+            "{command}"
+        );
+    }
 }

--- a/skills/fsl/references/syntax.md
+++ b/skills/fsl/references/syntax.md
@@ -815,6 +815,9 @@ could read (#570). No other word is reserved — `count`, `sum`, `stage`, `in`,
 - Assignment: `x = e`, `m[k] = e`, `m[k].f = e`, `o.f = e`, `o.f = some(e)`
 - Set/Seq/relation are re-assigned: `s = s.add(x)`, `q = q.pop().push(y)`,
   `r = r.add(a,b)` (chaining allowed)
+- A relation-typed field's **literal** initializer must be the empty `Set {}` — a non-empty
+  Set literal is rejected in both `init` and an inline initializer — and pairs are added with
+  the reassignment idiom `r = r.add(a, b)`, which is also allowed inside `init`.
 - `if expr { stmt... } [else { stmt... }]` is allowed in both `init` and action
   bodies (may nest with an if inside else)
 - `forall x: T { stmt... }` (bulk assignment)


### PR DESCRIPTION
Closes #1000.

## Problem

`fslc check` accepts a `relation` state field initialized with `Set {}`, but `fslc kernel`
rejected the same source with `collection literal type mismatch` at exit 2, so a checked
specification could not be converted to the public Kernel.

```console
$ fslc check kernel-empty-relation.fsl --strict-tags
{"result": "ok", "spec": "KernelEmptyRelation"}   # exit 0
$ fslc kernel kernel-empty-relation.fsl
{"result": "error", "kind": "semantics", "message": "collection literal type mismatch"}   # exit 2
```

**`check` is the correct side.** `fsl-core`'s typechecker names `TypeRef::Relation` explicitly in
three places — `infer_type`, `ensure_assignable`, and `validate_expression` — accepting the empty
`Set {}`. Two of them, `infer_type` and `ensure_assignable`, also *reject* a non-empty relation
literal with their own diagnostic; `validate_expression`'s arm only `debug_assert!`s emptiness, so
it records the invariant rather than enforcing it in release. The same rule is
implemented in `fsl-verifier`'s value layer and in the frozen Python reference. Four fixtures in
`rust/fslc/tests/fixtures/` initialize a relation this way. `docs/DESIGN-nested-option-support.md`
records that "Set/Seq/empty-relation literals retain their existing expected collection coercion
behavior". Acceptance is deliberate, not an omission.

The defect was in the projection: `expr_json_inner`'s `Expr::Set | Expr::Seq` arm had no
`TypeRef::Relation` case, so a relation type fell into the closing error arm.

## Contract change

An accepted empty relation initializer now projects as `kind="set_lit"` with a relation-typed
`type` and an empty `items` array. **No new expression `kind` is introduced**: the closed public
Kernel v1/v2 `kind` enums are unchanged, `$defs.type` already admits a `relation` variant, and
`fsl-tools`' typestate decoder already maps `set_lit`. Non-empty relation literals keep failing
closed.

The pre-existing Set/Seq projection is **moved into an `else` branch unchanged, not rewritten**:
of 15 deleted lines, 14 reappear verbatim modulo indentation; the one that does not is
`let (kind, item_ty) = match resolve(model, &ty)? {`, split into a `let resolved = …` binding
plus `match resolved {` so the type can be inspected once before the branch.

Affected public contracts: the `fslc kernel` JSON/exit contract, and the public Kernel expression
JSON for this initializer. Nothing else — grammar, runtime, solver, schemas, LSP and the Python
reference are untouched.

## Acceptance comparison (`DESIGN-nested-option-support.md` §11 item 4)

> "No transition" is a measured claim, not a default.

```
base SHA = 2cefd828c0081210e5e79724b28fcb2c344d1771   (= origin/main)
head     = this branch
corpus   = every .fsl under specs/ (23), examples/ (191), rust/fslc/tests/fixtures/ (271)
forms compared = 485, with each binary, run from the worktree
```

| command | forms | transitions | direction |
|---|---|---|---|
| `fslc check` | 485 | **0** | base and head exit distributions are identical: 348 × 0, 137 × 2 |
| `fslc kernel` | 485 | **4** | `error`→`ok` 4, **`ok`→`error` 0** |

The four are exactly the empty-relation forms — `issue_467_relation_demo.fsl` and
`issue_502_reachable_{cycle,empty,selfloop}.fsl` — all of which returned exit 2 with
`collection literal type mismatch` under base and exit 0 with `result="kernel"` under head. A
fifth `error`→`ok` would have meant the projection now accepts something the requirement never
named; there is none. §11 item 3 (breaking removals) does not apply: no form went `ok`→`error`,
which is also why the changelog fragment is `fixed` rather than `changed`.

⚠️ **On the per-tree procedure.** §11 item 2 asks for each SHA's tree to be materialized and each
binary run inside its own tree, so `use … from` imports resolve against that SHA's siblings.
**This was not done that way.** Both binaries were run from the single head worktree, and the
equivalence was measured instead: `git diff --name-only 2cefd828 -- '*.fsl'` is **empty**, so the
`.fsl` corpus and every import sibling are byte-identical between the two trees. **This satisfies
item 2's purpose; it is not a claim to have followed item 2's procedure.**

## Test evidence

`cargo test --manifest-path rust/Cargo.toml -p fslc-rust --test kernel_contract --locked` — 22
passed, 0 failed. Three tests are new:

- `empty_relation_initializer_exports_as_schema_valid_kernel` (**detector**) — runs `check` then
  `kernel` on the existing `issue_467_relation_demo.fsl`, validates the **whole successful CLI
  envelope against the public Kernel v1 schema** (reusing `jsonschema::validator_for`; no new
  validator), and asserts `set_lit` / relation `type` / empty `items` for both relation fields.
- `minimal_requirements_empty_relation_has_consistent_check_and_kernel` (**detector**) — the
  issue's minimal reproduction verbatim, written to a scratch directory.
- `nonempty_relation_literal_remains_a_semantic_rejection` (**preservation control**) — pins
  exit 2, `kind="semantics"` and the exact relation-literal message on **both** `check` and
  `kernel`. It keeps passing when the fix is reverted, and is not labelled a detector.

**Calibration.** Both detectors were run before the production change and failed for the expected
reason — `assert_eq!(kernel_status, 0)` producing 2, with the envelope
`{"result":"error","kind":"semantics","message":"collection literal type mismatch"}` — twice,
sequentially. The mutation each detector cites is deletion of the relation projection arm.

Other gates: `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` clean (zero-byte
output); `cargo clippy --manifest-path rust/Cargo.toml -p fsl-core -p fslc-rust --all-targets
--locked -- -D warnings` — zero warnings; the six Rust tests that read `docs/LANGUAGE.md`,
`docs/LANGUAGE.ja.md` or `skills/fsl/references/syntax.md` (`literate_docs_contract`,
`mutation_docs_contract`, `issue_698_distinctness_diagnostic`, `causal_docs_contract`,
`evidence_corpus_manifest`, `refine_corpus_parity`) all pass; and
`tests/test_site_reference_snapshot.py`, `tests/test_site_manual_integrity.py`,
`tests/test_site_refresh_contract.py` pass (35), so the generated site reference regenerates to
the committed bytes. `Compiling fsl-core` / `Checking fsl-core` appear in the test and clippy
logs, so each judged the changed crate.

⚠️ **`check_spdx_headers.py check` passes, and that says nothing about this change.** The detector
prints `PASS` without a count, so a full enumeration and an empty one are indistinguishable from
its output. This commit range adds one file — a `.md` changelog fragment — and **zero `.rs`,
`.py` or `.sh` files, so the SPDX rule has nothing to judge here.** Please do not read its green
as coverage.

## Documentation and skill updates

The three references were silent about relation initialization — `Set {}` appeared only in
`Set<T>` contexts — which is why the issue was ambiguous about which public path was correct. Each
gained one sentence inside an existing section (no `##` sections added, so `docs/LANGUAGE.md` and
`docs/LANGUAGE.ja.md` stay section-aligned 1:1):

> A relation-typed field's **literal** initializer must be the empty `Set {}` — a non-empty Set
> literal is rejected in both `init` and an inline initializer — and pairs are added with the
> reassignment idiom `r = r.add(a, b)`, which is also allowed inside `init`.

Every clause is measured, in both dialects that declare relation state fields (`requirements` and
`spec`): the two rejections carry **different diagnostic prefixes** (`invalid init statement:` vs
`invalid inline initializer for '<field>':`), so "both" rests on two distinct enforcement points;
an empty inline initializer is accepted, so the rejection is about emptiness rather than
placement; and `init { forall c: C { r = r.add(c, …) } }` is accepted. The sentence carries no
dialect qualifier because both diagnostics come from `fsl-core`'s shared typechecker, which runs
on the typed model after dialect lowering.

`docs/DESIGN-nested-option-support.md` gained the projection invariant, in
§5 *Lossless public observation and replay* — the public-observation section — rather than beside
§4's `eval_expected` list, which is a different layer. No line-numbered citations were added.

## Reachability of the kept guard (the code comment points at #1000, which points here)

`expr_json_inner`'s relation branch keeps `if !items.is_empty() { return Err(…) }`. The comment
there deliberately does not carry the derivation, because it depends on the call graph. It points
at issue #1000 — a comment cannot name a PR that does not exist yet — and this section is the
derivation's canonical home; the issue carries a link here and says so rather than repeating it.

**Three counts that are easy to conflate:**

| claim | count | sites |
|---|---|---|
| names `TypeRef::Relation` explicitly | 3 | `infer_type`, `ensure_assignable`, `validate_expression` |
| accepts the empty `Set {}` for a relation | 3 | the same three |
| **rejects** a non-empty relation literal | **2** | `infer_type`, `ensure_assignable` |

`validate_expression`'s relation arm is `debug_assert!(items.is_empty())`, which expands to nothing
when `debug_assertions` is off — the release default. Its own comment says emptiness "is already
enforced by `infer_type`/`ensure_assignable`", so it records the invariant rather than enforcing it.

**What would have to change for the arm to run.** All of the rejections would have to lapse
together, and they are separate code:

- `expression_type`, at the head of `expr_json_inner`, routes to `infer_type` — so no caller can
  skip it, and all 45 `expr_json` call sites are inside the private projection functions;
- `ensure_assignable` carries its own copy of the same rule;
- `validate_checked_model_types` runs `validate_statement` over every init assignment *before*
  projection starts;
- `statement_json` repeats `ensure_assignable` immediately before calling in, and
  `public_kernel_expression` calls `validate_public_expression` first.

A caller cannot route around this by omitting `expected`: with no expected relation type an
`Expr::Set` infers as a `Set`, or fails outright when it is empty (`public Kernel cannot infer
empty Set`), so it never enters the relation branch. **The precondition is therefore that
`expression_type` starts returning a relation type for a non-empty `Expr::Set` *and* the outer
validations stop rejecting it — necessary and sufficient only in combination.**

**Measured:** across the 485 corpus forms, no non-empty relation literal produced this arm's
message under either the base or the head binary. Four forms produced it under base — all *empty*
initializers, which this change makes project instead.

**Why it is kept.** The branch never reads `items`. With the guard gone a non-empty literal would
project as `set_lit` with `items: []` and silently drop its pairs. The closing `_` arm is
unreachable by the same argument and has been kept on the same grounds since before this change.

## Unrelated defect found by the sweep

The 485-form `kernel` sweep surfaced one form that exits **101 (a Rust panic)** under **both**
binaries: `rust/fslc/tests/fixtures/error_envelope_ai_unknown_tool.fsl` panics at
`fsl-core/src/dialect.rs` with `no entry found for key` and writes no JSON envelope, while
`fslc check` on the same file returns a proper exit 2 envelope. **Pre-existing, not caused by this
change and not fixed by it.** Filed as #1015.

## Review

Reviewed independently across model series, to zero findings, over six rounds.

**Six commits, of which one changes behaviour.** `57d7a746` is the fix; `7ca8effb`, `07305cdb`,
`e1a9a414`, `1e80f068` and `0b6b5270` are comment-only (`git diff` shows no executable line added
or removed in any of them), and each records the answer to a review finding rather than removing
the thing that was questioned. Every one re-ran `fmt`, the focused test and `clippy`, because a
comment still changes the file's bytes.

**Round 1 — two `major`.** (a) The emptiness guard in the new relation arm is unreachable, so
delete it. (b) The documentation sentence carries no dialect qualifier while the working record
disclaimed other dialects.

The unreachability is real, confirmed from `expression_type` at the head of the same function, the
three typechecker sites, and `statement_json` repeating `ensure_assignable` immediately before
calling in. **The guard is kept anyway.** The branch never reads `items`, so deleting it would
make a non-empty literal project as `set_lit` with `items: []` and silently drop its pairs — a
fail-closed path turned into a silent wrong value, which is the failure mode `AGENTS.md` singles
out as worse than a crash. The closing `_` arm is unreachable for the same reason and has been
kept on the same grounds since before this change; a rule that required deleting one would require
deleting the other. The reviewer withdrew (a) on that basis, keeping its factual finding and
retracting only the rule it had applied. (b) was a real inconsistency, and the *record* was the
weaker of the two: it was corrected with the per-dialect measurements above, and its falsifier was
strengthened from "no such dialect exists" to a structural one — declaring a relation state field
needs the shared `SpecItem::State` variant, and any future lowering still reaches `build_model`.

**Round 2 — one `minor`.** The comment implied that any single upstream check lapsing would be
enough. It would not; the checks are redundant. Corrected.

**Round 3 — one `minor`.** The corrected comment then named two ways the guard could come to
matter, and the second — a caller reaching `expr_json` without an `expected` relation type — does
not exist: with no expected relation type an `Expr::Set` infers as a `Set`, or fails outright when
it is empty, so it never enters the branch. **Three independent measurements agreed on this**, and
it was an over-claim on the authoring side, not the reviewer's. The final comment states the one
real condition — `expression_type` would have to start returning a relation type for a *non-empty*
`Expr::Set` — and keeps the refuted second route as the explanation of why there is no second
route, so the next reader does not repeat the derivation.

**Round 4 — one `minor`.** The narrowed condition was necessary but not sufficient: two sites
enforce the emptiness rule independently (`infer_type` and `ensure_assignable`), and the outer
`validate_checked_model_types` runs before projection starts, so `expression_type` changing alone
would not let anything through. Found by the reviewer and, independently, on the authoring side.

**Then the loop itself was stopped.** Rounds 2, 3 and 4 were each a new error in the comment
edited in the round before; findings against the artifact ran out in round 1. That is the signal
to stop applying patches and replace the mechanism, so the comment no longer carries the
derivation at all. It now states only what can be checked without leaving the screen — the branch
does not read `items`, so deleting the guard would silently drop pairs — and points at #1000 for
which sites enforce the rule, which only record it, and what would have to change. A comment that
makes no claim about the call graph cannot be wrong about the call graph.

⚠️ **This is a deliberate degradation, recorded so the next person can reverse it.** Someone
reading only the code no longer learns *why* the arm is unreachable without opening the issue.
The justification is narrow: across four attempts, the derivation was never once stated correctly
in that comment. Moving where it lives is more accurate than continuing to write something that
kept coming out wrong.

**Round 5 — one `minor`, on the replaced comment.** The replacement was incomplete. It still
opened with "This guard is unreachable on today's paths": narrowing the claim to *today* bounds
when it is true, but does not make it checkable without leaving the screen, so the mechanism
replacement had not actually removed the defect class it was aimed at. Corrected in `0b6b5270` —
the comment now says that whether either arm is reachable *depends on the call graph* and is
recorded in #1000, and asserts no verdict either way.

**Round 6 — zero findings** (blocker 0 / major 0 / minor 0), against `0b6b5270`'s content. The
reviewer verified the comment's two remaining claims are decidable inside the function, that the
externalisation no longer smuggles in a reachability verdict, and — asked to re-count — that
"Four attempts" is the right number, enumerating `7ca8effb`, `07305cdb`, `e1a9a414` and
`1e80f068` as the versions that tried to state the derivation, and excluding `0b6b5270` because
it removes rather than states it.

**A stopping rule was declared before round 6 was read**, since rounds 2–5 had been five
consecutive new errors in the comment edited the round before: zero findings would close it, and
a further finding about the comment's *wording* would be recorded as residue rather than edited,
with only two exceptions — a false negative in the checks this PR adds, and a false statement in
the documentation it ships. Round 6 came back at zero, so the rule was not exercised.
